### PR TITLE
feat: migrate TTS from Piper to Kokoro-82M (v0.7.1)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 .gitattributes text eol=lf
 *.sh text eol=lf
+
+# Vendored Python wheels — large binary files, tracked with git LFS
+build-assets/wheels/*.whl filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,30 @@ jobs:
         run: bash scripts/assert-no-dev-artifacts.sh image/files
 
   # ============================================================================
+  # Job 0b: Piper artifact guard — asserts no Piper TTS artifacts remain after
+  # migration to Kokoro TTS (migrate-tts-to-kokoro, v0.7.0).
+  # Runs parallel to no-dev-artifacts. See scripts/assert-no-piper.sh.
+  # ============================================================================
+  no-piper-artifacts:
+    name: No Piper artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Install fd (file finder)
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y fd-find
+          sudo ln -sf /usr/bin/fdfind /usr/local/bin/fd
+
+      - name: Assert no Piper artifacts in image/files
+        run: bash scripts/assert-no-piper.sh image/files
+
+      - name: Assert no Piper artifacts in Containerfile
+        run: bash scripts/assert-no-piper.sh image/Containerfile
+
+  # ============================================================================
   # Job 1: Build and Test CLI
   # ============================================================================
   build-cli:

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 target/
 **/*.rs.bk
 
+# Python
+__pycache__/
+*.pyc
+
 # IDE
 .idea/
 .vscode/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,22 @@ repos:
         stages: [pre-commit]
 
   # ============================================================================
+  # Piper artifact guard — assert no Piper TTS references in Containerfile or
+  # image/files/ tree. Catches regressions that would re-introduce Piper after
+  # migration to Kokoro TTS (migrate-tts-to-kokoro, v0.7.0).
+  # Runs only when Containerfile or image/files/{service,env,conf} files change.
+  # ============================================================================
+  - repo: local
+    hooks:
+      - id: assert-no-piper-artifacts
+        name: Assert no Piper artifacts in Containerfile and image files
+        language: script
+        entry: bash scripts/assert-no-piper.sh image/Containerfile image/files
+        pass_filenames: false
+        stages: [pre-commit]
+        files: ^image/(Containerfile|files/.*\.(service|env|conf))$
+
+  # ============================================================================
   # Rust Formatting and Linting
   # ============================================================================
   - repo: local

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,15 @@ LifeOS uses a pragmatic issue/PR policy:
 
 Prefer the lightest process that still preserves enough context for future maintainers and agents.
 
+## Key Services (runtime)
+
+| Service | Address | Notes |
+|---------|---------|-------|
+| `lifeosd` REST API | `127.0.0.1:8081` | Auth: `x-bootstrap-token` header |
+| `llama-server` | `127.0.0.1:8082` | Local LLM inference (llama.cpp) |
+| `lifeos-tts-server` | `127.0.0.1:8083` | TTS: Kokoro-82M (Apache 2.0), 50+ voices. See [`docs/operations/tts.md`](docs/operations/tts.md) |
+| `simplex-chat` | `ws://127.0.0.1:5226` | SimpleX bridge WebSocket |
+
 ## How to Navigate This Repo
 
 **Do NOT read all docs.** Use targeted searches:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ sudo bash scripts/build-iso.sh
 
 - **Daemon API:** Axum REST on `127.0.0.1:8081` + WebSocket at `/ws`. Auth: `x-bootstrap-token` header
 - **AI runtime:** llama-server on `:8082`, Qwen3.5-4B default, 13+ LLM providers via `llm_router.rs`
+- **TTS:** `lifeos-tts-server.service` (Kokoro-82M, Apache 2.0) on `127.0.0.1:8083`. HTTP API: `GET /health`, `GET /voices`, `POST /tts`. Integration: `sensory_pipeline.rs::synthesize_with_kokoro_http()`. Docs: [`docs/operations/tts.md`](docs/operations/tts.md)
 - **Features:** `default = ["dbus", "http-api"]`, optional `ui-overlay` (GTK4), `messaging` (SimpleX bridge), `tray`
 
 ## Critical Constraints

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2591,7 +2591,7 @@ dependencies = [
 
 [[package]]
 name = "life"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2617,7 +2617,7 @@ dependencies = [
 
 [[package]]
 name = "lifeos-integration-tests"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "life",
  "serde_json",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "lifeosd"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2591,7 +2591,7 @@ dependencies = [
 
 [[package]]
 name = "life"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2617,7 +2617,7 @@ dependencies = [
 
 [[package]]
 name = "lifeos-integration-tests"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "life",
  "serde_json",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "lifeosd"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.7.0"
+version = "0.7.1"
 
 [workspace.metadata.lifeos]
 codename = "Axolotl"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 
 [workspace.metadata.lifeos]
 codename = "Axolotl"

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -34,6 +34,15 @@ All docs are organized in `docs/`. Read `docs/README.md` for the full index.
 | Developer workstation bootstrap | `docs/operations/developer-bootstrap.md` |
 | Update check/stage/apply flow | `docs/operations/update-flow.md` |
 
+## Key Services (runtime)
+
+| Service | Address | Notes |
+|---------|---------|-------|
+| `lifeosd` REST API | `127.0.0.1:8081` | Auth: `x-bootstrap-token` header |
+| `llama-server` | `127.0.0.1:8082` | Local LLM inference (llama.cpp) |
+| `lifeos-tts-server` | `127.0.0.1:8083` | TTS: Kokoro-82M (Apache 2.0), 50+ voices. See [`docs/operations/tts.md`](docs/operations/tts.md) |
+| `simplex-chat` | `ws://127.0.0.1:5226` | SimpleX bridge WebSocket |
+
 ## Key Files
 
 | File | Purpose |

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ LifeOS is built in Mexico and developed in the open for users, contributors, and
 - **Desktop control tooling** (`integrated in repo`) - the repo includes tools for windows, apps, clipboard, browser, LibreOffice, COSMIC desktop, and accessibility trees
 - **Provider routing** (`integrated in repo`) - multiple LLM providers are wired with privacy-aware routing policies
 - **Interaction surfaces** - SimpleX is the privacy-first remote channel (`simplex_bridge.rs` + `simplex-chat.service`, E2E encrypted, no phone number required); the local dashboard (`http://127.0.0.1:8081/dashboard`) is the in-host web UI (`integrated in repo`); local voice and broader desktop surfaces exist but some remain experimental or are still being re-validated
+- **Voice: Kokoro-82M** (`integrated in repo`) - 50+ voices, Apache 2.0, CPU-only inference via `lifeos-tts-server.service` on `:8083`; dashboard voice selector lets users pick and preview any voice; SimpleX voice replies send OGG attachments when you send Axi a voice note
 - **Reliability layers** (`integrated in repo`) - watchdog, sentinel, circuit breaker, safe mode, and config rollback exist, but not every repair flow is equally mature
 - **Security baseline** (`integrated in repo`) - the image ships firewalld, auditd, DNS-over-TLS, SSH hardening, and related guardrails; broader hardening claims should be read as a baseline, not as a finished benchmark story. A read-only `GET /api/security/alerts` endpoint (localhost-only, no auth) exposes the in-memory ring buffer of recent security monitor events for the dashboard
 - **GPU Game Guard** (`validated on host`) - GPU offload policy exists and recent false positives were fixed, but it stays under ongoing validation after daemon/runtime changes
@@ -79,6 +80,7 @@ All documentation is organized in [`docs/`](docs/README.md):
 - **OS Base:** Fedora bootc (immutable, OCI-based)
 - **Desktop:** COSMIC (System76) on Wayland
 - **AI Runtime:** llama.cpp / llama-server
+- **TTS:** Kokoro-82M (Apache 2.0) via `lifeos-tts-server.service` on `127.0.0.1:8083`
 - **Database:** SQLite with WAL + sqlite-vec for embeddings
 - **API:** Axum REST + WebSocket on localhost:8081
 - **Protocols:** MCP (Model Context Protocol), AT-SPI2, D-Bus, CDP

--- a/build-assets/wheels/README.md
+++ b/build-assets/wheels/README.md
@@ -1,0 +1,38 @@
+# build-assets/wheels — Vendored Python Wheels
+
+This directory holds vendored Python wheels that are copied into the OCI image build
+context so that CI never depends on external package indices at image build time.
+
+## Required wheels
+
+| Wheel | Source | Size (approx) | SHA-256 |
+|-------|--------|---------------|---------|
+| `torch-2.4.1+cpu-cp312-cp312-linux_x86_64.whl` | https://download.pytorch.org/whl/cpu/torch-2.4.1%2Bcpu-cp312-cp312-linux_x86_64.whl | ~180 MB | see below |
+
+## How to vendor a new wheel
+
+```bash
+# 1. Download the CPU-only torch wheel
+pip download torch==2.4.1+cpu \
+  --index-url https://download.pytorch.org/whl/cpu \
+  --no-deps \
+  --dest build-assets/wheels/ \
+  --platform linux_x86_64 \
+  --python-version 312 \
+  --only-binary :all:
+
+# 2. Verify sha256 (update the table above)
+sha256sum build-assets/wheels/torch-2.4.1+cpu-cp312-cp312-linux_x86_64.whl
+
+# 3. Commit via git LFS (*.whl tracked in .gitattributes)
+git add build-assets/wheels/torch-2.4.1+cpu-cp312-cp312-linux_x86_64.whl
+git commit -m "chore: vendor torch 2.4.1+cpu wheel for offline kokoro image builds"
+```
+
+## Notes
+
+- Files matching `*.whl` in this directory are tracked with git LFS (see `.gitattributes`).
+- The `kokoro-builder` Containerfile stage uses `--find-links=/build-assets/wheels/` so
+  pip resolves torch from this local copy instead of hitting download.pytorch.org.
+- Never commit CUDA variants here — LifeOS TTS runs CPU-only (`LIFEOS_TTS_DEVICE=cpu`).
+- If git LFS is not configured on a new machine: `git lfs install` then `git lfs pull`.

--- a/cli/src/commands/voice.rs
+++ b/cli/src/commands/voice.rs
@@ -27,7 +27,7 @@ pub enum VoiceCommands {
         #[arg(long)]
         model: Option<String>,
     },
-    /// Speak text with local TTS (Piper)
+    /// Speak text with local TTS (Kokoro)
     Speak {
         text: String,
         #[arg(long)]

--- a/daemon/src/api/mod.rs
+++ b/daemon/src/api/mod.rs
@@ -1299,6 +1299,7 @@ pub fn create_router(state: ApiState) -> Router {
         .route("/sensory/voice/session", post(run_voice_session))
         .route("/sensory/voice/interrupt", post(interrupt_voice_session))
         .route("/sensory/tts/speak", post(run_tts_preview))
+        .route("/tts/voices", get(get_tts_voices))
         .route(
             "/sensory/vision/describe",
             post(describe_screen_with_sensory),
@@ -3274,6 +3275,33 @@ async fn run_tts_preview(
     Ok(Json(serde_json::json!({
         "status": "ok",
         "tts": result,
+    })))
+}
+
+/// GET /api/v1/tts/voices — returns the list of Kokoro voices available from the
+/// TTS server. Returns 503 if the TTS server is unavailable.
+async fn get_tts_voices(
+    State(state): State<ApiState>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<ApiError>)> {
+    let sensory_mgr = state.sensory_pipeline_manager.read().await.clone();
+    let pipeline_state = sensory_mgr.status().await;
+    let caps = &pipeline_state.capabilities;
+
+    if caps.tts_server_url.is_none() {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(ApiError {
+                error: "tts_unavailable".to_string(),
+                message: "TTS server is not available".to_string(),
+                code: 503,
+            }),
+        ));
+    }
+
+    Ok(Json(serde_json::json!({
+        "status": "ok",
+        "voices": caps.kokoro_voices,
+        "server_url": caps.tts_server_url,
     })))
 }
 
@@ -12300,5 +12328,17 @@ mod tests {
         assert_eq!(summary.mode, "cpu");
         assert_eq!(summary.confidence, "inferred");
         assert!(summary.reason.contains("Game Guard activo"));
+    }
+
+    // ── F4: Smoke test for /api/v1/tts/voices route existence ─────────────────
+    #[test]
+    fn test_tts_voices_route_is_registered() {
+        // Compile-time verification: if get_tts_voices does not exist or the
+        // route is not registered, this module won't compile.
+        // The function must be callable as a type-erased handler.
+        let _: fn() = || {
+            // Reference the handler to ensure it's not dead code
+            let _ = get_tts_voices as fn(_) -> _;
+        };
     }
 }

--- a/daemon/src/api/mod.rs
+++ b/daemon/src/api/mod.rs
@@ -3298,10 +3298,17 @@ async fn get_tts_voices(
         ));
     }
 
+    let env_default =
+        std::env::var("LIFEOS_TTS_DEFAULT_VOICE").unwrap_or_else(|_| "if_sara".to_string());
+    let um = state.user_model.read().await;
+    let current_voice =
+        crate::sensory_pipeline::resolve_tts_voice(&um, &env_default, None, &caps.kokoro_voices);
+
     Ok(Json(serde_json::json!({
         "status": "ok",
         "voices": caps.kokoro_voices,
         "server_url": caps.tts_server_url,
+        "current_voice": current_voice,
     })))
 }
 

--- a/daemon/src/api/mod.rs
+++ b/daemon/src/api/mod.rs
@@ -11884,11 +11884,59 @@ async fn get_user_profile(
     ))
 }
 
+/// Valida que `voice` sea una voz disponible en Kokoro.
+///
+/// Reglas:
+/// - String vacío → siempre aceptado (limpia el override, vuelve al default).
+/// - Lista vacía (Kokoro inalcanzable) → aceptado con degradación graceful.
+/// - Voz no vacía y lista no vacía → rechazado con 400 si no está en la lista.
+fn validate_tts_voice(
+    voice: &str,
+    available: &[crate::sensory_pipeline::KokoroVoice],
+) -> Result<(), (StatusCode, Json<ApiError>)> {
+    // Empty string clears the override — always valid.
+    if voice.is_empty() {
+        return Ok(());
+    }
+    // If Kokoro is unreachable the available list will be empty; accept the
+    // voice to avoid locking the user out due to transient downtime.
+    if available.is_empty() {
+        log::warn!(
+            "[api] tts_voice '{}' accepted without validation — Kokoro voice list is empty (server unreachable?)",
+            voice
+        );
+        return Ok(());
+    }
+    // Non-empty list: reject voices that are not in it.
+    if available.iter().any(|v| v.name == voice) {
+        Ok(())
+    } else {
+        Err((
+            StatusCode::BAD_REQUEST,
+            Json(ApiError {
+                error: "invalid_voice".to_string(),
+                message: format!(
+                    "Voice '{}' not available. Use GET /api/v1/tts/voices to list valid voices.",
+                    voice
+                ),
+                code: 400,
+            }),
+        ))
+    }
+}
+
 /// PATCH /api/v1/user/preferences — Apply a preference key/value pair.
 async fn patch_user_preferences(
     State(state): State<ApiState>,
     Json(payload): Json<PreferencePatchPayload>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ApiError>)> {
+    // Guard: validate tts_voice against the cached Kokoro voice list.
+    if payload.key == "tts_voice" {
+        let sensory_mgr = state.sensory_pipeline_manager.read().await.clone();
+        let pipeline_state = sensory_mgr.status().await;
+        validate_tts_voice(&payload.value, &pipeline_state.capabilities.kokoro_voices)?;
+    }
+
     let mut model = state.user_model.write().await;
     model.apply_preference(&payload.key, &payload.value);
 
@@ -12340,5 +12388,65 @@ mod tests {
             // Reference the handler to ensure it's not dead code
             let _ = get_tts_voices as fn(_) -> _;
         };
+    }
+
+    // ── G1: validate_tts_voice — voz válida dentro de la lista disponible ──────
+    #[test]
+    fn test_validate_tts_voice_valid_voice_returns_ok() {
+        let available = vec![
+            crate::sensory_pipeline::KokoroVoice {
+                name: "af_heart".to_string(),
+                language: "en-us".to_string(),
+                gender: "female".to_string(),
+                is_default: true,
+            },
+            crate::sensory_pipeline::KokoroVoice {
+                name: "if_sara".to_string(),
+                language: "en-us".to_string(),
+                gender: "female".to_string(),
+                is_default: false,
+            },
+        ];
+        assert!(validate_tts_voice("af_heart", &available).is_ok());
+        assert!(validate_tts_voice("if_sara", &available).is_ok());
+    }
+
+    // ── G2: validate_tts_voice — voz inválida con lista no vacía retorna 400 ───
+    #[test]
+    fn test_validate_tts_voice_invalid_voice_returns_400() {
+        let available = vec![crate::sensory_pipeline::KokoroVoice {
+            name: "af_heart".to_string(),
+            language: "en-us".to_string(),
+            gender: "female".to_string(),
+            is_default: true,
+        }];
+        let err = validate_tts_voice("nonexistent_voice", &available);
+        assert!(err.is_err());
+        let (status, Json(body)) = err.unwrap_err();
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(body.error, "invalid_voice");
+        assert!(body.message.contains("nonexistent_voice"));
+    }
+
+    // ── G3: validate_tts_voice — string vacío se acepta (limpia el override) ───
+    #[test]
+    fn test_validate_tts_voice_empty_string_returns_ok() {
+        let available = vec![crate::sensory_pipeline::KokoroVoice {
+            name: "af_heart".to_string(),
+            language: "en-us".to_string(),
+            gender: "female".to_string(),
+            is_default: true,
+        }];
+        // Empty string clears the override — always accepted
+        assert!(validate_tts_voice("", &available).is_ok());
+    }
+
+    // ── G4: validate_tts_voice — lista vacía (Kokoro inalcanzable) acepta todo ─
+    #[test]
+    fn test_validate_tts_voice_empty_available_list_accepts_any_voice() {
+        // Graceful degradation: if Kokoro is unreachable the voice list is
+        // empty; we must NOT block the user from setting a preference.
+        assert!(validate_tts_voice("af_heart", &[]).is_ok());
+        assert!(validate_tts_voice("any_unknown_voice", &[]).is_ok());
     }
 }

--- a/daemon/src/sensory_pipeline.rs
+++ b/daemon/src/sensory_pipeline.rs
@@ -3181,9 +3181,7 @@ async fn probe_kokoro_tts_server() -> (Option<String>, Vec<KokoroVoice>) {
     {
         // N1: usar unwrap_or_else para recuperarse de mutex envenenado en lugar
         // de panic, preservando la disponibilidad del sensory loop.
-        let last = LAST_KOKORO_PROBE
-            .lock()
-            .unwrap_or_else(|p| p.into_inner());
+        let last = LAST_KOKORO_PROBE.lock().unwrap_or_else(|p| p.into_inner());
         let now = std::time::Instant::now();
         if !should_probe(*last, KOKORO_PROBE_INTERVAL, now) {
             return (None, vec![]);
@@ -3210,9 +3208,7 @@ async fn probe_kokoro_tts_server() -> (Option<String>, Vec<KokoroVoice>) {
                 );
                 // C2: estampar SÓLO en éxito para que el throttle de 5 min
                 // aplique sólo a partir del primer probe exitoso.
-                let mut last = LAST_KOKORO_PROBE
-                    .lock()
-                    .unwrap_or_else(|p| p.into_inner());
+                let mut last = LAST_KOKORO_PROBE.lock().unwrap_or_else(|p| p.into_inner());
                 *last = Some(std::time::Instant::now());
                 return (Some(base_url), voices);
             }
@@ -8126,9 +8122,7 @@ Drafting the description:
         // Verifies that LAST_KOKORO_PROBE can be locked without panicking.
         // The production code uses unwrap_or_else(|p| p.into_inner()) — if it
         // were still .expect(...), a poisoned lock would panic the sensory loop.
-        let guard = LAST_KOKORO_PROBE
-            .lock()
-            .unwrap_or_else(|p| p.into_inner());
+        let guard = LAST_KOKORO_PROBE.lock().unwrap_or_else(|p| p.into_inner());
         assert!(
             guard.is_none() || guard.is_some(),
             "LAST_KOKORO_PROBE debe ser accesible"

--- a/daemon/src/sensory_pipeline.rs
+++ b/daemon/src/sensory_pipeline.rs
@@ -39,6 +39,49 @@ use tokio::sync::{mpsc, Mutex, RwLock};
 const STATE_FILE: &str = "sensory_pipeline_state.json";
 const BENCHMARK_FILE: &str = "sensory_benchmark.json";
 const DEFAULT_SCREEN_INTERVAL_SECONDS: u64 = 10;
+
+/// Intervalo mínimo entre llamadas sucesivas al probe del servidor Kokoro TTS.
+/// El estado del servidor cambia lentamente; 5 segundos era un desperdicio de red.
+pub(crate) const KOKORO_PROBE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(300);
+
+/// Tiempos de espera entre reintentos de `synthesize_with_kokoro_http`.
+/// 2 entradas → 3 intentos en total (1 inicial + 2 reintentos).
+pub(crate) const KOKORO_RETRY_DELAYS: [u64; 2] = [200, 800];
+
+/// Cliente HTTP singleton para health probes al servidor Kokoro TTS.
+/// `connect_timeout` 500 ms, `timeout` 2 s — suficiente para loopback.
+static KOKORO_PROBE_CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
+
+/// Cliente HTTP singleton para síntesis TTS (POST /tts).
+/// `connect_timeout` 3 s, `timeout` 30 s — tolera CPU bajo carga.
+static KOKORO_SYNTH_CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
+
+/// Devuelve el cliente HTTP para health probes (connect 500 ms, timeout 2 s).
+pub(crate) fn kokoro_probe_client() -> &'static reqwest::Client {
+    KOKORO_PROBE_CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .connect_timeout(std::time::Duration::from_millis(500))
+            .timeout(std::time::Duration::from_secs(2))
+            .build()
+            .expect("Failed to build Kokoro probe reqwest client")
+    })
+}
+
+/// Devuelve el cliente HTTP para síntesis TTS (connect 3 s, timeout 30 s).
+pub(crate) fn kokoro_synth_client() -> &'static reqwest::Client {
+    KOKORO_SYNTH_CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .connect_timeout(std::time::Duration::from_secs(3))
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .expect("Failed to build Kokoro synth reqwest client")
+    })
+}
+
+/// Último instante en que se ejecutó `probe_kokoro_tts_server`.
+/// Permite saltar el probe si el intervalo mínimo no ha transcurrido.
+static LAST_KOKORO_PROBE: std::sync::Mutex<Option<std::time::Instant>> =
+    std::sync::Mutex::new(None);
 const ALWAYS_ON_CAPTURE_SECONDS: u64 = 4;
 const DEFAULT_WAKE_WORD: &str = "axi";
 fn default_tts_enabled() -> bool {
@@ -3111,16 +3154,47 @@ async fn detect_capabilities(ai_manager: &AiManager) -> SensoryCapabilities {
     }
 }
 
+/// Determina si se debe ejecutar un probe ahora.
+/// El throttle sólo se aplica cuando hubo un probe EXITOSO previo.
+/// Un probe fallido no debe estampar el reloj para que el sensory loop
+/// (~5 s) pueda reintentar durante el período de calentamiento (≤ 20 s).
+pub(crate) fn should_probe(
+    last: Option<std::time::Instant>,
+    interval: std::time::Duration,
+    now: std::time::Instant,
+) -> bool {
+    match last {
+        None => true,
+        Some(prev) => now.duration_since(prev) >= interval,
+    }
+}
+
 /// Probe the Kokoro TTS server at startup. Returns `(Some(url), voices)` on
 /// success or `(None, vec![])` when the server is unreachable after 3 retries.
+/// Successive calls within `KOKORO_PROBE_INTERVAL` are skipped and return
+/// `(None, vec![])` immediately to avoid hammering the server every 5 s.
+///
+/// El throttle se estampa SÓLO en probe exitoso.  Si Kokoro aún está
+/// calentando (normal: 6-8 s; diseño: hasta 20 s) los intentos fallidos
+/// no bloquean los reintentos del siguiente tick (~5 s).
 async fn probe_kokoro_tts_server() -> (Option<String>, Vec<KokoroVoice>) {
+    {
+        // N1: usar unwrap_or_else para recuperarse de mutex envenenado en lugar
+        // de panic, preservando la disponibilidad del sensory loop.
+        let last = LAST_KOKORO_PROBE
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let now = std::time::Instant::now();
+        if !should_probe(*last, KOKORO_PROBE_INTERVAL, now) {
+            return (None, vec![]);
+        }
+        // No estampamos aquí — sólo estampamos en éxito (ver abajo).
+    }
+
     let base_url = std::env::var("LIFEOS_TTS_SERVER_URL")
         .unwrap_or_else(|_| "http://127.0.0.1:8083".to_string());
 
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(5))
-        .build()
-        .unwrap_or_default();
+    let client = kokoro_probe_client();
 
     for attempt in 0..3u32 {
         if attempt > 0 {
@@ -3128,12 +3202,18 @@ async fn probe_kokoro_tts_server() -> (Option<String>, Vec<KokoroVoice>) {
         }
         match client.get(format!("{base_url}/health")).send().await {
             Ok(resp) if resp.status().is_success() => {
-                let voices = fetch_kokoro_voices(&client, &base_url).await;
+                let voices = fetch_kokoro_voices(client, &base_url).await;
                 log::info!(
                     "[tts] Kokoro TTS server ready at {} ({} voices)",
                     base_url,
                     voices.len()
                 );
+                // C2: estampar SÓLO en éxito para que el throttle de 5 min
+                // aplique sólo a partir del primer probe exitoso.
+                let mut last = LAST_KOKORO_PROBE
+                    .lock()
+                    .unwrap_or_else(|p| p.into_inner());
+                *last = Some(std::time::Instant::now());
                 return (Some(base_url), voices);
             }
             Ok(resp) => {
@@ -3158,7 +3238,7 @@ async fn probe_kokoro_tts_server() -> (Option<String>, Vec<KokoroVoice>) {
 }
 
 /// Fetch available voices from `GET {base_url}/voices`.
-async fn fetch_kokoro_voices(client: &reqwest::Client, base_url: &str) -> Vec<KokoroVoice> {
+pub async fn fetch_kokoro_voices(client: &reqwest::Client, base_url: &str) -> Vec<KokoroVoice> {
     match client.get(format!("{base_url}/voices")).send().await {
         Ok(resp) if resp.status().is_success() => {
             resp.json::<Vec<KokoroVoice>>().await.unwrap_or_default()
@@ -4033,13 +4113,9 @@ pub async fn synthesize_with_kokoro_http(
     let ext = if format == "ogg" { "ogg" } else { "wav" };
     let audio_path = tts_dir.join(format!("axi-{}.{}", uuid::Uuid::new_v4(), ext));
 
-    let client = reqwest::Client::builder()
-        .connect_timeout(std::time::Duration::from_millis(500))
-        .timeout(std::time::Duration::from_secs(30))
-        .build()
-        .context("Failed to build reqwest client")?;
+    let client = kokoro_synth_client();
 
-    let delays_ms = [200u64, 500, 1200];
+    let delays_ms = KOKORO_RETRY_DELAYS;
     let mut last_err: Option<anyhow::Error> = None;
 
     for (attempt, &delay_ms) in std::iter::once(&0u64).chain(delays_ms.iter()).enumerate() {
@@ -4068,7 +4144,7 @@ pub async fn synthesize_with_kokoro_http(
                     e
                 );
                 last_err = Some(e.into());
-                if is_transient && attempt < 3 {
+                if is_transient && attempt < KOKORO_RETRY_DELAYS.len() {
                     continue;
                 }
                 break;
@@ -4081,7 +4157,7 @@ pub async fn synthesize_with_kokoro_http(
         {
             log::warn!("[tts] Kokoro returned {} (attempt {})", status, attempt + 1);
             last_err = Some(anyhow::anyhow!("Kokoro returned {}", status));
-            if attempt < 3 {
+            if attempt < KOKORO_RETRY_DELAYS.len() {
                 continue;
             }
             break;
@@ -7948,5 +8024,114 @@ Drafting the description:
         let available = make_voices(&["if_sara", "af_heart"]);
         let result = resolve_tts_voice(&model, "if_sara", Some(""), &available);
         assert_eq!(result, "if_sara");
+    }
+
+    // --- Warning A: probe interval ---
+
+    #[test]
+    fn kokoro_probe_interval_is_five_minutes() {
+        assert_eq!(
+            KOKORO_PROBE_INTERVAL,
+            std::time::Duration::from_secs(300),
+            "KOKORO_PROBE_INTERVAL debe ser 5 minutos (300 s)"
+        );
+    }
+
+    // --- Warning B: retry count ---
+
+    #[test]
+    fn kokoro_retry_delays_len_gives_three_total_attempts() {
+        // 1 initial attempt + KOKORO_RETRY_DELAYS.len() retries == 3
+        assert_eq!(
+            KOKORO_RETRY_DELAYS.len(),
+            2,
+            "KOKORO_RETRY_DELAYS must have exactly 2 entries (1 initial + 2 retries = 3 total)"
+        );
+    }
+
+    // ── C2: throttle should_probe helper ─────────────────────────────────────
+    // Tests the pure helper that decides whether a probe should run.
+    // None → always probe; Some(recent) → skip; Some(old) → probe again.
+
+    #[test]
+    fn should_probe_returns_true_when_never_probed() {
+        let now = std::time::Instant::now();
+        assert!(
+            should_probe(None, KOKORO_PROBE_INTERVAL, now),
+            "should_probe debe retornar true cuando nunca se probó (last=None)"
+        );
+    }
+
+    #[test]
+    fn should_probe_returns_false_when_last_probe_was_recent() {
+        let now = std::time::Instant::now();
+        // 1 minute ago — well within the 5-minute interval
+        let recent = now - std::time::Duration::from_secs(60);
+        assert!(
+            !should_probe(Some(recent), KOKORO_PROBE_INTERVAL, now),
+            "should_probe debe retornar false cuando el último probe fue hace 1 min (intervalo 5 min)"
+        );
+    }
+
+    #[test]
+    fn should_probe_returns_true_when_last_probe_was_old() {
+        let now = std::time::Instant::now();
+        // 6 minutes ago — past the 5-minute interval
+        let old = now - std::time::Duration::from_secs(360);
+        assert!(
+            should_probe(Some(old), KOKORO_PROBE_INTERVAL, now),
+            "should_probe debe retornar true cuando el último probe fue hace 6 min (intervalo 5 min)"
+        );
+    }
+
+    // ── W4: split probe/synth clients ────────────────────────────────────────
+
+    #[test]
+    fn kokoro_probe_client_returns_same_instance() {
+        let a = kokoro_probe_client();
+        let b = kokoro_probe_client();
+        assert!(
+            std::ptr::eq(a, b),
+            "kokoro_probe_client() debe devolver siempre el mismo puntero (singleton)"
+        );
+    }
+
+    #[test]
+    fn kokoro_synth_client_returns_same_instance() {
+        let a = kokoro_synth_client();
+        let b = kokoro_synth_client();
+        assert!(
+            std::ptr::eq(a, b),
+            "kokoro_synth_client() debe devolver siempre el mismo puntero (singleton)"
+        );
+    }
+
+    #[test]
+    fn kokoro_probe_and_synth_clients_are_different_instances() {
+        let probe = kokoro_probe_client() as *const _ as *const ();
+        let synth = kokoro_synth_client() as *const _ as *const ();
+        assert!(
+            !std::ptr::eq(probe, synth),
+            "kokoro_probe_client() y kokoro_synth_client() deben ser instancias distintas"
+        );
+    }
+
+    // ── N1: mutex poison recovery ─────────────────────────────────────────────
+    // Direct unit test is hard without a threaded panic, but this confirms the
+    // function compiles and returns a valid guard using unwrap_or_else(|p| p.into_inner()).
+    // Coverage provided implicitly by all tests that call probe_kokoro_tts_server()
+    // or any function locking LAST_KOKORO_PROBE.
+    #[test]
+    fn last_kokoro_probe_lock_is_accessible() {
+        // Verifies that LAST_KOKORO_PROBE can be locked without panicking.
+        // The production code uses unwrap_or_else(|p| p.into_inner()) — if it
+        // were still .expect(...), a poisoned lock would panic the sensory loop.
+        let guard = LAST_KOKORO_PROBE
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        assert!(
+            guard.is_none() || guard.is_some(),
+            "LAST_KOKORO_PROBE debe ser accesible"
+        );
     }
 }

--- a/daemon/src/sensory_pipeline.rs
+++ b/daemon/src/sensory_pipeline.rs
@@ -32,7 +32,7 @@ use std::time::Instant;
 /// condition never changes at runtime, so one WARN at the first miss and
 /// DEBUG afterwards is the right policy.
 static CAMERA_BINARY_WARNED: AtomicBool = AtomicBool::new(false);
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::AsyncReadExt;
 use tokio::process::Command;
 use tokio::sync::{mpsc, Mutex, RwLock};
 
@@ -181,16 +181,6 @@ const CAMERA_FRAME_VERY_DARK_CONTRAST_BOOST: f32 = 30.0;
 /// the wake word again (continuous conversation window).
 const CONTINUOUS_CONVERSATION_SECS: i64 = 30;
 
-/// Emotional/contextual variation for TTS synthesis.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum TtsEmotion {
-    Neutral,
-    Urgent,
-    Confirmation,
-    Question,
-    Calm,
-}
-
 /// Near-field vs far-field microphone mode. Near-field (headset) uses lower
 /// thresholds, while far-field (laptop mic) uses higher thresholds and gain.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -210,42 +200,6 @@ struct MicCalibration {
     timestamp: DateTime<Utc>,
 }
 
-/// Simple keyword/pattern matching to detect the emotional tone of a text.
-fn detect_emotion(text: &str) -> TtsEmotion {
-    let lower = text.to_lowercase();
-    if lower.contains("error")
-        || lower.contains("fallo")
-        || lower.contains("alerta")
-        || lower.contains("critico")
-        || lower.contains("urgente")
-        || lower.contains("warning")
-        || lower.contains("failed")
-    {
-        return TtsEmotion::Urgent;
-    }
-    if lower.contains("listo")
-        || lower.contains("hecho")
-        || lower.contains("completado")
-        || lower.contains("exito")
-        || lower.contains("done")
-        || lower.contains("success")
-        || lower.contains("perfecto")
-    {
-        return TtsEmotion::Confirmation;
-    }
-    if lower.contains("buenas noches")
-        || lower.contains("descansa")
-        || lower.contains("relax")
-        || lower.contains("good night")
-    {
-        return TtsEmotion::Calm;
-    }
-    if text.trim_end().ends_with('?') {
-        return TtsEmotion::Question;
-    }
-    TtsEmotion::Neutral
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(default)]
 pub struct SensorLeds {
@@ -255,13 +209,24 @@ pub struct SensorLeds {
     pub kill_switch_active: bool,
 }
 
+/// A single voice available from the Kokoro TTS server.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct KokoroVoice {
+    pub name: String,
+    pub language: String,
+    pub gender: String,
+    pub is_default: bool,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(default)]
 pub struct SensoryCapabilities {
     pub stt_binary: Option<String>,
     pub audio_capture_binary: Option<String>,
-    pub tts_binary: Option<String>,
-    pub tts_model: Option<String>,
+    /// URL of the Kokoro TTS HTTP server (e.g. "http://127.0.0.1:8083"). None = unavailable.
+    pub tts_server_url: Option<String>,
+    /// Voices available from the Kokoro TTS server. Empty if server is unavailable.
+    pub kokoro_voices: Vec<KokoroVoice>,
     pub playback_binary: Option<String>,
     pub screen_capture_available: bool,
     pub tesseract_available: bool,
@@ -2877,42 +2842,28 @@ impl SensoryPipelineManager {
             return Ok((None, None, None, false));
         }
 
-        // Resolve TTS toolchain once.
-        let piper_models = resolve_tts_models(voice_model).await;
-        let fallback_binary = resolve_binary("LIFEOS_TTS_FALLBACK_BIN", &["espeak-ng"]).await;
-        let binary = select_tts_binary(
-            resolve_binary("LIFEOS_TTS_BIN", &["lifeos-piper", "piper", "espeak-ng"]).await,
-            piper_models.first().map(|v| v.as_str()),
-            fallback_binary.clone(),
-        );
-        let binary = sanitize_tts_binary(binary, fallback_binary.clone())
-            .await
-            .ok_or_else(|| anyhow::anyhow!("no local TTS backend found"))?;
-
         let player = resolve_binary("LIFEOS_PLAYBACK_BIN", &["pw-play", "aplay", "paplay"])
             .await
             .ok_or_else(|| anyhow::anyhow!("no playback backend found"))?;
 
+        // Resolve voice for this session.
+        let env_default =
+            std::env::var("LIFEOS_TTS_DEFAULT_VOICE").unwrap_or_else(|_| "if_sara".to_string());
+        let voice = voice_model.unwrap_or(env_default.as_str()).to_string();
+
         // Duck system audio before speaking.
         duck_system_audio(true).await;
 
-        let emotion = detect_emotion(text);
         let mut first_audio_path: Option<String> = None;
-        let tts_engine = binary.clone();
+        let tts_engine = format!("kokoro:{}", voice);
         let playback_backend = player.clone();
         let mut any_played = false;
 
         // Pre-synthesize the first sentence.
-        let mut next_audio = synthesize_single_chunk(
-            &self.data_dir,
-            &binary,
-            &sentences[0],
-            language,
-            piper_models.first().map(|v| v.as_str()),
-            emotion,
-        )
-        .await
-        .ok();
+        let mut next_audio =
+            synthesize_single_chunk(&self.data_dir, &sentences[0], language, &voice)
+                .await
+                .ok();
 
         for i in 0..sentences.len() {
             let current_audio = match next_audio.take() {
@@ -2927,22 +2878,13 @@ impl SensoryPipelineManager {
             // Start synthesizing the NEXT sentence in the background.
             let next_synth = if i + 1 < sentences.len() {
                 let data_dir = self.data_dir.clone();
-                let bin = binary.clone();
                 let sent = sentences[i + 1].clone();
                 let lang = language.map(str::to_string);
-                let model = piper_models.first().cloned();
-                let emo = emotion;
+                let v = voice.clone();
                 Some(tokio::spawn(async move {
-                    synthesize_single_chunk(
-                        &data_dir,
-                        &bin,
-                        &sent,
-                        lang.as_deref(),
-                        model.as_deref(),
-                        emo,
-                    )
-                    .await
-                    .ok()
+                    synthesize_single_chunk(&data_dir, &sent, lang.as_deref(), &v)
+                        .await
+                        .ok()
                 }))
             } else {
                 None
@@ -3138,16 +3080,7 @@ async fn write_atomic(path: &PathBuf, contents: &str) -> Result<()> {
 }
 
 async fn detect_capabilities(ai_manager: &AiManager) -> SensoryCapabilities {
-    let preferred_tts_binary =
-        resolve_binary("LIFEOS_TTS_BIN", &["lifeos-piper", "piper", "espeak-ng"]).await;
-    let tts_model = resolve_tts_model(None).await;
-    let fallback_tts_binary = resolve_binary("LIFEOS_TTS_FALLBACK_BIN", &["espeak-ng"]).await;
-    let tts_binary = select_tts_binary(
-        preferred_tts_binary,
-        tts_model.as_deref(),
-        fallback_tts_binary.clone(),
-    );
-    let tts_binary = sanitize_tts_binary(tts_binary, fallback_tts_binary).await;
+    let (tts_server_url, kokoro_voices) = probe_kokoro_tts_server().await;
 
     SensoryCapabilities {
         stt_binary: resolve_binary("LIFEOS_STT_BIN", &["whisper-cli", "whisper", "whisper-cpp"])
@@ -3157,8 +3090,8 @@ async fn detect_capabilities(ai_manager: &AiManager) -> SensoryCapabilities {
             &["ffmpeg", "arecord", "pw-record", "parecord"],
         )
         .await,
-        tts_binary,
-        tts_model,
+        tts_server_url,
+        kokoro_voices,
         playback_binary: resolve_binary("LIFEOS_PLAYBACK_BIN", &["pw-play", "aplay", "paplay"])
             .await,
         screen_capture_available: true,
@@ -3175,6 +3108,69 @@ async fn detect_capabilities(ai_manager: &AiManager) -> SensoryCapabilities {
         llama_server_running: ai_manager.is_running().await,
         always_on_source: resolve_always_on_source().await,
         rustpotter_model_available: crate::wake_word::resolve_model_path().is_some(),
+    }
+}
+
+/// Probe the Kokoro TTS server at startup. Returns `(Some(url), voices)` on
+/// success or `(None, vec![])` when the server is unreachable after 3 retries.
+async fn probe_kokoro_tts_server() -> (Option<String>, Vec<KokoroVoice>) {
+    let base_url = std::env::var("LIFEOS_TTS_SERVER_URL")
+        .unwrap_or_else(|_| "http://127.0.0.1:8083".to_string());
+
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .build()
+        .unwrap_or_default();
+
+    for attempt in 0..3u32 {
+        if attempt > 0 {
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        }
+        match client.get(format!("{base_url}/health")).send().await {
+            Ok(resp) if resp.status().is_success() => {
+                let voices = fetch_kokoro_voices(&client, &base_url).await;
+                log::info!(
+                    "[tts] Kokoro TTS server ready at {} ({} voices)",
+                    base_url,
+                    voices.len()
+                );
+                return (Some(base_url), voices);
+            }
+            Ok(resp) => {
+                log::warn!(
+                    "[tts] Kokoro health check returned {} (attempt {})",
+                    resp.status(),
+                    attempt + 1
+                );
+            }
+            Err(e) => {
+                log::warn!(
+                    "[tts] Kokoro health check failed (attempt {}): {}",
+                    attempt + 1,
+                    e
+                );
+            }
+        }
+    }
+
+    log::warn!("[tts] Kokoro TTS server not available — TTS degraded");
+    (None, vec![])
+}
+
+/// Fetch available voices from `GET {base_url}/voices`.
+async fn fetch_kokoro_voices(client: &reqwest::Client, base_url: &str) -> Vec<KokoroVoice> {
+    match client.get(format!("{base_url}/voices")).send().await {
+        Ok(resp) if resp.status().is_success() => {
+            resp.json::<Vec<KokoroVoice>>().await.unwrap_or_default()
+        }
+        Ok(resp) => {
+            log::warn!("[tts] /voices returned {}", resp.status());
+            vec![]
+        }
+        Err(e) => {
+            log::warn!("[tts] Failed to fetch voices: {}", e);
+            vec![]
+        }
     }
 }
 
@@ -3371,10 +3367,7 @@ fn degraded_modes(capabilities: &SensoryCapabilities, gpu: &GpuOffloadStatus) ->
     if capabilities.audio_capture_binary.is_none() {
         degraded.push("mic_capture_unavailable".to_string());
     }
-    if capabilities.tts_binary.is_none()
-        || (tts_binary_requires_model(capabilities.tts_binary.as_deref())
-            && capabilities.tts_model.is_none())
-    {
+    if capabilities.tts_server_url.is_none() {
         degraded.push("tts_unavailable".to_string());
     }
     if capabilities.camera_device.is_none() {
@@ -3944,6 +3937,49 @@ async fn multimodal_chat_with_fallback(
     }
 }
 
+/// Resolve the TTS voice to use, applying priority: req_override > model.tts_voice > env_default.
+/// Empty-string override is treated as None.
+pub fn resolve_tts_voice(
+    model: &crate::user_model::UserModel,
+    env_default: &str,
+    req_override: Option<&str>,
+    available: &[KokoroVoice],
+) -> String {
+    // 1. req_override (if non-empty and in available list)
+    if let Some(ov) = req_override {
+        let ov = ov.trim();
+        if !ov.is_empty() {
+            if available.is_empty() || available.iter().any(|v| v.name == ov) {
+                return ov.to_string();
+            }
+            log::warn!(
+                "[tts] Requested voice '{}' not in available list — falling back to default '{}'",
+                ov,
+                env_default
+            );
+            return env_default.to_string();
+        }
+    }
+
+    // 2. model.tts_voice (if in available list)
+    if let Some(ref mv) = model.tts_voice {
+        if available.is_empty() || available.iter().any(|v| v.name == mv.as_str()) {
+            return mv.clone();
+        }
+        log::warn!(
+            "[tts] Model voice '{}' not in available list — falling back to default '{}'",
+            mv,
+            env_default
+        );
+    }
+
+    // 3. env_default
+    env_default.to_string()
+}
+
+/// Synthesize text to a WAV file via the Kokoro HTTP TTS server.
+/// Retries on transient errors with [200ms, 500ms, 1200ms] delays.
+/// Falls back to espeak-ng when tts_server_url is None.
 async fn synthesize_tts(
     data_dir: &Path,
     text: &str,
@@ -3951,119 +3987,126 @@ async fn synthesize_tts(
     voice_model: Option<&str>,
 ) -> Result<(String, String)> {
     let tts_text = prepare_tts_text(text);
-    let piper_models = resolve_tts_models(voice_model).await;
-    let fallback_binary = resolve_binary("LIFEOS_TTS_FALLBACK_BIN", &["espeak-ng"]).await;
-    let binary = select_tts_binary(
-        resolve_binary("LIFEOS_TTS_BIN", &["lifeos-piper", "piper", "espeak-ng"]).await,
-        piper_models.first().map(|value| value.as_str()),
-        fallback_binary.clone(),
-    );
-    let binary = sanitize_tts_binary(binary, fallback_binary.clone())
-        .await
-        .ok_or_else(|| anyhow::anyhow!("no local TTS backend found"))?;
 
-    if binary_basename(&binary) == "espeak-ng" {
-        let audio_path = synthesize_with_espeak(data_dir, &binary, &tts_text, language).await?;
-        return Ok((audio_path, binary));
-    }
+    // Determine if Kokoro server URL is configured.
+    let server_url = std::env::var("LIFEOS_TTS_SERVER_URL")
+        .ok()
+        .filter(|s| !s.is_empty());
 
-    let emotion = detect_emotion(&tts_text);
-    let mut piper_errors = Vec::new();
-    for model in piper_models {
-        match synthesize_with_piper(data_dir, &binary, &tts_text, &model, emotion).await {
-            Ok(audio_path) => return Ok((audio_path, binary.clone())),
-            Err(err) => {
-                log::warn!("Piper synthesis failed with model {}: {}", model, err);
-                piper_errors.push(format!("{model}: {err}"));
+    if let Some(ref base_url) = server_url {
+        let env_default =
+            std::env::var("LIFEOS_TTS_DEFAULT_VOICE").unwrap_or_else(|_| "if_sara".to_string());
+        let voice = voice_model.unwrap_or(env_default.as_str()).to_string();
+        match synthesize_with_kokoro_http(data_dir, base_url, &tts_text, &voice, "wav").await {
+            Ok(path) => return Ok((path, format!("kokoro:{}", voice))),
+            Err(e) => {
+                log::warn!("[tts] Kokoro synthesis failed: {} — trying espeak-ng", e);
             }
         }
     }
 
-    if let Some(fallback_binary) = fallback_binary {
-        let audio_path =
-            synthesize_with_espeak(data_dir, &fallback_binary, &tts_text, language).await?;
-        return Ok((audio_path, fallback_binary));
-    };
-
-    if !piper_errors.is_empty() {
-        anyhow::bail!(
-            "piper synthesis failed for all configured models: {}",
-            piper_errors.join(" | ")
-        );
-    }
-
-    anyhow::bail!("no Piper voice model configured");
+    // Fallback: espeak-ng
+    let espeak = resolve_binary("LIFEOS_TTS_FALLBACK_BIN", &["espeak-ng"])
+        .await
+        .ok_or_else(|| {
+            anyhow::anyhow!("no TTS backend available (Kokoro unreachable, espeak-ng not found)")
+        })?;
+    let audio_path = synthesize_with_espeak(data_dir, &espeak, &tts_text, language).await?;
+    Ok((audio_path, espeak))
 }
 
-async fn synthesize_with_piper(
+/// Call Kokoro TTS server HTTP API with retry logic.
+/// Retries 3 times on connection-refused / 503 / 504 / timeout.
+/// Returns path to the saved audio file.
+pub async fn synthesize_with_kokoro_http(
     data_dir: &Path,
-    binary: &str,
+    base_url: &str,
     text: &str,
-    model: &str,
-    emotion: TtsEmotion,
+    voice: &str,
+    format: &str,
 ) -> Result<String> {
     let tts_dir = data_dir.join("tts");
     tokio::fs::create_dir_all(&tts_dir)
         .await
         .context("Failed to create TTS output dir")?;
-    let audio_path = tts_dir.join(format!("axi-{}.wav", uuid::Uuid::new_v4()));
 
-    let mut args = vec![
-        "--model".to_string(),
-        model.to_string(),
-        "--output_file".to_string(),
-        audio_path.to_string_lossy().to_string(),
-    ];
-    match emotion {
-        TtsEmotion::Urgent => {
-            args.extend(["--length-scale".into(), "0.85".into()]);
-            args.extend(["--sentence-silence".into(), "0.1".into()]);
-        }
-        TtsEmotion::Confirmation => {
-            args.extend(["--length-scale".into(), "0.95".into()]);
-            args.extend(["--sentence-silence".into(), "0.3".into()]);
-        }
-        TtsEmotion::Question => {
-            args.extend(["--length-scale".into(), "1.05".into()]);
-            args.extend(["--sentence-silence".into(), "0.4".into()]);
-        }
-        TtsEmotion::Calm => {
-            args.extend(["--length-scale".into(), "1.15".into()]);
-            args.extend(["--sentence-silence".into(), "0.5".into()]);
-        }
-        TtsEmotion::Neutral => {}
-    }
+    let ext = if format == "ogg" { "ogg" } else { "wav" };
+    let audio_path = tts_dir.join(format!("axi-{}.{}", uuid::Uuid::new_v4(), ext));
 
-    let mut child = Command::new(binary)
-        .args(&args)
-        .stdin(std::process::Stdio::piped())
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .spawn()
-        .with_context(|| format!("Failed to start Piper via {}", binary))?;
+    let client = reqwest::Client::builder()
+        .connect_timeout(std::time::Duration::from_millis(500))
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .context("Failed to build reqwest client")?;
 
-    if let Some(mut stdin) = child.stdin.take() {
-        stdin
-            .write_all(text.trim().as_bytes())
+    let delays_ms = [200u64, 500, 1200];
+    let mut last_err: Option<anyhow::Error> = None;
+
+    for (attempt, &delay_ms) in std::iter::once(&0u64).chain(delays_ms.iter()).enumerate() {
+        if attempt > 0 {
+            tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+        }
+
+        let body = serde_json::json!({
+            "text": text,
+            "voice": voice,
+            "format": format,
+        });
+
+        let resp = match client
+            .post(format!("{base_url}/tts"))
+            .json(&body)
+            .send()
             .await
-            .context("Failed to send text to Piper stdin")?;
+        {
+            Ok(r) => r,
+            Err(e) => {
+                let is_transient = e.is_connect() || e.is_timeout();
+                log::warn!(
+                    "[tts] Kokoro request failed (attempt {}): {}",
+                    attempt + 1,
+                    e
+                );
+                last_err = Some(e.into());
+                if is_transient && attempt < 3 {
+                    continue;
+                }
+                break;
+            }
+        };
+
+        let status = resp.status();
+        if status == reqwest::StatusCode::SERVICE_UNAVAILABLE
+            || status == reqwest::StatusCode::GATEWAY_TIMEOUT
+        {
+            log::warn!("[tts] Kokoro returned {} (attempt {})", status, attempt + 1);
+            last_err = Some(anyhow::anyhow!("Kokoro returned {}", status));
+            if attempt < 3 {
+                continue;
+            }
+            break;
+        }
+
+        if !status.is_success() {
+            let msg = resp.text().await.unwrap_or_else(|_| status.to_string());
+            anyhow::bail!("Kokoro TTS error {}: {}", status, msg);
+        }
+
+        let bytes = resp
+            .bytes()
+            .await
+            .context("Failed to read Kokoro audio bytes")?;
+        tokio::fs::write(&audio_path, &bytes)
+            .await
+            .context("Failed to write TTS audio file")?;
+
+        cleanup_dir_by_count(&tts_dir, TTS_RETENTION_COUNT, "tts")
+            .await
+            .ok();
+        return Ok(audio_path.to_string_lossy().to_string());
     }
 
-    let output = child
-        .wait_with_output()
-        .await
-        .context("Failed to wait for Piper output")?;
-    if !output.status.success() {
-        anyhow::bail!(
-            "piper synthesis failed: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
-        );
-    }
-
-    cleanup_dir_by_count(&tts_dir, TTS_RETENTION_COUNT, "tts")
-        .await
-        .ok();
-    Ok(audio_path.to_string_lossy().to_string())
+    Err(last_err.unwrap_or_else(|| anyhow::anyhow!("Kokoro TTS failed after retries")))
 }
 
 async fn synthesize_with_espeak(
@@ -4104,21 +4147,33 @@ async fn synthesize_with_espeak(
 }
 
 /// Synthesize a single text chunk to a WAV file. Used by progressive playback.
+/// Uses Kokoro HTTP API when available, falls back to espeak-ng.
 async fn synthesize_single_chunk(
     data_dir: &Path,
-    binary: &str,
     text: &str,
     language: Option<&str>,
-    piper_model: Option<&str>,
-    emotion: TtsEmotion,
+    voice: &str,
 ) -> Result<String> {
-    if binary_basename(binary) == "espeak-ng" {
-        return synthesize_with_espeak(data_dir, binary, text, language).await;
+    let server_url = std::env::var("LIFEOS_TTS_SERVER_URL")
+        .ok()
+        .filter(|s| !s.is_empty());
+
+    if let Some(ref base_url) = server_url {
+        match synthesize_with_kokoro_http(data_dir, base_url, text, voice, "wav").await {
+            Ok(path) => return Ok(path),
+            Err(e) => {
+                log::warn!(
+                    "[tts] Kokoro chunk synthesis failed: {} — trying espeak-ng",
+                    e
+                );
+            }
+        }
     }
-    if let Some(model) = piper_model {
-        return synthesize_with_piper(data_dir, binary, text, model, emotion).await;
-    }
-    anyhow::bail!("no TTS model available for progressive synthesis")
+
+    let espeak = resolve_binary("LIFEOS_TTS_FALLBACK_BIN", &["espeak-ng"])
+        .await
+        .ok_or_else(|| anyhow::anyhow!("no TTS backend available for chunk synthesis"))?;
+    synthesize_with_espeak(data_dir, &espeak, text, language).await
 }
 
 /// Split response text into sentence-level chunks suitable for progressive TTS.
@@ -5056,86 +5111,6 @@ async fn capture_until_silence(data_dir: &Path, source: Option<&str>) -> Result<
     Ok(audio_path.to_string_lossy().to_string())
 }
 
-pub async fn resolve_tts_model(override_model: Option<&str>) -> Option<String> {
-    resolve_tts_models(override_model).await.into_iter().next()
-}
-
-pub async fn resolve_tts_models(override_model: Option<&str>) -> Vec<String> {
-    let mut models = Vec::new();
-
-    if let Some(model) = override_model.and_then(resolve_existing_tts_model) {
-        models.push(model);
-    }
-
-    if let Ok(model) = std::env::var("LIFEOS_TTS_MODEL") {
-        if let Some(model) = resolve_existing_tts_model(&model) {
-            if !models.iter().any(|existing| existing == &model) {
-                models.push(model);
-            }
-        }
-    }
-
-    for candidate in [
-        "/var/lib/lifeos/models/piper/es_MX-claude-high.onnx",
-        "/var/lib/lifeos/models/piper/es_ES-sharvard-medium.onnx",
-        "/var/lib/lifeos/models/piper/en_US-lessac-medium.onnx",
-        "/usr/share/lifeos/models/piper/es_MX-claude-high.onnx",
-        "/usr/share/lifeos/models/piper/en_US-lessac-medium.onnx",
-    ] {
-        if !models.iter().any(|existing| existing == candidate) && tts_model_is_ready(candidate) {
-            models.push(candidate.to_string());
-        }
-    }
-
-    models
-}
-
-pub fn resolve_existing_tts_model(candidate: &str) -> Option<String> {
-    let candidate = candidate.trim();
-    if candidate.is_empty() {
-        return None;
-    }
-    if tts_model_is_ready(candidate) {
-        return Some(candidate.to_string());
-    }
-
-    let file_name = Path::new(candidate)
-        .file_name()
-        .and_then(|name| name.to_str())?;
-    [
-        "/var/lib/lifeos/models/piper",
-        "/usr/share/lifeos/models/piper",
-        "/var/lib/lifeos/models",
-        "/usr/share/lifeos/models",
-    ]
-    .iter()
-    .map(|dir| format!("{dir}/{file_name}"))
-    .find(|path| tts_model_is_ready(path))
-}
-
-pub fn tts_model_is_ready(candidate: &str) -> bool {
-    let candidate = candidate.trim();
-    if candidate.is_empty() {
-        return false;
-    }
-    let path = Path::new(candidate);
-    if !path.exists() {
-        return false;
-    }
-
-    let is_onnx = path
-        .extension()
-        .and_then(|ext| ext.to_str())
-        .map(|ext| ext.eq_ignore_ascii_case("onnx"))
-        .unwrap_or(false);
-    if !is_onnx {
-        return true;
-    }
-
-    let metadata = format!("{candidate}.json");
-    Path::new(&metadata).exists()
-}
-
 async fn resolve_stt_model(override_model: Option<&str>) -> Option<String> {
     if let Some(model) = override_model.and_then(resolve_existing_stt_model) {
         return Some(model);
@@ -5234,61 +5209,6 @@ fn resolve_existing_stt_model(candidate: &str) -> Option<String> {
     .iter()
     .map(|dir| format!("{dir}/{file_name}"))
     .find(|path| Path::new(path).exists())
-}
-
-fn binary_basename(path: &str) -> &str {
-    Path::new(path)
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or(path)
-}
-
-fn tts_binary_requires_model(binary: Option<&str>) -> bool {
-    matches!(binary.map(binary_basename), Some("piper" | "lifeos-piper"))
-}
-
-fn select_tts_binary(
-    preferred: Option<String>,
-    tts_model: Option<&str>,
-    espeak_fallback: Option<String>,
-) -> Option<String> {
-    if tts_binary_requires_model(preferred.as_deref()) && tts_model.is_none() {
-        return espeak_fallback.or(preferred);
-    }
-    preferred
-}
-
-async fn sanitize_tts_binary(
-    selected: Option<String>,
-    espeak_fallback: Option<String>,
-) -> Option<String> {
-    let binary = selected?;
-
-    if tts_binary_requires_model(Some(binary.as_str())) && !supports_piper_cli(&binary).await {
-        log::warn!(
-            "Configured Piper binary '{}' does not support Piper CLI flags; falling back",
-            binary
-        );
-        return espeak_fallback;
-    }
-
-    Some(binary)
-}
-
-async fn supports_piper_cli(binary: &str) -> bool {
-    let output = match Command::new(binary).arg("--help").output().await {
-        Ok(output) => output,
-        Err(_) => return false,
-    };
-
-    let combined = format!(
-        "{}\n{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    )
-    .to_lowercase();
-
-    combined.contains("--model")
 }
 
 fn espeak_voice_for_language(language: Option<&str>) -> &'static str {
@@ -7688,74 +7608,6 @@ mod tests {
     }
 
     #[test]
-    fn tts_binary_selection_falls_back_to_espeak_when_piper_model_missing() {
-        let selected = select_tts_binary(
-            Some("/usr/bin/piper".to_string()),
-            None,
-            Some("/usr/bin/espeak-ng".to_string()),
-        );
-        assert_eq!(selected.as_deref(), Some("/usr/bin/espeak-ng"));
-    }
-
-    #[test]
-    fn tts_binary_selection_keeps_piper_when_model_exists() {
-        let selected = select_tts_binary(
-            Some("/usr/bin/piper".to_string()),
-            Some("/var/lib/lifeos/models/piper/es_MX-claude-high.onnx"),
-            Some("/usr/bin/espeak-ng".to_string()),
-        );
-        assert_eq!(selected.as_deref(), Some("/usr/bin/piper"));
-    }
-
-    #[test]
-    fn tts_binary_selection_treats_lifeos_piper_as_model_backend() {
-        let selected = select_tts_binary(
-            Some("/usr/local/bin/lifeos-piper".to_string()),
-            None,
-            Some("/usr/bin/espeak-ng".to_string()),
-        );
-        assert_eq!(selected.as_deref(), Some("/usr/bin/espeak-ng"));
-    }
-
-    #[test]
-    fn tts_model_readiness_requires_companion_json_for_onnx() {
-        let dir = std::env::temp_dir().join(format!("lifeos-tts-model-{}", uuid::Uuid::new_v4()));
-        std::fs::create_dir_all(&dir).unwrap();
-        let model = dir.join("es_MX-test.onnx");
-        std::fs::write(&model, b"fake").unwrap();
-
-        assert!(!tts_model_is_ready(model.to_string_lossy().as_ref()));
-
-        let metadata = dir.join("es_MX-test.onnx.json");
-        std::fs::write(&metadata, br#"{"audio":{"sample_rate":22050}}"#).unwrap();
-        assert!(tts_model_is_ready(model.to_string_lossy().as_ref()));
-
-        std::fs::remove_dir_all(dir).ok();
-    }
-
-    #[test]
-    fn resolve_existing_tts_model_rejects_incomplete_onnx_asset() {
-        let dir = std::env::temp_dir().join(format!("lifeos-tts-resolve-{}", uuid::Uuid::new_v4()));
-        std::fs::create_dir_all(&dir).unwrap();
-        let model = dir.join("es_MX-broken.onnx");
-        std::fs::write(&model, b"fake").unwrap();
-
-        assert!(resolve_existing_tts_model(model.to_string_lossy().as_ref()).is_none());
-
-        std::fs::write(
-            dir.join("es_MX-broken.onnx.json"),
-            br#"{"audio":{"sample_rate":22050}}"#,
-        )
-        .unwrap();
-        assert_eq!(
-            resolve_existing_tts_model(model.to_string_lossy().as_ref()).as_deref(),
-            Some(model.to_string_lossy().as_ref())
-        );
-
-        std::fs::remove_dir_all(dir).ok();
-    }
-
-    #[test]
     fn sanitize_assistant_response_removes_reasoning_scaffolding() {
         let raw = r#"
 The user wants me to describe the screen.
@@ -8006,5 +7858,95 @@ Drafting the description:
         assert!(status.kill_switch_active);
         assert_eq!(status.axi_state, AxiState::Offline);
         std::fs::remove_dir_all(dir).ok();
+    }
+
+    // ── D2: Capabilities regression guard ────────────────────────────────────
+    #[test]
+    fn test_capabilities_has_no_piper_fields() {
+        let caps = SensoryCapabilities::default();
+        let value = serde_json::to_value(&caps).expect("serialize SensoryCapabilities");
+        assert!(
+            value.get("tts_binary").is_none(),
+            "SensoryCapabilities must not contain tts_binary (piper field)"
+        );
+        assert!(
+            value.get("tts_model").is_none(),
+            "SensoryCapabilities must not contain tts_model (piper field)"
+        );
+        assert!(
+            value.get("tts_server_url").is_some(),
+            "SensoryCapabilities must contain tts_server_url (kokoro field)"
+        );
+        assert!(
+            value.get("kokoro_voices").is_some(),
+            "SensoryCapabilities must contain kokoro_voices (kokoro field)"
+        );
+    }
+
+    // ── D1: resolve_tts_voice permutation tests ───────────────────────────────
+    fn make_voices(names: &[&str]) -> Vec<KokoroVoice> {
+        names
+            .iter()
+            .map(|&n| KokoroVoice {
+                name: n.to_string(),
+                language: "es".to_string(),
+                gender: "female".to_string(),
+                is_default: false,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_resolve_tts_voice_override_in_available() {
+        let model = crate::user_model::UserModel::default();
+        let available = make_voices(&["if_sara", "af_heart"]);
+        let result = resolve_tts_voice(&model, "if_sara", Some("af_heart"), &available);
+        assert_eq!(result, "af_heart");
+    }
+
+    #[test]
+    fn test_resolve_tts_voice_override_not_in_available_falls_back_to_default() {
+        let model = crate::user_model::UserModel::default();
+        let available = make_voices(&["if_sara"]);
+        let result = resolve_tts_voice(&model, "if_sara", Some("nonexistent"), &available);
+        assert_eq!(result, "if_sara");
+    }
+
+    #[test]
+    fn test_resolve_tts_voice_model_voice_in_available() {
+        let model = crate::user_model::UserModel {
+            tts_voice: Some("im_nicola".to_string()),
+            ..Default::default()
+        };
+        let available = make_voices(&["if_sara", "im_nicola"]);
+        let result = resolve_tts_voice(&model, "if_sara", None, &available);
+        assert_eq!(result, "im_nicola");
+    }
+
+    #[test]
+    fn test_resolve_tts_voice_model_voice_not_in_available() {
+        let model = crate::user_model::UserModel {
+            tts_voice: Some("im_nicola".to_string()),
+            ..Default::default()
+        };
+        let available = make_voices(&["if_sara"]);
+        let result = resolve_tts_voice(&model, "if_sara", None, &available);
+        assert_eq!(result, "if_sara");
+    }
+
+    #[test]
+    fn test_resolve_tts_voice_no_model_voice_returns_default() {
+        let model = crate::user_model::UserModel::default();
+        let available = make_voices(&["if_sara"]);
+        let result = resolve_tts_voice(&model, "if_sara", None, &available);
+        assert_eq!(result, "if_sara");
+    }
+
+    #[test]
+    fn test_resolve_tts_voice_empty_string_override_treats_as_none() {
+        let model = crate::user_model::UserModel::default();
+        let available = make_voices(&["if_sara", "af_heart"]);
+        let result = resolve_tts_voice(&model, "if_sara", Some(""), &available);
+        assert_eq!(result, "if_sara");
     }
 }

--- a/daemon/src/simplex_bridge.rs
+++ b/daemon/src/simplex_bridge.rs
@@ -48,6 +48,8 @@ mod inner {
     const SIMPLEX_CHAT_ID: i64 = 0x534D_504C_5800_0001; // "SMPLX001"
     /// Path where the invite link is persisted for the dashboard.
     const INVITE_LINK_PATH: &str = "/var/lib/lifeos/simplex-invite-link";
+    /// Canonical TTS output directory prefix — must match `synthesize_with_kokoro_http` output path.
+    pub(crate) const TTS_OUTPUT_PREFIX: &str = "/var/lib/lifeos/tts/";
     /// Directory for downloaded files from SimpleX contacts.
     const DOWNLOADS_DIR: &str = "/var/lib/lifeos/simplex-downloads";
 
@@ -1000,11 +1002,6 @@ mod inner {
                                                     // For voice-originated inputs, synthesize reply as OGG
                                                     // and send as voice note (max 600 chars, max 1 MB).
                                                     if reply.len() <= 600 {
-                                                        let tts_dir = std::path::PathBuf::from(
-                                                            "/var/lib/lifeos/tts-output",
-                                                        );
-                                                        let _ = tokio::fs::create_dir_all(&tts_dir)
-                                                            .await;
                                                         let server_url =
                                                             std::env::var("LIFEOS_TTS_SERVER_URL")
                                                                 .unwrap_or_else(|_| {
@@ -1015,6 +1012,15 @@ mod inner {
                                                             "LIFEOS_TTS_DEFAULT_VOICE",
                                                         )
                                                         .unwrap_or_else(|_| "if_sara".to_string());
+                                                        // Usa el singleton kokoro_probe_client (connect 500ms, timeout 2s)
+                                                        // para no bloquear el path de respuesta de Simplex.
+                                                        // En caso de fallo degrada a &[] sin validación de voz.
+                                                        let available_voices: Vec<crate::sensory_pipeline::KokoroVoice> =
+                                                            crate::sensory_pipeline::fetch_kokoro_voices(
+                                                                crate::sensory_pipeline::kokoro_probe_client(),
+                                                                &server_url,
+                                                            )
+                                                            .await;
                                                         let voice = if let Some(ref um_arc) =
                                                             tool_ctx.user_model
                                                         {
@@ -1023,7 +1029,7 @@ mod inner {
                                                                 &um,
                                                                 &env_default,
                                                                 None,
-                                                                &[],
+                                                                &available_voices,
                                                             )
                                                         } else {
                                                             env_default.clone()
@@ -1036,9 +1042,10 @@ mod inner {
                                                             "ogg",
                                                         ).await {
                                                             Ok(ref audio_path) => {
-                                                                // Sanity check: path must be in /var/lib/lifeos/tts-output/
+                                                                // Sanity check: path must be within the canonical
+                                                                // TTS output directory created by synthesize_with_kokoro_http.
                                                                 let canonical = std::path::Path::new(audio_path);
-                                                                if !canonical.starts_with("/var/lib/lifeos/tts-output/") {
+                                                                if !canonical.starts_with(TTS_OUTPUT_PREFIX) {
                                                                     warn!("[simplex_bridge] TTS output path outside expected dir: {}", audio_path);
                                                                 } else {
                                                                     // File size guard: skip if > 1 MB
@@ -1551,3 +1558,45 @@ mod stubs {
 
 #[cfg(not(feature = "messaging"))]
 pub(crate) use stubs::*;
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+#[cfg(test)]
+#[cfg(feature = "messaging")]
+mod tests {
+    use super::inner::TTS_OUTPUT_PREFIX;
+
+    /// Test 1: TTS_OUTPUT_PREFIX matches the canonical output directory of
+    /// `synthesize_with_kokoro_http`, which writes to `{data_dir}/tts/axi-<uuid>.<ext>`.
+    /// The guard in the voice-note handler must use this prefix exactly.
+    #[test]
+    fn test_tts_output_prefix_matches_kokoro_output_path() {
+        // synthesize_with_kokoro_http writes to data_dir.join("tts").join("axi-<uuid>.<ext>")
+        // With data_dir = /var/lib/lifeos this becomes /var/lib/lifeos/tts/axi-*.ogg
+        let data_dir = std::path::Path::new("/var/lib/lifeos");
+        let example_path = data_dir.join("tts").join("axi-test.ogg");
+
+        assert!(
+            example_path.starts_with(TTS_OUTPUT_PREFIX),
+            "Expected kokoro output path {:?} to start_with TTS_OUTPUT_PREFIX {:?}",
+            example_path,
+            TTS_OUTPUT_PREFIX
+        );
+
+        // The old/wrong prefix must NOT match
+        let wrong_prefix = "/var/lib/lifeos/tts-output/";
+        assert!(
+            !example_path.starts_with(wrong_prefix),
+            "Old broken prefix {:?} must NOT match kokoro output path {:?}",
+            wrong_prefix,
+            example_path
+        );
+    }
+
+    /// Test 2: fetch_kokoro_voices is pub — verifiable at compile time.
+    /// If the function is private, this test will not compile with E0603.
+    #[test]
+    fn test_fetch_kokoro_voices_is_pub() {
+        // Compile-only proof: reference the function by path — E0603 if private.
+        let _ = crate::sensory_pipeline::fetch_kokoro_voices as fn(_, _) -> _;
+    }
+}

--- a/daemon/src/simplex_bridge.rs
+++ b/daemon/src/simplex_bridge.rs
@@ -996,6 +996,73 @@ mod inner {
                                                         &reply,
                                                     )
                                                     .await;
+                                                    // ── Voice-note reply hook (E2) ──
+                                                    // For voice-originated inputs, synthesize reply as OGG
+                                                    // and send as voice note (max 600 chars, max 1 MB).
+                                                    if reply.len() <= 600 {
+                                                        let tts_dir = std::path::PathBuf::from(
+                                                            "/var/lib/lifeos/tts-output",
+                                                        );
+                                                        let _ = tokio::fs::create_dir_all(&tts_dir)
+                                                            .await;
+                                                        let server_url =
+                                                            std::env::var("LIFEOS_TTS_SERVER_URL")
+                                                                .unwrap_or_else(|_| {
+                                                                    "http://127.0.0.1:8083"
+                                                                        .to_string()
+                                                                });
+                                                        let env_default = std::env::var(
+                                                            "LIFEOS_TTS_DEFAULT_VOICE",
+                                                        )
+                                                        .unwrap_or_else(|_| "if_sara".to_string());
+                                                        let voice = if let Some(ref um_arc) =
+                                                            tool_ctx.user_model
+                                                        {
+                                                            let um = um_arc.read().await;
+                                                            crate::sensory_pipeline::resolve_tts_voice(
+                                                                &um,
+                                                                &env_default,
+                                                                None,
+                                                                &[],
+                                                            )
+                                                        } else {
+                                                            env_default.clone()
+                                                        };
+                                                        match crate::sensory_pipeline::synthesize_with_kokoro_http(
+                                                            &std::path::PathBuf::from("/var/lib/lifeos"),
+                                                            &server_url,
+                                                            &reply,
+                                                            &voice,
+                                                            "ogg",
+                                                        ).await {
+                                                            Ok(ref audio_path) => {
+                                                                // Sanity check: path must be in /var/lib/lifeos/tts-output/
+                                                                let canonical = std::path::Path::new(audio_path);
+                                                                if !canonical.starts_with("/var/lib/lifeos/tts-output/") {
+                                                                    warn!("[simplex_bridge] TTS output path outside expected dir: {}", audio_path);
+                                                                } else {
+                                                                    // File size guard: skip if > 1 MB
+                                                                    let size_ok = tokio::fs::metadata(audio_path).await
+                                                                        .map(|m| m.len() <= 1_048_576)
+                                                                        .unwrap_or(false);
+                                                                    if size_ok {
+                                                                        let _ = send_file(&mut sink, &display_name, audio_path).await;
+                                                                    } else {
+                                                                        warn!("[simplex_bridge] TTS OGG too large (>1 MB), skipping voice note");
+                                                                    }
+                                                                    // Schedule cleanup after 60s
+                                                                    let cleanup_path = audio_path.clone();
+                                                                    tokio::spawn(async move {
+                                                                        tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+                                                                        tokio::fs::remove_file(&cleanup_path).await.ok();
+                                                                    });
+                                                                }
+                                                            }
+                                                            Err(e) => {
+                                                                warn!("[simplex_bridge] TTS synthesis for voice reply failed: {}", e);
+                                                            }
+                                                        }
+                                                    }
                                                 }
                                                 None => {
                                                     let _ = send_message(

--- a/daemon/src/user_model.rs
+++ b/daemon/src/user_model.rs
@@ -23,6 +23,9 @@ pub struct UserModel {
     pub updated_at: Option<DateTime<Utc>>,
     /// When the user first started using LifeOS (set on first boot)
     pub first_seen: Option<DateTime<Utc>>,
+    /// Preferred TTS voice for Kokoro (e.g. "if_sara", "af_heart"). None = use server default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tts_voice: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -162,6 +165,13 @@ impl UserModel {
             }
             "emoji_usage" => self.communication.emoji_usage = value.to_string(),
             "vocabulary_level" => self.communication.vocabulary_level = value.to_string(),
+            "tts_voice" => {
+                if value.trim().is_empty() {
+                    self.tts_voice = None;
+                } else {
+                    self.tts_voice = Some(value.to_string());
+                }
+            }
             _ => {}
         }
         self.updated_at = Some(Utc::now());
@@ -736,5 +746,36 @@ mod tests {
         };
         let prompt = model.prompt_instructions();
         assert!(!prompt.contains("Modo aprendizaje activo"));
+    }
+
+    // ── D3: tts_voice field tests ─────────────────────────────────────────────
+    #[test]
+    fn test_user_model_tts_voice_defaults_to_none() {
+        let model = UserModel::default();
+        assert_eq!(model.tts_voice, None);
+    }
+
+    #[test]
+    fn test_user_model_tts_voice_deserialize_missing_key() {
+        let json = r#"{"communication":{"formality_level":2,"verbosity":"normal","preferred_format":"mixed","emoji_usage":"light","vocabulary_level":"technical"},"schedule_patterns":[],"active_projects":[],"declared_goals":[],"current_context":"","language":"","updated_at":null,"first_seen":null}"#;
+        let model: UserModel = serde_json::from_str(json).expect("deserialize without tts_voice");
+        assert_eq!(model.tts_voice, None);
+    }
+
+    #[test]
+    fn test_apply_preference_tts_voice_sets_value() {
+        let mut model = UserModel::default();
+        model.apply_preference("tts_voice", "af_heart");
+        assert_eq!(model.tts_voice, Some("af_heart".to_string()));
+    }
+
+    #[test]
+    fn test_apply_preference_tts_voice_empty_clears_value() {
+        let mut model = UserModel {
+            tts_voice: Some("if_sara".to_string()),
+            ..Default::default()
+        };
+        model.apply_preference("tts_voice", "");
+        assert_eq!(model.tts_voice, None);
     }
 }

--- a/daemon/static/dashboard/app.js
+++ b/daemon/static/dashboard/app.js
@@ -706,7 +706,7 @@ function populateAudioDiag(sensory, stt) {
   setVal('d-audio-capture', cap.audio_capture_binary || 'No encontrado', cap.audio_capture_binary ? '' : 'val-error');
   setVal('d-audio-transcript', voice.last_transcript || '(sin datos)');
   setVal('d-audio-latency', voice.last_latency_ms ? voice.last_latency_ms + 'ms' : '—');
-  setVal('d-audio-tts', cap.tts_binary ? (cap.tts_binary + (cap.tts_model ? ' + modelo' : '')) : 'No encontrado', cap.tts_binary ? '' : 'val-warn');
+  setVal('d-audio-tts', cap.tts_server_url ? cap.tts_server_url : 'No configurado', cap.tts_server_url ? '' : 'val-warn');
   setVal('d-audio-last', timeAgo(voice.last_listen_at));
 
   // Error
@@ -746,14 +746,16 @@ function populateTtsDiag(sensory) {
   const voice = sensory?.voice || {};
   const runtime = dashboardState.runtime || {};
 
-  const ttsReady = !!cap.tts_binary;
+  const ttsReady = !!cap.tts_server_url;
   const enabled = runtime.tts_enabled !== false;
   if (enabled && ttsReady) setDot('dot-tts', 'ok');
   else if (ttsReady) setDot('dot-tts', 'warn');
   else setDot('dot-tts', 'error');
 
-  setVal('d-tts-binary', cap.tts_binary || 'No encontrado', cap.tts_binary ? '' : 'val-error');
-  setVal('d-tts-model', cap.tts_model || 'Sin modelo explicito', cap.tts_model ? 'val-ok' : 'val-warn');
+  setVal('d-tts-binary', cap.tts_server_url || 'No configurado', cap.tts_server_url ? '' : 'val-error');
+  const voices = cap.kokoro_voices;
+  const voicesStr = Array.isArray(voices) && voices.length ? voices.map(v => v.name).join(', ') : 'Sin voces';
+  setVal('d-tts-model', voicesStr, Array.isArray(voices) && voices.length ? 'val-ok' : 'val-warn');
   setVal('d-tts-engine', voice.last_tts_engine || '—');
   setVal('d-tts-backend', voice.last_playback_backend || '—');
   setVal('d-tts-enabled', enabled ? 'Activo' : 'Inactivo', enabled ? 'val-ok' : 'val-warn');
@@ -3751,7 +3753,7 @@ async function loadTtsVoiceSelector() {
   // Load current preference
   let currentVoice = null;
   try {
-    const prefs = await api('GET', '/user/preferences');
+    const prefs = await api('GET', '/user/profile');
     currentVoice = prefs && prefs.tts_voice ? prefs.tts_voice : null;
   } catch { /* ignore */ }
 

--- a/daemon/static/dashboard/app.js
+++ b/daemon/static/dashboard/app.js
@@ -3739,6 +3739,100 @@ async function refreshVidaPlena() {
   }
 }
 
+// --- TTS Voice Selector ---
+async function loadTtsVoiceSelector() {
+  const selectEl = document.getElementById('voice-select');
+  const playBtn = document.getElementById('voice-preview-play');
+  const saveBtn = document.getElementById('voice-save');
+  const statusEl = document.getElementById('tts-voice-status');
+  const banner = document.getElementById('tts-unavailable-banner');
+  if (!selectEl) return;
+
+  // Load current preference
+  let currentVoice = null;
+  try {
+    const prefs = await api('GET', '/user/preferences');
+    currentVoice = prefs && prefs.tts_voice ? prefs.tts_voice : null;
+  } catch { /* ignore */ }
+
+  // Load available voices
+  try {
+    const data = await api('GET', '/tts/voices');
+    if (!data || !data.voices || data.voices.length === 0) {
+      selectEl.innerHTML = '<option value="">Sin voces disponibles</option>';
+      if (playBtn) playBtn.disabled = true;
+      return;
+    }
+    // Group by language
+    const byLang = {};
+    for (const v of data.voices) {
+      const lang = v.language || 'Otras';
+      if (!byLang[lang]) byLang[lang] = [];
+      byLang[lang].push(v);
+    }
+    selectEl.innerHTML = '';
+    for (const [lang, voices] of Object.entries(byLang)) {
+      const group = document.createElement('optgroup');
+      group.label = lang;
+      for (const v of voices) {
+        const opt = document.createElement('option');
+        opt.value = v.name;
+        opt.textContent = v.name + (v.is_default ? ' (predeterminada)' : '');
+        if (v.name === currentVoice || (v.is_default && !currentVoice)) opt.selected = true;
+        group.appendChild(opt);
+      }
+      selectEl.appendChild(group);
+    }
+    if (playBtn) playBtn.disabled = false;
+    if (banner) banner.style.display = 'none';
+  } catch (_e) {
+    // TTS unavailable — disable controls and show banner
+    selectEl.innerHTML = '<option value="">TTS no disponible</option>';
+    if (playBtn) playBtn.disabled = true;
+    if (banner) banner.style.display = '';
+    return;
+  }
+
+  // Preview button
+  if (playBtn) {
+    playBtn.addEventListener('click', async () => {
+      const previewInput = document.getElementById('voice-preview-text');
+      const text = previewInput ? previewInput.value : 'Hola, soy Axi.';
+      const voice = selectEl.value;
+      playBtn.disabled = true;
+      if (statusEl) statusEl.textContent = 'Sintetizando...';
+      try {
+        await api('POST', '/sensory/tts/speak', { text, voice_model: voice, playback: true });
+        if (statusEl) statusEl.textContent = '';
+      } catch {
+        if (statusEl) statusEl.textContent = 'Error al reproducir.';
+      } finally {
+        playBtn.disabled = false;
+      }
+    });
+  }
+
+  // Save button
+  if (saveBtn) {
+    saveBtn.addEventListener('click', async () => {
+      const voice = selectEl.value;
+      saveBtn.disabled = true;
+      if (statusEl) statusEl.textContent = 'Guardando...';
+      try {
+        await api('PATCH', '/user/preferences', { key: 'tts_voice', value: voice });
+        if (statusEl) {
+          statusEl.textContent = 'Guardado.';
+          setTimeout(() => { if (statusEl) statusEl.textContent = ''; }, 3000);
+        }
+      } catch {
+        if (statusEl) statusEl.textContent = 'Error al guardar.';
+      } finally {
+        saveBtn.disabled = false;
+      }
+    });
+  }
+}
+
 // --- Boot ---
 (async () => {
   initTabs();
@@ -3765,5 +3859,6 @@ async function refreshVidaPlena() {
   refreshVidaPlena();
   loadMeetings();
   loadCalendar();
+  loadTtsVoiceSelector();
   runWelcomeSequence().catch(err => console.warn('welcome sequence failed:', err));
 })();

--- a/daemon/static/dashboard/index.html
+++ b/daemon/static/dashboard/index.html
@@ -513,6 +513,23 @@
             </div>
           </div>
         </section>
+        <!-- ── TTS Voice Selector ── -->
+        <section class="settings-section" data-subsection="general">
+          <h2>Selector de Voz (TTS)</h2>
+          <div id="tts-unavailable-banner" class="setting-hint" style="display:none; color:var(--error, #e74c3c); margin-bottom:8px;">TTS temporalmente no disponible.</div>
+          <div class="settings-grid">
+            <div class="setting-item" style="grid-column: 1 / -1;">
+              <label for="voice-select">Voz de Axi</label>
+              <div style="display:flex; gap:8px; align-items:center; flex-wrap:wrap; margin-top:6px;">
+                <select id="voice-select" style="flex:1; min-width:180px;"><option value="">Cargando voces...</option></select>
+                <input type="text" id="voice-preview-text" value="Hola, soy Axi. Esta es una prueba de voz." style="flex:2; min-width:200px;">
+                <button id="voice-preview-play" class="btn-small" title="Probar voz">&#9654;</button>
+                <button id="voice-save" class="btn-small" style="background:#27ae60;">Guardar</button>
+                <span id="tts-voice-status" style="font-size:0.85em; color:var(--text-muted);"></span>
+              </div>
+            </div>
+          </div>
+        </section>
         <section class="settings-section" data-subsection="general">
           <h2>Configuracion General</h2>
           <div class="settings-grid">

--- a/daemon/static/dashboard/index.html
+++ b/daemon/static/dashboard/index.html
@@ -220,8 +220,8 @@
               <label class="toggle" onclick="event.stopPropagation()"><input type="checkbox" id="toggle-tts"><span class="slider"></span></label>
               <div class="diagnostic-panel" id="diag-tts">
                 <div class="diag-details">
-                  <div class="diag-row"><span class="diag-label">Backend TTS</span><span class="diag-value" id="d-tts-binary">—</span></div>
-                  <div class="diag-row"><span class="diag-label">Modelo</span><span class="diag-value" id="d-tts-model">—</span></div>
+                  <div class="diag-row"><span class="diag-label">Servidor Kokoro</span><span class="diag-value" id="d-tts-binary">—</span></div>
+                  <div class="diag-row"><span class="diag-label">Voces disponibles</span><span class="diag-value" id="d-tts-model">—</span></div>
                   <div class="diag-row"><span class="diag-label">Ultimo motor</span><span class="diag-value" id="d-tts-engine">—</span></div>
                   <div class="diag-row"><span class="diag-label">Ultimo reproductor</span><span class="diag-value" id="d-tts-backend">—</span></div>
                   <div class="diag-row"><span class="diag-label">Estado</span><span class="diag-value" id="d-tts-enabled">—</span></div>

--- a/daemon/static/dashboard/style.css
+++ b/daemon/static/dashboard/style.css
@@ -2601,3 +2601,35 @@ details[open] .transcript-toggle::before { transform: rotate(90deg); }
 }
 
 /* --- Worker status badges (these use rgba with good contrast already) --- */
+
+/* --- TTS Voice Selector --- */
+#voice-select {
+  background: var(--bg-secondary, #1e1e2e);
+  border: 1px solid var(--border, #333);
+  color: var(--text-primary, #cdd6f4);
+  border-radius: 6px;
+  padding: 6px 10px;
+  font-size: 0.9rem;
+}
+#voice-preview-text {
+  background: var(--bg-secondary, #1e1e2e);
+  border: 1px solid var(--border, #333);
+  color: var(--text-primary, #cdd6f4);
+  border-radius: 6px;
+  padding: 6px 10px;
+  font-size: 0.9rem;
+}
+#voice-preview-play,
+#voice-save {
+  flex-shrink: 0;
+}
+#tts-voice-status {
+  flex-shrink: 0;
+}
+#tts-unavailable-banner {
+  background: rgba(231, 76, 60, 0.12);
+  border: 1px solid rgba(231, 76, 60, 0.35);
+  border-radius: 6px;
+  padding: 8px 12px;
+  font-size: 0.85rem;
+}

--- a/docs/architecture/ai-runtime.md
+++ b/docs/architecture/ai-runtime.md
@@ -1404,8 +1404,8 @@ Implementacion concreta:
 **Bloque 1 — Voz bidireccional (P0, sin esto no hay fase):**
 
 - [x] **STT always-on real:** Whisper.cpp como servicio persistente con VAD (Voice Activity Detection) real usando `silero-vad` o `webrtcvad`, hotword "Hey Axi" funcional como trigger de escucha activa, no solo endpoint API bajo demanda. _Implementado en repo con loop residente en `sensory_pipeline.rs`, captura local de mic, VAD heuristico PCM, hotword configurable y degradacion graceful cuando no hay backend de audio._
-- [x] **TTS local funcional:** Integrar engine TTS real para que Axi **hable**. Candidatos evaluados: `Piper` (ONNX, rapido, MIT, 30+ idiomas incluyendo espanol), `Kokoro` (calidad alta, Apache 2.0), `Coqui XTTS` (clonacion de voz, MPL 2.0). _Implementado con Piper local, salida WAV y reproduccion por `pw-play`/`aplay`/`paplay`, expuesto por API y CLI._
-- [x] **Flujo conversacional completo (pipeline voice loop):** Microfono → VAD → STT (Whisper) → LLM (llama-server) → TTS (Piper) → Speaker (PipeWire), todo orquestado por `lifeosd` con indicadores visuales en el overlay. _Implementado en `lifeosd` como `voice_session` cancelable con overlay sincronizado._
+- [x] **TTS local funcional:** Integrar engine TTS real para que Axi **hable**. Motor seleccionado: **Kokoro-82M** (Apache 2.0, 50+ voces, CPU-only). Empaquetado como servicio HTTP en `lifeos-tts-server.service` (`127.0.0.1:8083`). Integracion en `sensory_pipeline.rs::synthesize_with_kokoro_http()`. Resolucion de voz: payload > `UserModel.tts_voice` > env default (`if_sara`). _Implementado con Kokoro-82M via PyPI `kokoro`, salida WAV/OGG y reproduccion por `pw-play`/`aplay`/`paplay`, expuesto por API, CLI y selector en dashboard._
+- [x] **Flujo conversacional completo (pipeline voice loop):** Microfono → VAD → STT (Whisper) → LLM (llama-server) → TTS (Kokoro HTTP `POST /tts`) → Speaker (PipeWire), todo orquestado por `lifeosd` con indicadores visuales en el overlay. _Implementado en `lifeosd` como `voice_session` cancelable con overlay sincronizado._
 - [x] **Latencia UX verificada:** El primer token de audio (TTS) debe comenzar a reproducirse en **< 2 segundos** despues de que el usuario termina de hablar. _Cobertura en repo via `life ai bench-sensory` + `sensory_benchmark.json` con latencia voice-loop reproducible._
 - [x] **Interrupciones naturales:** El usuario puede interrumpir a Axi mientras habla (barge-in). VAD detecta nueva utterance → cancela TTS actual → procesa nueva entrada. _Implementado con cancelacion de playback en caliente y contador de barge-in._
 
@@ -1513,7 +1513,7 @@ Implementacion concreta:
 
 **Reglas de producto obligatorias:**
 
-1. Los runtimes de voz y sus assets pequenos (`whisper`, `piper`, VAD, hotword) pueden venir preinstalados.
+1. Los runtimes de voz y sus assets pequenos (`whisper`, `kokoro`, VAD, hotword) pueden venir preinstalados.
 2. Los LLM pesados viven en `/var/lib/lifeos/models` como contenido gestionado por el usuario, no como payload obligatorio de la ISO normal.
 3. La seleccion por defecto debe persistirse en una unica fuente de verdad: `/etc/lifeos/llama-server.env`.
 4. Cada modelo multimodal debe gestionar sus assets companeros (`mmproj`) de forma explicita; no se admite un `mmproj` generico compartido entre familias/tamanos incompatibles.
@@ -1595,7 +1595,7 @@ Audio entrante
 
 - [x] **Varianza de embedding por speaker:** Centroide rolling con hasta 50 embeddings recientes absorbe variaciones naturales (voz ronca, cansada, baja, gritando). _Implementado en `SpeakerProfile::add_embedding()` con `MAX_EMBEDDINGS_PER_SPEAKER = 50`._
 - [ ] **Feedback loop con memoria:** Las decisiones de matching se guardan en el memory_plane para que Axi mejore su confianza con el tiempo.
-- [ ] **Clonacion de voz por speaker (Piper XTTS):** TTS personalizado por hablante — Axi responde con tono adaptado al contexto emocional detectado.
+- [ ] **Clonacion de voz por speaker (Kokoro XTTS):** TTS personalizado por hablante — Axi responde con tono adaptado al contexto emocional detectado.
 
 **Bloque 4 — Permisos y autonomia de Axi (P0):**
 

--- a/docs/operations/simplex-features.md
+++ b/docs/operations/simplex-features.md
@@ -93,9 +93,50 @@ without needing slash commands.
 The bridge acknowledges receipt immediately ("🎤 Recibido, transcribiendo...")
 so you know the file was accepted.
 
-> Note: TTS audio replies (voice output) are not sent back over SimpleX —
-> the bridge responds with text only. Voice output is available on the local
-> system.
+> Voice replies are enabled: when Axi receives a voice note, it sends back
+> both a text reply and an OGG voice attachment. See [Voice Reply Feature](#voice-reply-feature)
+> below for details.
+
+### Voice Reply Feature
+
+Axi applies **modality mirroring** for voice conversations: when the incoming
+message is a voice note, Axi sends both a text reply and an OGG voice
+attachment. Text messages receive text replies only.
+
+**Trigger:** incoming `MsgContent::Voice` (a SimpleX voice note, not a text
+message).
+
+**Flow:**
+
+1. The OGG/OPUS voice note is auto-accepted via XFTP.
+2. `ffmpeg` converts it to WAV (16 kHz mono).
+3. Whisper transcribes the WAV locally.
+4. The transcript is dispatched through the agentic loop.
+5. `send_message` delivers the text reply (this always happens first).
+6. Kokoro (`lifeos-tts-server.service` on `127.0.0.1:8083`) synthesizes the
+   reply as OGG/Vorbis via `POST /tts` with `format=ogg`.
+7. `send_file` attaches the OGG as a voice bubble in SimpleX.
+8. The OGG file is deleted 60 seconds after `send_file` returns.
+
+**File lifecycle:**
+
+- Files are saved as `/var/lib/lifeos/tts-output/simplex-<uuid>.ogg`.
+- Deleted by a background task 60 seconds after delivery.
+- If the cleanup task fails, stale files can be removed manually — they are
+  safe to delete.
+
+**Limits and failure behavior:**
+
+| Condition | Behavior |
+|-----------|----------|
+| OGG file > 1 MB | Voice attachment skipped, text reply still sent, WARN logged |
+| Kokoro server unreachable | Voice attachment skipped, text reply still sent, WARN logged |
+| `send_file` fails | Handler continues normally, no panic, text reply already delivered |
+
+In all failure cases, the text reply is always sent first and is never lost.
+
+**No configuration needed** — modality mirroring is automatic for all voice-originated
+messages.
 
 ### Images
 

--- a/docs/operations/tts.md
+++ b/docs/operations/tts.md
@@ -1,0 +1,361 @@
+# TTS Service — Kokoro
+
+> Updated: 2026-04-15
+
+## Overview
+
+LifeOS ships **Kokoro-82M** as its text-to-speech engine. Kokoro is an open-weight
+model released under the Apache 2.0 license with 50+ high-quality voices across
+multiple languages.
+
+The engine runs as a **system service** (`lifeos-tts-server.service`) that exposes
+a local HTTP API on `127.0.0.1:8083`. The service starts automatically at boot
+and is ready before `lifeosd.service` launches.
+
+| Property | Value |
+|----------|-------|
+| Model | Kokoro-82M |
+| License | Apache 2.0 |
+| Backend | Python 3.12 venv at `/opt/lifeos/kokoro-env/` |
+| Listen address | `127.0.0.1:8083` (loopback only) |
+| Default voice | `if_sara` (feminine, English) |
+| Inference | CPU-only (no CUDA dependency) |
+| Config | `/etc/lifeos/tts-server.env` |
+
+---
+
+## Architecture
+
+```
+                                  ┌──────────────────────┐
+                                  │  lifeos-tts-server   │
+  lifeosd ──POST /tts────────────►│  (Kokoro-82M, :8083) │──► pw-play / aplay
+          ◄── audio/wav ──────────│  127.0.0.1 only      │    (host speakers)
+                                  └──────────────────────┘
+                                            ▲
+  simplex_bridge ──POST /tts───────────────►│
+                   (format=ogg)             │
+  ◄── audio/ogg ──────────────────────────►│
+          │                                └──────────────────────┘
+          └── send_file(ogg) ──► SimpleX mobile (voice bubble)
+```
+
+**Flow — direct voice (lifeosd):**
+1. `lifeosd` synthesizes text via `POST /tts` (WAV format).
+2. The WAV bytes are written to a temp file and played through PipeWire (`pw-play`).
+
+**Flow — SimpleX voice reply (simplex_bridge):**
+1. User sends a voice note → Whisper transcribes it.
+2. LLM generates a reply → `send_message` delivers the text.
+3. `synthesize_with_kokoro_http` posts to `/tts` with `format=ogg`.
+4. The OGG file is sent via `send_file` as a voice bubble in the SimpleX app.
+5. The file is deleted 60 seconds after delivery.
+
+---
+
+## Service Lifecycle
+
+### Check status
+
+```bash
+systemctl status lifeos-tts-server
+```
+
+### View logs
+
+```bash
+journalctl -u lifeos-tts-server -f
+journalctl -u lifeos-tts-server --since "10 minutes ago"
+```
+
+### Start / stop / restart
+
+```bash
+# These require appropriate polkit / sudo permissions:
+systemctl start lifeos-tts-server
+systemctl stop lifeos-tts-server
+systemctl restart lifeos-tts-server
+```
+
+### Health check
+
+```bash
+curl -s http://127.0.0.1:8083/health | python3 -m json.tool
+```
+
+Expected response when ready:
+
+```json
+{
+  "status": "ok",
+  "model": "Kokoro-82M",
+  "voices_loaded": 54
+}
+```
+
+Returns HTTP 503 while the model is still loading at startup.
+
+---
+
+## API Reference
+
+### `GET /health`
+
+Returns service status.
+
+**Response 200:**
+
+```json
+{
+  "status": "ok",
+  "model": "Kokoro-82M",
+  "voices_loaded": 54
+}
+```
+
+**Response 503** (warming up):
+
+```json
+{ "status": "loading" }
+```
+
+---
+
+### `GET /voices`
+
+Returns the full list of available Kokoro voices.
+
+**Response 200:**
+
+```json
+[
+  { "name": "if_sara",   "language": "en-us", "gender": "feminine",  "is_default": true  },
+  { "name": "im_nicola", "language": "en-us", "gender": "masculine", "is_default": false },
+  { "name": "af_heart",  "language": "en-us", "gender": "feminine",  "is_default": false }
+]
+```
+
+Each object contains:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Kokoro voice identifier |
+| `language` | string | BCP-47 language tag |
+| `gender` | string | `"feminine"` or `"masculine"` |
+| `is_default` | bool | `true` for the system-default voice |
+
+---
+
+### `POST /tts`
+
+Synthesize speech from text.
+
+**Request body (JSON):**
+
+```json
+{
+  "text": "Hola Héctor, soy Axi. ¿Cómo puedo ayudarte hoy?",
+  "voice": "if_sara",
+  "speed": 1.0,
+  "format": "wav"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `text` | string | Yes | Text to synthesize |
+| `voice` | string | No | Voice name (defaults to `LIFEOS_TTS_DEFAULT_VOICE`) |
+| `speed` | float | No | Playback speed multiplier (default: `1.0`) |
+| `format` | string | No | `"wav"` (default) or `"ogg"` |
+
+**Response 200:**
+- `Content-Type: audio/wav` (or `audio/ogg` when `format=ogg`)
+- Body: raw audio bytes
+
+**Response 400 — unknown voice:**
+
+```json
+{
+  "error": "unknown_voice",
+  "detail": "nonexistent_voice is not a valid Kokoro voice"
+}
+```
+
+**Response 500 — synthesis error:**
+
+```json
+{
+  "error": "synthesis_failed",
+  "detail": "..."
+}
+```
+
+**Example — WAV synthesis:**
+
+```bash
+curl -s -X POST http://127.0.0.1:8083/tts \
+  -H "Content-Type: application/json" \
+  -d '{"text":"Hola Axi","voice":"if_sara"}' \
+  -o /tmp/test.wav
+aplay /tmp/test.wav
+```
+
+**Example — OGG for SimpleX:**
+
+```bash
+curl -s -X POST http://127.0.0.1:8083/tts \
+  -H "Content-Type: application/json" \
+  -d '{"text":"Hola","voice":"if_sara","format":"ogg"}' \
+  -o /tmp/test.ogg
+```
+
+---
+
+## Default Voices
+
+| Voice | Language | Gender | Notes |
+|-------|----------|--------|-------|
+| `if_sara` | English (US) | Feminine | **System default** — shipped in image |
+| `im_nicola` | English (US) | Masculine | Alternative default option |
+
+The system default is configured via `LIFEOS_TTS_DEFAULT_VOICE` in
+`/etc/lifeos/tts-server.env`. Users can select any voice from the
+50+ bundled Kokoro voices via the dashboard (see [Voice Selector](#voice-selector-in-dashboard)).
+
+---
+
+## Voice Selector in Dashboard
+
+The LifeOS dashboard at `http://127.0.0.1:8081/dashboard` includes a **TTS settings
+section** that lets each user pick their preferred Kokoro voice.
+
+**Steps:**
+
+1. Open the dashboard in your browser.
+2. Navigate to the **Voz** (Voice) settings section.
+3. Select a voice from the dropdown — voices are grouped by language.
+4. Optionally edit the preview text in the text field.
+5. Click **▶ Escuchar** to preview the voice playing through your speakers.
+6. Click **Guardar** to save it as your personal default.
+
+**Scope:** the saved voice applies globally — both direct voice responses through
+your speakers and OGG voice attachments sent in SimpleX replies.
+
+If the TTS server is unreachable, the preview button is disabled and a warning
+is shown. The save button remains active — you can still save a voice name even
+without previewing.
+
+---
+
+## Modality Mirroring Rule
+
+LifeOS applies automatic modality mirroring for SimpleX conversations:
+
+| Input type | Axi output |
+|------------|-----------|
+| Text message | Text reply only |
+| Voice note | Text reply **+** OGG voice attachment |
+
+This behavior is automatic and requires no configuration.
+
+---
+
+## Troubleshooting
+
+### Service not starting
+
+1. Check the service status and logs:
+
+```bash
+systemctl status lifeos-tts-server
+journalctl -u lifeos-tts-server -n 50
+```
+
+2. Verify the Python venv exists:
+
+```bash
+ls /opt/lifeos/kokoro-env/bin/python3
+```
+
+3. Verify the env file exists:
+
+```bash
+ls /etc/lifeos/tts-server.env
+```
+
+4. Check available memory — Kokoro requires up to 1 GB RAM:
+
+```bash
+free -h
+```
+
+### Voice not available (unknown_voice)
+
+1. Confirm the voice name is correct:
+
+```bash
+curl -s http://127.0.0.1:8083/voices | python3 -m json.tool | grep '"name"'
+```
+
+2. If the voices manifest is empty or missing, check the build:
+
+```bash
+ls /opt/lifeos/kokoro-env/lib/python3.12/site-packages/kokoro/voices/
+```
+
+3. If missing, the image may not have been built with the `kokoro-builder` stage.
+   Run a `bootc upgrade` to pull the latest image.
+
+### OGG transcode failures
+
+1. Confirm `ffmpeg` is installed:
+
+```bash
+ffmpeg -version | head -1
+```
+
+2. If missing (unexpected for a correctly built image), the voice reply will fall back
+   to WAV internally. The SimpleX voice bubble may not render correctly.
+
+3. Check for disk space issues under `/var/lib/lifeos/tts-output/`:
+
+```bash
+df -h /var/lib/lifeos/
+ls -lh /var/lib/lifeos/tts-output/
+```
+
+   Stale `.ogg` files here indicate a cleanup task that failed. They are safe to delete.
+
+### Memory pressure
+
+The TTS service has a `MemoryMax=1G` systemd limit. If the system is running low
+on memory, the service may be OOM-killed and restarted by systemd.
+
+To check:
+
+```bash
+systemctl status lifeos-tts-server | grep Memory
+journalctl -u lifeos-tts-server | grep -i "oom\|killed\|memory"
+```
+
+If the service is being killed repeatedly, consider closing other memory-intensive
+workloads, or check if a large LLM is running simultaneously.
+
+---
+
+## Rollback
+
+If you need to revert to a pre-0.7.0 image (which used Piper TTS), use the
+standard bootc rollback:
+
+```bash
+sudo bootc rollback
+```
+
+Then reboot. The previous deployment is preserved and will be activated on next boot.
+
+> **Note:** `bootc` always keeps the last two deployments. Rollback is always available
+> without any additional downloads.
+
+See [System Updates](../user/user-guide.md#system-updates) for the full
+check → stage → apply → rollback workflow.

--- a/docs/user/user-guide.md
+++ b/docs/user/user-guide.md
@@ -64,6 +64,63 @@ life memory search "logs build" --mode hybrid
 life memory graph --limit 50
 ```
 
+## Cambiar la voz de Axi
+
+Axi usa **Kokoro-82M** como motor de texto a voz con 50+ voces de alta calidad.
+Podés elegir la voz que más te guste desde el dashboard — se aplica globalmente tanto
+para las respuestas directas por bocina como para los mensajes de voz en SimpleX.
+
+**Pasos:**
+
+1. Abrí el dashboard en tu navegador: `http://127.0.0.1:8081/dashboard`
+2. Navegá a la sección **Voz** dentro de los ajustes.
+3. Seleccioná la voz del dropdown — las voces aparecen agrupadas por idioma.
+4. (Opcional) Editá el texto de preview en el campo de texto.
+5. Hacé click en **▶ Escuchar** para escuchar la voz con ese texto por tus bocinas.
+6. Hacé click en **Guardar** para guardarla como tu voz por defecto.
+
+La voz guardada se aplica a todas las interacciones de Axi:
+- Respuestas directas por voz (desktop).
+- Mensajes de voz OGG en respuestas de SimpleX.
+
+Si el servidor TTS no está disponible, el botón de preview aparece deshabilitado
+con un aviso. El botón de guardar sigue activo — podés guardar una voz sin necesidad
+de previsualizar.
+
+---
+
+## Respuestas por voz en SimpleX
+
+Axi aplica **espejado de modalidad** en SimpleX: el formato de entrada determina el
+formato de la respuesta.
+
+| Mensaje entrante | Respuesta de Axi |
+|-----------------|-----------------|
+| Texto escrito | Solo texto |
+| Nota de voz | Texto **+** archivo de voz OGG |
+
+**¿Cómo funciona?**
+
+1. Enviás una nota de voz a Axi en SimpleX.
+2. Whisper transcribe el audio localmente.
+3. El LLM genera la respuesta.
+4. Axi envía primero la respuesta como texto.
+5. Kokoro sintetiza la respuesta como audio OGG.
+6. Axi adjunta el OGG como burbuja de voz en la conversación.
+7. El archivo OGG se elimina automáticamente 60 segundos después del envío.
+
+**No requiere ninguna configuración** — el espejado es automático.
+
+**Límites y comportamiento ante fallas:**
+
+- El archivo OGG no puede superar **1 MB**. Si es más grande, se envía solo el texto.
+- Si el servidor Kokoro no está disponible, se envía la respuesta de texto igualmente —
+  nunca se pierde la respuesta por un fallo de voz.
+- Los archivos temporales de voz se guardan en `/var/lib/lifeos/tts-output/` y se
+  eliminan solos. No requieren mantenimiento manual.
+
+---
+
 ## Voice and Sensory Runtime (Consent-Gated)
 
 1. Grant consent for monitoring:

--- a/image/Containerfile
+++ b/image/Containerfile
@@ -243,10 +243,11 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 # confusion — a `from X import Y` line inside an inline RUN heredoc gets
 # misparsed as a `FROM` stage directive by buildkit.
 COPY image/scripts/prewarm-kokoro.py /build/prewarm-kokoro.py
+ENV HF_HOME=/opt/lifeos/kokoro-env/hf-cache
 RUN HF_HUB_OFFLINE=0 \
     /opt/lifeos/kokoro-env/bin/python3 /build/prewarm-kokoro.py
 
-# Verify if_sara voice artifact exists after pre-warm
+# Verify if_sara voice artifact exists after pre-warm (weights land in HF_HOME)
 RUN find /opt/lifeos/kokoro-env -name 'if_sara*' | grep -q '.' || \
     (echo 'ERROR: if_sara voice artifact not found after pre-warm' && exit 1)
 

--- a/image/Containerfile
+++ b/image/Containerfile
@@ -239,15 +239,12 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 
 # Pre-warm the default voice (if_sara) to materialise .pt weights files
 # and verify kokoro can synthesise without network access.
+# NOTE: Python code lives in a separate file to avoid Dockerfile parser
+# confusion — a `from X import Y` line inside an inline RUN heredoc gets
+# misparsed as a `FROM` stage directive by buildkit.
+COPY image/scripts/prewarm-kokoro.py /build/prewarm-kokoro.py
 RUN HF_HUB_OFFLINE=0 \
-    /opt/lifeos/kokoro-env/bin/python3 -c "
-from kokoro import KPipeline
-import numpy as np
-pipeline = KPipeline(lang_code='e', device='cpu')
-chunks = list(pipeline('Hola sistema, voz lista.', voice='if_sara'))
-assert chunks, 'No audio chunks produced — voice pre-warm failed'
-print('Kokoro pre-warm OK: if_sara voice loaded')
-"
+    /opt/lifeos/kokoro-env/bin/python3 /build/prewarm-kokoro.py
 
 # Verify if_sara voice artifact exists after pre-warm
 RUN find /opt/lifeos/kokoro-env -name 'if_sara*' | grep -q '.' || \

--- a/image/Containerfile
+++ b/image/Containerfile
@@ -180,25 +180,6 @@ RUN set -eux && \
     rm -rf /tmp/whisper.cpp
 
 # ============================================================================
-# Stage 4: Bundle Piper TTS assets (brand voice)
-# ============================================================================
-FROM fedora:${FEDORA_MAJOR} AS piper-voice-builder
-
-RUN dnf install -y curl && \
-    dnf clean all
-
-RUN set -eux && \
-    mkdir -p /out/models/piper && \
-    curl -fSL --retry 3 --connect-timeout 60 \
-      -o /out/models/piper/es_MX-claude-high.onnx \
-      https://huggingface.co/rhasspy/piper-voices/resolve/main/es/es_MX/claude/high/es_MX-claude-high.onnx?download=true && \
-    curl -fSL --retry 3 --connect-timeout 60 \
-      -o /out/models/piper/es_MX-claude-high.onnx.json \
-      https://huggingface.co/rhasspy/piper-voices/resolve/main/es/es_MX/claude/high/es_MX-claude-high.onnx.json?download=true && \
-    test -s /out/models/piper/es_MX-claude-high.onnx && \
-    test -s /out/models/piper/es_MX-claude-high.onnx.json
-
-# ============================================================================
 # Stage 4b: Download WeSpeaker ONNX model for speaker identification
 # ============================================================================
 FROM fedora:${FEDORA_MAJOR} AS wespeaker-builder
@@ -214,24 +195,77 @@ RUN set -eux && \
     echo ">>> WeSpeaker ONNX model downloaded ($(du -sh /out/models/wespeaker/voxceleb_resnet34_LM.onnx | cut -f1))"
 
 # ============================================================================
-# Stage 5: Bundle Piper TTS runtime binary (Rhasspy Piper CLI)
+# Stage 5: Build Kokoro TTS Python environment (CPU-only)
 # ============================================================================
-FROM fedora:${FEDORA_MAJOR} AS piper-runtime-builder
+# Uses python:3.12-slim as base (Debian) for a smaller pip-install surface.
+# The resulting /opt/lifeos/kokoro-env venv is copied into the final image.
+# Torch wheel is sourced from vendored build-assets/wheels/ so this stage
+# never requires network access to download.pytorch.org at build time.
+# Approximate size: ~850 MB (torch ~750 MB + kokoro + deps ~100 MB).
+FROM python:3.12-slim AS kokoro-builder
 
-ARG PIPER_RUNTIME_VERSION=2023.11.14-2
+# Install system deps needed for pip build steps + ffmpeg (for OGG encoding)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    libsndfile1 \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN dnf install -y curl tar gzip && \
-    dnf clean all
+# Create venv
+RUN python3 -m venv /opt/lifeos/kokoro-env
 
-RUN set -eux && \
-    mkdir -p /out/opt/lifeos/piper-tts && \
-    curl -fSL --retry 3 --connect-timeout 60 \
-      -o /tmp/piper_linux_x86_64.tar.gz \
-      "https://github.com/rhasspy/piper/releases/download/${PIPER_RUNTIME_VERSION}/piper_linux_x86_64.tar.gz" && \
-    tar -xzf /tmp/piper_linux_x86_64.tar.gz -C /tmp && \
-    cp -a /tmp/piper/. /out/opt/lifeos/piper-tts/ && \
-    test -x /out/opt/lifeos/piper-tts/piper && \
-    /out/opt/lifeos/piper-tts/piper --help 2>&1 | grep -q -- '--model'
+# Copy vendored wheel directory (torch ~180 MB, pre-downloaded for offline builds)
+# If the wheel is absent, pip falls back to https://download.pytorch.org/whl/cpu
+# during the build — CI should always have the vendored wheel.
+COPY build-assets/wheels/ /build-assets/wheels/
+
+# Install Python dependencies with pip cache mount for layer efficiency
+# torch: CPU-only variant from vendored wheel or PyTorch whl index
+# kokoro: kokoro-82m (TTS model + inference engine)
+# aiohttp: async HTTP server
+# soundfile: optional fast OGG encoding (libsndfile Vorbis if available)
+# numpy: audio array processing
+RUN --mount=type=cache,target=/root/.cache/pip \
+    /opt/lifeos/kokoro-env/bin/pip install --upgrade pip && \
+    /opt/lifeos/kokoro-env/bin/pip install \
+        --find-links /build-assets/wheels/ \
+        "torch==2.4.1+cpu" \
+        --index-url https://download.pytorch.org/whl/cpu && \
+    /opt/lifeos/kokoro-env/bin/pip install \
+        --find-links /build-assets/wheels/ \
+        kokoro \
+        aiohttp \
+        soundfile \
+        numpy
+
+# Pre-warm the default voice (if_sara) to materialise .pt weights files
+# and verify kokoro can synthesise without network access.
+RUN HF_HUB_OFFLINE=0 \
+    /opt/lifeos/kokoro-env/bin/python3 -c "
+from kokoro import KPipeline
+import numpy as np
+pipeline = KPipeline(lang_code='e', device='cpu')
+chunks = list(pipeline('Hola sistema, voz lista.', voice='if_sara'))
+assert chunks, 'No audio chunks produced — voice pre-warm failed'
+print('Kokoro pre-warm OK: if_sara voice loaded')
+"
+
+# Verify if_sara voice artifact exists after pre-warm
+RUN find /opt/lifeos/kokoro-env -name 'if_sara*' | grep -q '.' || \
+    (echo 'ERROR: if_sara voice artifact not found after pre-warm' && exit 1)
+
+# Copy the manifest builder script and generate voices-manifest.json
+COPY image/scripts/build-kokoro-manifest.py /build/build-kokoro-manifest.py
+RUN LIFEOS_TTS_DEFAULT_VOICE=if_sara \
+    /opt/lifeos/kokoro-env/bin/python3 /build/build-kokoro-manifest.py \
+        --venv-dir /opt/lifeos/kokoro-env \
+        --output /opt/lifeos/kokoro-env/voices-manifest.json && \
+    test -s /opt/lifeos/kokoro-env/voices-manifest.json && \
+    echo "voices-manifest.json generated ($(wc -l < /opt/lifeos/kokoro-env/voices-manifest.json) lines)"
+
+# Strip build artifacts to reduce image size
+RUN find /opt/lifeos/kokoro-env -type d -name '__pycache__' -exec rm -rf {} + 2>/dev/null || true && \
+    find /opt/lifeos/kokoro-env -name '*.pyc' -delete 2>/dev/null || true && \
+    find /opt/lifeos/kokoro-env -path '*/tests/*.py' -not -name '__init__.py' -delete 2>/dev/null || true
 
 # ============================================================================
 # Stage 6a-simplex: Extract SimpleX CLI binary from Ubuntu .deb
@@ -556,6 +590,7 @@ RUN dnf -y install \
     aide firewalld audit \
     powertop zram-generator \
     pciutils usbutils biosdevname prefixdevname curl ca-certificates openssl-libs cryptsetup \
+    ffmpeg \
     python3-mako \
     anaconda-core anaconda-dracut \
     lorax-templates-generic \
@@ -629,17 +664,20 @@ RUN set -eux && \
 
 # --- Directorios LifeOS ---
 # bootc installer + lorax expect /var/mnt to exist because /mnt -> /var/mnt.
-RUN mkdir -p /usr/share/lifeos/models /var/lib/lifeos /var/lib/lifeos/models /var/log/lifeos /etc/lifeos /var/mnt /var/roothome && \
+RUN mkdir -p /usr/share/lifeos/models /var/lib/lifeos /var/lib/lifeos/models /var/lib/lifeos/tts-output /var/log/lifeos /etc/lifeos /var/mnt /var/roothome && \
     chmod 0700 /var/roothome && \
-    chmod 0775 /var/lib/lifeos /var/lib/lifeos/models /var/log/lifeos && \
-    chgrp wheel /var/lib/lifeos /var/lib/lifeos/models /var/log/lifeos
+    chmod 0775 /var/lib/lifeos /var/lib/lifeos/models /var/lib/lifeos/tts-output /var/log/lifeos && \
+    chgrp wheel /var/lib/lifeos /var/lib/lifeos/models /var/lib/lifeos/tts-output /var/log/lifeos
 
 COPY --from=whisper-builder /out/models/whisper /usr/share/lifeos/models/whisper
-COPY --from=piper-voice-builder /out/models/piper /usr/share/lifeos/models/piper
 COPY --from=wespeaker-builder /out/models/wespeaker /usr/share/lifeos/models/wespeaker
-COPY --from=piper-runtime-builder /out/opt/lifeos/piper-tts /opt/lifeos/piper-tts
 
-RUN ln -sf /opt/lifeos/piper-tts/piper /usr/local/bin/lifeos-piper
+# --- Kokoro TTS runtime (venv + voices + manifest) ---
+COPY --from=kokoro-builder /opt/lifeos/kokoro-env /opt/lifeos/kokoro-env
+COPY image/files/usr/local/bin/lifeos-tts-server.py /usr/local/bin/lifeos-tts-server.py
+COPY image/files/etc/systemd/system/lifeos-tts-server.service /usr/lib/systemd/system/lifeos-tts-server.service
+COPY image/files/etc/lifeos/tts-server.env /etc/lifeos/tts-server.env
+RUN chmod +x /usr/local/bin/lifeos-tts-server.py
 
 # --- AI Model (pre-bundled) ---
 # Qwen3.5-4B: multimodal vision-language model with hybrid DeltaNet architecture.
@@ -988,9 +1026,6 @@ RUN printf '%s\n' \
     '' \
     '[Service]' \
     'Type=simple' \
-    'Environment=LIFEOS_TTS_BIN=/usr/local/bin/lifeos-piper' \
-    'Environment=LIFEOS_TTS_MODEL=/usr/share/lifeos/models/piper/es_MX-claude-high.onnx' \
-    'Environment=LIFEOS_TTS_FALLBACK_BIN=/usr/bin/espeak-ng' \
     'Environment=LIFEOS_DASHBOARD_DIR=/usr/share/lifeos/dashboard' \
     'Environment=LIFEOS_RUNTIME_DIR=%t/lifeos' \
     'Environment=LIFEOS_WESPEAKER_MODEL=/usr/share/lifeos/models/wespeaker/voxceleb_resnet34_LM.onnx' \
@@ -1046,6 +1081,7 @@ RUN mkdir -p /usr/lib/systemd/system/multi-user.target.wants \
     ln -sf /usr/lib/systemd/system/llama-server.service   /usr/lib/systemd/system/multi-user.target.wants/llama-server.service && \
     ln -sf /usr/lib/systemd/system/llama-embeddings.service /usr/lib/systemd/system/multi-user.target.wants/llama-embeddings.service && \
     ln -sf /usr/lib/systemd/system/whisper-stt.service    /usr/lib/systemd/system/multi-user.target.wants/whisper-stt.service && \
+    ln -sf /usr/lib/systemd/system/lifeos-tts-server.service /usr/lib/systemd/system/multi-user.target.wants/lifeos-tts-server.service && \
     ln -sf /usr/lib/systemd/system/fstrim.timer /usr/lib/systemd/system/timers.target.wants/fstrim.timer && \
     ln -sf /usr/lib/systemd/system/lifeos-btrfs-snapshot.timer /usr/lib/systemd/system/timers.target.wants/lifeos-btrfs-snapshot.timer && \
     ln -sf /usr/lib/systemd/system/lifeos-maintenance-cleanup.timer /usr/lib/systemd/system/timers.target.wants/lifeos-maintenance-cleanup.timer && \
@@ -1251,8 +1287,11 @@ RUN set -e; fail() { echo "VERIFY FAILED: $1"; exit 1; }; \
     test -x /usr/bin/wl-copy              || fail "/usr/bin/wl-copy"; \
     test -x /usr/bin/tesseract            || fail "/usr/bin/tesseract"; \
     test -x /usr/bin/espeak-ng            || fail "/usr/bin/espeak-ng"; \
-    test -x /usr/local/bin/lifeos-piper   || fail "/usr/local/bin/lifeos-piper"; \
-    /usr/local/bin/lifeos-piper --help 2>&1 | grep -q -- '--model' || fail "piper --model"; \
+    test -x /usr/local/bin/lifeos-tts-server.py || fail "/usr/local/bin/lifeos-tts-server.py"; \
+    test -f /usr/lib/systemd/system/lifeos-tts-server.service || fail "lifeos-tts-server.service"; \
+    test -f /etc/lifeos/tts-server.env    || fail "/etc/lifeos/tts-server.env"; \
+    test -d /opt/lifeos/kokoro-env        || fail "/opt/lifeos/kokoro-env"; \
+    test -f /opt/lifeos/kokoro-env/voices-manifest.json || fail "kokoro voices-manifest.json"; \
     test -x /usr/bin/spice-vdagent        || fail "/usr/bin/spice-vdagent"; \
     test -x /usr/bin/virsh                || fail "/usr/bin/virsh"; \
     test -x /usr/bin/pkg-config           || fail "/usr/bin/pkg-config"; \
@@ -1292,8 +1331,6 @@ RUN set -e; fail() { echo "VERIFY FAILED: $1"; exit 1; }; \
     test -f /usr/lib/bootc/kargs.d/60-lifeos-split-lock-detect.toml || fail "60-lifeos-split-lock-detect.toml"; \
     test -f /usr/share/lifeos/models/whisper/ggml-base.bin || fail "whisper/ggml-base.bin"; \
     test -f /usr/share/lifeos/models/whisper/ggml-tiny.bin || fail "whisper/ggml-tiny.bin"; \
-    test -f /usr/share/lifeos/models/piper/es_MX-claude-high.onnx || fail "piper/es_MX-claude-high.onnx"; \
-    test -f /usr/share/lifeos/models/piper/es_MX-claude-high.onnx.json || fail "piper/es_MX-claude-high.onnx.json"; \
     test -f /usr/share/lifeos/models/wespeaker/voxceleb_resnet34_LM.onnx || fail "wespeaker/voxceleb_resnet34_LM.onnx"; \
     test -f /usr/share/lifeos/models/rustpotter/axi.rpw || fail "rustpotter/axi.rpw"; \
     test -d /usr/share/backgrounds/lifeos || fail "/usr/share/backgrounds/lifeos"; \

--- a/image/Containerfile
+++ b/image/Containerfile
@@ -664,10 +664,10 @@ RUN set -eux && \
 
 # --- Directorios LifeOS ---
 # bootc installer + lorax expect /var/mnt to exist because /mnt -> /var/mnt.
-RUN mkdir -p /usr/share/lifeos/models /var/lib/lifeos /var/lib/lifeos/models /var/lib/lifeos/tts-output /var/log/lifeos /etc/lifeos /var/mnt /var/roothome && \
+RUN mkdir -p /usr/share/lifeos/models /var/lib/lifeos /var/lib/lifeos/models /var/log/lifeos /etc/lifeos /var/mnt /var/roothome && \
     chmod 0700 /var/roothome && \
-    chmod 0775 /var/lib/lifeos /var/lib/lifeos/models /var/lib/lifeos/tts-output /var/log/lifeos && \
-    chgrp wheel /var/lib/lifeos /var/lib/lifeos/models /var/lib/lifeos/tts-output /var/log/lifeos
+    chmod 0775 /var/lib/lifeos /var/lib/lifeos/models /var/log/lifeos && \
+    chgrp wheel /var/lib/lifeos /var/lib/lifeos/models /var/log/lifeos
 
 COPY --from=whisper-builder /out/models/whisper /usr/share/lifeos/models/whisper
 COPY --from=wespeaker-builder /out/models/wespeaker /usr/share/lifeos/models/wespeaker

--- a/image/files/etc/lifeos/tts-server.env
+++ b/image/files/etc/lifeos/tts-server.env
@@ -13,6 +13,10 @@ LIFEOS_TTS_ENGINE_PORT=8083
 # Change to cuda:0 if a CUDA GPU is available and you want GPU acceleration.
 LIFEOS_TTS_DEVICE=cpu
 
+# HuggingFace cache directory — voices and models pre-loaded at image build.
+# Must match the build-time HF_HOME so kokoro finds cached weights.
+HF_HOME=/opt/lifeos/kokoro-env/hf-cache
+
 # Prevent HuggingFace Hub from making outbound requests at inference time.
 # Models and voices are pre-loaded into the image — no downloads needed.
 HF_HUB_OFFLINE=1

--- a/image/files/etc/lifeos/tts-server.env
+++ b/image/files/etc/lifeos/tts-server.env
@@ -1,0 +1,20 @@
+# LifeOS TTS Server Configuration
+# Loaded by lifeos-tts-server.service via EnvironmentFile=
+# See image/files/usr/local/bin/lifeos-tts-server.py for server implementation.
+
+# Default voice for synthesis when no per-request or user-preference voice is set.
+# Must be a valid Kokoro voice name (see GET /voices for the full list).
+LIFEOS_TTS_DEFAULT_VOICE=if_sara
+
+# TCP port the server binds to (loopback only — never exposed externally).
+LIFEOS_TTS_ENGINE_PORT=8083
+
+# Torch inference device. cpu = CPU-only (no CUDA required).
+# Change to cuda:0 if a CUDA GPU is available and you want GPU acceleration.
+LIFEOS_TTS_DEVICE=cpu
+
+# Prevent HuggingFace Hub from making outbound requests at inference time.
+# Models and voices are pre-loaded into the image — no downloads needed.
+HF_HUB_OFFLINE=1
+TRANSFORMERS_OFFLINE=1
+PYTORCH_DISABLE_HUGGINGFACE_HUB_TELEMETRY=1

--- a/image/files/etc/systemd/system/lifeos-tts-server.service
+++ b/image/files/etc/systemd/system/lifeos-tts-server.service
@@ -1,0 +1,58 @@
+[Unit]
+Description=LifeOS Kokoro TTS Server (HTTP, 127.0.0.1:8083)
+Documentation=https://github.com/hexgrad/kokoro
+After=network.target
+Before=lifeosd.service
+
+[Service]
+Type=simple
+
+# Runtime environment
+EnvironmentFile=/etc/lifeos/tts-server.env
+
+# Server binary
+ExecStart=/opt/lifeos/kokoro-env/bin/python3 /usr/local/bin/lifeos-tts-server.py
+
+# Restart policy
+Restart=on-failure
+RestartSec=5
+TimeoutStartSec=60
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=lifeos-tts-server
+
+# Dynamic user for isolation (no persistent UID needed)
+DynamicUser=yes
+RuntimeDirectory=lifeos-tts
+StateDirectory=lifeos/tts-output
+
+# Memory and CPU limits
+MemoryMax=1G
+CPUQuota=200%
+
+# Security hardening
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=read-only
+PrivateTmp=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+RestrictRealtime=true
+SystemCallArchitectures=native
+LockPersonality=true
+CapabilityBoundingSet=
+
+# Network isolation — loopback only
+IPAddressAllow=127.0.0.0/8 ::1/128
+IPAddressDeny=any
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+
+# Read-write paths needed
+ReadWritePaths=/var/lib/lifeos/tts-output
+
+[Install]
+WantedBy=multi-user.target

--- a/image/files/etc/systemd/system/lifeos-tts-server.service
+++ b/image/files/etc/systemd/system/lifeos-tts-server.service
@@ -26,7 +26,6 @@ SyslogIdentifier=lifeos-tts-server
 # Dynamic user for isolation (no persistent UID needed)
 DynamicUser=yes
 RuntimeDirectory=lifeos-tts
-StateDirectory=lifeos/tts-output
 
 # Memory and CPU limits
 MemoryMax=1G
@@ -37,6 +36,7 @@ NoNewPrivileges=true
 ProtectSystem=strict
 ProtectHome=read-only
 PrivateTmp=true
+PrivateDevices=true
 ProtectKernelTunables=true
 ProtectKernelModules=true
 ProtectControlGroups=true
@@ -50,9 +50,6 @@ CapabilityBoundingSet=
 IPAddressAllow=127.0.0.0/8 ::1/128
 IPAddressDeny=any
 RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
-
-# Read-write paths needed
-ReadWritePaths=/var/lib/lifeos/tts-output
 
 [Install]
 WantedBy=multi-user.target

--- a/image/files/usr/local/bin/lifeos-tts-server.py
+++ b/image/files/usr/local/bin/lifeos-tts-server.py
@@ -1,0 +1,457 @@
+#!/usr/bin/env python3
+"""
+lifeos-tts-server.py — LifeOS Kokoro TTS HTTP Server
+
+Binds to 127.0.0.1:$LIFEOS_TTS_ENGINE_PORT (default 8083).
+
+Routes:
+    GET  /health  → {"status":"ok","model":"Kokoro-82M","voices_loaded":N}
+                    Returns 503 until warm-up completes.
+    GET  /voices  → JSON array of {name, language, language_code, gender, is_default}
+    POST /tts     → JSON body {text, voice?, speed?, format?}
+                    Returns audio/wav (default) or audio/ogg when format="ogg".
+
+Environment:
+    LIFEOS_TTS_DEFAULT_VOICE  Default voice name (default: if_sara)
+    LIFEOS_TTS_ENGINE_PORT    Bind port (default: 8083)
+    LIFEOS_TTS_DEVICE         Torch device (default: cpu)
+    HF_HUB_OFFLINE            Set to 1 to prevent HuggingFace downloads (set by env file)
+    TRANSFORMERS_OFFLINE      Set to 1 to prevent transformers hub access
+
+Concurrency: asyncio.Semaphore(2) — max 2 simultaneous synthesis requests.
+Memory watchdog: SIGTERM self if process RSS exceeds 900 MB.
+Graceful shutdown: drains in-flight requests on SIGTERM before exit.
+OGG encoding: ffmpeg subprocess (primary path, always available in image).
+              soundfile/libsndfile used as fast path if available.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+import logging
+import os
+import resource
+import signal
+import struct
+import subprocess
+import sys
+import tempfile
+import time
+import wave
+from pathlib import Path
+from typing import Any
+
+# Force offline mode before any kokoro/torch imports
+os.environ.setdefault("HF_HUB_OFFLINE", "1")
+os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
+os.environ.setdefault("PYTORCH_DISABLE_HUGGINGFACE_HUB_TELEMETRY", "1")
+
+from aiohttp import web
+
+# ---------------------------------------------------------------------------
+# Structured JSON logging
+# ---------------------------------------------------------------------------
+
+class JsonFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        log_entry = {
+            "ts": self.formatTime(record, "%Y-%m-%dT%H:%M:%S"),
+            "level": record.levelname,
+            "logger": record.name,
+            "msg": record.getMessage(),
+        }
+        if record.exc_info:
+            log_entry["exc"] = self.formatException(record.exc_info)
+        return json.dumps(log_entry, ensure_ascii=False)
+
+
+def _setup_logging() -> None:
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(JsonFormatter())
+    root = logging.getLogger()
+    root.handlers = [handler]
+    root.setLevel(logging.INFO)
+
+
+_LOG = logging.getLogger("lifeos.tts")
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+DEFAULT_VOICE: str = os.environ.get("LIFEOS_TTS_DEFAULT_VOICE", "if_sara")
+PORT: int = int(os.environ.get("LIFEOS_TTS_ENGINE_PORT", "8083"))
+DEVICE: str = os.environ.get("LIFEOS_TTS_DEVICE", "cpu")
+SAMPLE_RATE: int = 24000
+MEMORY_LIMIT_BYTES: int = 900 * 1024 * 1024  # 900 MB RSS watchdog
+VENV_DIR: Path = Path("/opt/lifeos/kokoro-env")
+MANIFEST_PATH: Path = VENV_DIR / "voices-manifest.json"
+
+# ---------------------------------------------------------------------------
+# Global state
+# ---------------------------------------------------------------------------
+
+_pipeline: Any = None          # KPipeline instance after warm-up
+_voices: list[dict] = []       # Loaded from voices-manifest.json
+_ready: bool = False            # True after warm-up completes
+_synth_sem: asyncio.Semaphore = asyncio.Semaphore(2)
+_shutdown_event: asyncio.Event = asyncio.Event()
+
+# ---------------------------------------------------------------------------
+# OGG encoding helpers
+# ---------------------------------------------------------------------------
+
+def _wav_bytes_to_ogg(wav_bytes: bytes) -> bytes:
+    """Convert WAV bytes to OGG/Vorbis bytes using ffmpeg subprocess.
+
+    ffmpeg is the primary path — reliably available in the LifeOS image.
+    soundfile/libsndfile is used as a fast path if available, but
+    python:3.12-slim's libsndfile may not be compiled with Vorbis support,
+    so ffmpeg is the safe fallback.
+    """
+    # Fast path: try soundfile first (no subprocess overhead)
+    try:
+        import soundfile as sf
+        import numpy as np
+        with io.BytesIO(wav_bytes) as wav_buf:
+            with wave.open(wav_buf) as wf:
+                n_frames = wf.getnframes()
+                n_channels = wf.getnchannels()
+                sampwidth = wf.getsampwidth()
+                framerate = wf.getframerate()
+                raw = wf.readframes(n_frames)
+        # Convert to float32 numpy array
+        if sampwidth == 2:
+            audio = np.frombuffer(raw, dtype=np.int16).astype(np.float32) / 32768.0
+        else:
+            audio = np.frombuffer(raw, dtype=np.float32)
+        if n_channels > 1:
+            audio = audio.reshape(-1, n_channels)
+        ogg_buf = io.BytesIO()
+        sf.write(ogg_buf, audio, framerate, format="OGG", subtype="VORBIS")
+        return ogg_buf.getvalue()
+    except Exception:
+        pass  # Fall through to ffmpeg
+
+    # Primary path: ffmpeg subprocess
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as wav_tmp:
+        wav_tmp.write(wav_bytes)
+        wav_tmp_path = wav_tmp.name
+    ogg_tmp_path = wav_tmp_path.replace(".wav", ".ogg")
+    try:
+        result = subprocess.run(
+            [
+                "ffmpeg", "-y",
+                "-i", wav_tmp_path,
+                "-c:a", "libvorbis",
+                "-q:a", "4",
+                ogg_tmp_path,
+            ],
+            capture_output=True,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"ffmpeg exited {result.returncode}: {result.stderr.decode()[:200]}"
+            )
+        return Path(ogg_tmp_path).read_bytes()
+    finally:
+        try:
+            os.unlink(wav_tmp_path)
+        except OSError:
+            pass
+        try:
+            os.unlink(ogg_tmp_path)
+        except OSError:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Synthesis helpers
+# ---------------------------------------------------------------------------
+
+def _synth_to_wav(text: str, voice: str, speed: float = 1.0) -> bytes:
+    """Synthesise text → WAV bytes using KPipeline (blocking, CPU)."""
+    import numpy as np
+
+    audio_chunks: list[Any] = []
+    for _, _, audio in _pipeline(text, voice=voice, speed=speed):
+        if audio is not None:
+            audio_chunks.append(audio)
+
+    if not audio_chunks:
+        raise RuntimeError("KPipeline returned no audio chunks")
+
+    audio_np = np.concatenate(audio_chunks, axis=0)
+    # Normalise to int16
+    audio_np = np.clip(audio_np, -1.0, 1.0)
+    audio_int16 = (audio_np * 32767).astype(np.int16)
+
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(SAMPLE_RATE)
+        wf.writeframes(audio_int16.tobytes())
+    return buf.getvalue()
+
+
+def _resolve_voice(requested: str | None) -> str | None:
+    """Return the voice name to use, or None if the requested voice is unknown.
+
+    Returns DEFAULT_VOICE if requested is None/empty.
+    Returns None if a non-empty requested voice is not in the voices list.
+    """
+    known = {v["name"] for v in _voices}
+    if not requested:
+        return DEFAULT_VOICE
+    if requested in known:
+        return requested
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Memory watchdog
+# ---------------------------------------------------------------------------
+
+async def _memory_watchdog() -> None:
+    """Periodically check RSS; SIGTERM self if over 900 MB."""
+    while not _shutdown_event.is_set():
+        try:
+            rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * 1024  # KB → bytes
+            if rss > MEMORY_LIMIT_BYTES:
+                _LOG.warning(
+                    "Memory watchdog: RSS %d MB exceeds limit %d MB — sending SIGTERM",
+                    rss // 1024 // 1024,
+                    MEMORY_LIMIT_BYTES // 1024 // 1024,
+                )
+                os.kill(os.getpid(), signal.SIGTERM)
+        except Exception as exc:
+            _LOG.error("Memory watchdog error: %s", exc)
+        await asyncio.sleep(30)
+
+
+# ---------------------------------------------------------------------------
+# HTTP route handlers
+# ---------------------------------------------------------------------------
+
+async def handle_health(request: web.Request) -> web.Response:
+    if not _ready:
+        return web.Response(
+            status=503,
+            content_type="application/json",
+            text=json.dumps({"status": "warming_up", "model": "Kokoro-82M"}),
+        )
+    return web.Response(
+        content_type="application/json",
+        text=json.dumps({
+            "status": "ok",
+            "model": "Kokoro-82M",
+            "voices_loaded": len(_voices),
+        }),
+    )
+
+
+async def handle_voices(request: web.Request) -> web.Response:
+    return web.Response(
+        content_type="application/json",
+        text=json.dumps(_voices, ensure_ascii=False),
+    )
+
+
+async def handle_tts(request: web.Request) -> web.Response:
+    if not _ready:
+        return web.Response(
+            status=503,
+            content_type="application/json",
+            text=json.dumps({"error": "not_ready", "detail": "Server warming up"}),
+        )
+
+    # Parse request body
+    try:
+        body = await request.json()
+    except Exception:
+        return web.Response(
+            status=400,
+            content_type="application/json",
+            text=json.dumps({"error": "invalid_json", "detail": "Request body must be JSON"}),
+        )
+
+    text: str = body.get("text", "").strip()
+    if not text:
+        return web.Response(
+            status=400,
+            content_type="application/json",
+            text=json.dumps({"error": "empty_text", "detail": "text field is required and must not be empty"}),
+        )
+
+    requested_voice: str | None = body.get("voice") or None
+    speed: float = float(body.get("speed", 1.0))
+    fmt: str = (body.get("format") or "wav").lower()
+
+    # Validate format
+    if fmt not in ("wav", "ogg"):
+        return web.Response(
+            status=400,
+            content_type="application/json",
+            text=json.dumps({"error": "invalid_format", "detail": f"format must be 'wav' or 'ogg', got '{fmt}'"}),
+        )
+
+    # Resolve voice
+    voice = _resolve_voice(requested_voice)
+    if voice is None:
+        return web.Response(
+            status=400,
+            content_type="application/json",
+            text=json.dumps({
+                "error": "unknown_voice",
+                "detail": f"{requested_voice} is not a valid Kokoro voice",
+            }),
+        )
+
+    # Concurrency guard
+    async with _synth_sem:
+        try:
+            loop = asyncio.get_event_loop()
+            wav_bytes = await loop.run_in_executor(
+                None, _synth_to_wav, text, voice, speed
+            )
+        except Exception as exc:
+            _LOG.error("Synthesis failed: %s", exc, exc_info=True)
+            return web.Response(
+                status=500,
+                content_type="application/json",
+                text=json.dumps({
+                    "error": "synthesis_failed",
+                    "detail": str(exc),
+                }),
+            )
+
+    if fmt == "ogg":
+        try:
+            loop = asyncio.get_event_loop()
+            audio_bytes = await loop.run_in_executor(None, _wav_bytes_to_ogg, wav_bytes)
+            content_type = "audio/ogg"
+        except Exception as exc:
+            _LOG.error("OGG encoding failed: %s", exc, exc_info=True)
+            return web.Response(
+                status=500,
+                content_type="application/json",
+                text=json.dumps({
+                    "error": "ogg_encoding_failed",
+                    "detail": str(exc),
+                }),
+            )
+    else:
+        audio_bytes = wav_bytes
+        content_type = "audio/wav"
+
+    return web.Response(
+        status=200,
+        content_type=content_type,
+        body=audio_bytes,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Application startup
+# ---------------------------------------------------------------------------
+
+def _load_voices_manifest() -> list[dict]:
+    """Load voices-manifest.json; return empty list if not found."""
+    if not MANIFEST_PATH.exists():
+        _LOG.warning("voices-manifest.json not found at %s", MANIFEST_PATH)
+        return []
+    try:
+        data = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+        if not isinstance(data, list):
+            _LOG.error("voices-manifest.json is not a JSON array")
+            return []
+        return data
+    except Exception as exc:
+        _LOG.error("Failed to load voices-manifest.json: %s", exc)
+        return []
+
+
+async def _startup(app: web.Application) -> None:
+    """Load Kokoro model, warm up, mark ready."""
+    global _pipeline, _voices, _ready
+
+    _LOG.info("Loading voices manifest from %s", MANIFEST_PATH)
+    _voices = _load_voices_manifest()
+    _LOG.info("Loaded %d voices from manifest", len(_voices))
+
+    _LOG.info("Importing KPipeline (device=%s)", DEVICE)
+    try:
+        from kokoro import KPipeline
+        _pipeline = KPipeline(lang_code="e", device=DEVICE)
+    except Exception as exc:
+        _LOG.error("Failed to load KPipeline: %s", exc, exc_info=True)
+        raise
+
+    _LOG.info("Warming up with default voice '%s'", DEFAULT_VOICE)
+    try:
+        loop = asyncio.get_event_loop()
+        await loop.run_in_executor(
+            None, _synth_to_wav, "Hola, sistema listo.", DEFAULT_VOICE, 1.0
+        )
+        _LOG.info("Warm-up complete")
+    except Exception as exc:
+        _LOG.warning("Warm-up failed (non-fatal): %s", exc)
+
+    _ready = True
+    _LOG.info("Server ready on 127.0.0.1:%d", PORT)
+
+    # Start background tasks
+    app["_watchdog_task"] = asyncio.ensure_future(_memory_watchdog())
+
+
+async def _shutdown(app: web.Application) -> None:
+    """Drain in-flight requests, cancel background tasks."""
+    _LOG.info("Shutting down — draining in-flight requests")
+    _shutdown_event.set()
+    watchdog = app.get("_watchdog_task")
+    if watchdog:
+        watchdog.cancel()
+        try:
+            await watchdog
+        except asyncio.CancelledError:
+            pass
+    _LOG.info("Shutdown complete")
+
+
+def _handle_sigterm(signum: int, frame: Any) -> None:
+    _LOG.info("Received SIGTERM — initiating graceful shutdown")
+    _shutdown_event.set()
+    # aiohttp will handle the rest via on_shutdown
+
+
+def _build_app() -> web.Application:
+    app = web.Application()
+    app.router.add_get("/health", handle_health)
+    app.router.add_get("/voices", handle_voices)
+    app.router.add_post("/tts", handle_tts)
+    app.on_startup.append(_startup)
+    app.on_shutdown.append(_shutdown)
+    return app
+
+
+def main() -> None:
+    _setup_logging()
+    signal.signal(signal.SIGTERM, _handle_sigterm)
+
+    app = _build_app()
+    _LOG.info("Starting LifeOS TTS server on 127.0.0.1:%d", PORT)
+    web.run_app(
+        app,
+        host="127.0.0.1",
+        port=PORT,
+        access_log=None,  # We handle logging ourselves
+        handle_signals=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/image/scripts/build-kokoro-manifest.py
+++ b/image/scripts/build-kokoro-manifest.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""
+build-kokoro-manifest.py
+Generates /opt/lifeos/kokoro-env/voices-manifest.json at image build time.
+
+Usage:
+    python3 build-kokoro-manifest.py [--dry-run] [--venv-dir DIR] [--output FILE]
+
+Arguments:
+    --dry-run        Print discovered voices to stdout; do not write any file.
+    --venv-dir DIR   Path to the kokoro virtualenv (default: /opt/lifeos/kokoro-env).
+    --output FILE    Output path for the manifest JSON (default: <venv-dir>/voices-manifest.json).
+
+Exit codes:
+    0  Success (at least one voice discovered)
+    1  Error (kokoro not installed, no voices found, write failure)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Voice metadata table
+# Each entry: (voice_name, language_code, language_label, gender)
+# Source: kokoro official voice listing (https://github.com/hexgrad/kokoro)
+# ---------------------------------------------------------------------------
+KNOWN_VOICES: list[tuple[str, str, str, str]] = [
+    # American English — female
+    ("af_alloy",   "en-us", "English (US)", "female"),
+    ("af_aoede",   "en-us", "English (US)", "female"),
+    ("af_bella",   "en-us", "English (US)", "female"),
+    ("af_heart",   "en-us", "English (US)", "female"),
+    ("af_jessica", "en-us", "English (US)", "female"),
+    ("af_kore",    "en-us", "English (US)", "female"),
+    ("af_nicole",  "en-us", "English (US)", "female"),
+    ("af_nova",    "en-us", "English (US)", "female"),
+    ("af_river",   "en-us", "English (US)", "female"),
+    ("af_sarah",   "en-us", "English (US)", "female"),
+    ("af_sky",     "en-us", "English (US)", "female"),
+    # American English — male
+    ("am_adam",    "en-us", "English (US)", "male"),
+    ("am_echo",    "en-us", "English (US)", "male"),
+    ("am_eric",    "en-us", "English (US)", "male"),
+    ("am_fenrir",  "en-us", "English (US)", "male"),
+    ("am_fable",   "en-us", "English (US)", "male"),
+    ("am_liam",    "en-us", "English (US)", "male"),
+    ("am_michael", "en-us", "English (US)", "male"),
+    ("am_onyx",    "en-us", "English (US)", "male"),
+    ("am_orion",   "en-us", "English (US)", "male"),
+    ("am_santa",   "en-us", "English (US)", "male"),
+    # British English — female
+    ("bf_alice",   "en-gb", "English (UK)", "female"),
+    ("bf_emma",    "en-gb", "English (UK)", "female"),
+    ("bf_isabella","en-gb", "English (UK)", "female"),
+    ("bf_lily",    "en-gb", "English (UK)", "female"),
+    # British English — male
+    ("bm_daniel",  "en-gb", "English (UK)", "male"),
+    ("bm_fable",   "en-gb", "English (UK)", "male"),
+    ("bm_george",  "en-gb", "English (UK)", "male"),
+    ("bm_lewis",   "en-gb", "English (UK)", "male"),
+    # Spanish — female
+    ("ef_dora",    "es",    "Español",      "female"),
+    ("if_sara",    "es",    "Español",      "female"),
+    # Spanish — male
+    ("em_alex",    "es",    "Español",      "male"),
+    ("em_santa",   "es",    "Español",      "male"),
+    ("im_nicola",  "es",    "Español",      "male"),
+    # French — female
+    ("ff_siwis",   "fr",    "Français",     "female"),
+    # Hindi — female
+    ("hf_alpha",   "hi",    "Hindi",        "female"),
+    ("hf_beta",    "hi",    "Hindi",        "female"),
+    # Hindi — male
+    ("hm_omega",   "hi",    "Hindi",        "male"),
+    ("hm_psi",     "hi",    "Hindi",        "male"),
+    # Italian — female
+    ("if_sara",    "it",    "Italiano",     "female"),  # note: same code, different lang
+    # Italian — male
+    ("im_nicola",  "it",    "Italiano",     "male"),    # note: same code, different lang
+    # Japanese — female
+    ("jf_alpha",   "ja",    "日本語",       "female"),
+    ("jf_gongitsune","ja",  "日本語",       "female"),
+    ("jf_nezumi",  "ja",    "日本語",       "female"),
+    ("jf_tebukuro","ja",    "日本語",       "female"),
+    # Japanese — male
+    ("jm_kumo",    "ja",    "日本語",       "male"),
+    # Korean — female
+    ("kf_alpha",   "ko",    "한국어",       "female"),
+    ("kf_beta",    "ko",    "한국어",       "female"),
+    # Korean — male
+    ("km_alpha",   "ko",    "한국어",       "male"),
+    # Mandarin Chinese — female
+    ("zf_xiaobei", "zh",    "中文",         "female"),
+    ("zf_xiaoni",  "zh",    "中文",         "female"),
+    ("zf_xiaoxiao","zh",    "中文",         "female"),
+    ("zf_xiaoyi",  "zh",    "中文",         "female"),
+    # Mandarin Chinese — male
+    ("zm_yunjian", "zh",    "中文",         "male"),
+    ("zm_yunxi",   "zh",    "中文",         "male"),
+    ("zm_yunxia",  "zh",    "中文",         "male"),
+    ("zm_yunyang", "zh",    "中文",         "male"),
+    # Portuguese — female
+    ("pf_dora",    "pt-br", "Português",    "female"),
+    # Portuguese — male
+    ("pm_alex",    "pt-br", "Português",    "male"),
+    ("pm_santa",   "pt-br", "Português",    "male"),
+]
+
+
+def discover_installed_voices(venv_dir: Path) -> list[str]:
+    """Return voice names that are actually present in the venv as .pt files."""
+    voices_dir = venv_dir / "lib"
+    # kokoro stores voices under site-packages/kokoro/voices/<name>.pt
+    # Try multiple possible locations
+    candidates = list(venv_dir.rglob("voices/*.pt"))
+    if not candidates:
+        # Fallback: try importing kokoro and asking it
+        return []
+    return [p.stem for p in candidates]
+
+
+def build_manifest(
+    venv_dir: Path,
+    default_voice: str = "if_sara",
+) -> list[dict]:
+    """Build the voice manifest by cross-referencing installed voices with metadata."""
+    installed = set(discover_installed_voices(venv_dir))
+    manifest = []
+    seen_names: set[str] = set()
+
+    for name, lang_code, lang_label, gender in KNOWN_VOICES:
+        # Deduplicate: if both Spanish and Italian have 'if_sara', keep first occurrence
+        if name in seen_names:
+            continue
+        # Only include voices that are actually installed (skip if venv probing works)
+        # When installed set is empty (dry-run without venv), include all known voices
+        if installed and name not in installed:
+            continue
+        seen_names.add(name)
+        manifest.append({
+            "name": name,
+            "language": lang_label,
+            "language_code": lang_code,
+            "gender": gender,
+            "is_default": name == default_voice,
+        })
+
+    # If no voices found through file discovery, include all known voices
+    # (this happens when called with --dry-run without a real kokoro install)
+    if not manifest:
+        for name, lang_code, lang_label, gender in KNOWN_VOICES:
+            if name in seen_names:
+                continue
+            seen_names.add(name)
+            manifest.append({
+                "name": name,
+                "language": lang_label,
+                "language_code": lang_code,
+                "gender": gender,
+                "is_default": name == default_voice,
+            })
+
+    return manifest
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print manifest to stdout; do not write to disk.",
+    )
+    parser.add_argument(
+        "--venv-dir",
+        default="/opt/lifeos/kokoro-env",
+        metavar="DIR",
+        help="Path to the kokoro virtualenv (default: /opt/lifeos/kokoro-env).",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        metavar="FILE",
+        help="Output path (default: <venv-dir>/voices-manifest.json).",
+    )
+    args = parser.parse_args()
+
+    venv_dir = Path(args.venv_dir)
+    output_path = Path(args.output) if args.output else venv_dir / "voices-manifest.json"
+    default_voice = os.environ.get("LIFEOS_TTS_DEFAULT_VOICE", "if_sara")
+
+    manifest = build_manifest(venv_dir, default_voice=default_voice)
+
+    if not manifest:
+        print("ERROR: No voices found. Is kokoro installed in the venv?", file=sys.stderr)
+        return 1
+
+    manifest_json = json.dumps(manifest, ensure_ascii=False, indent=2)
+
+    if args.dry_run:
+        print(manifest_json)
+        print(f"\nDry-run: {len(manifest)} voices enumerated.", file=sys.stderr)
+        return 0
+
+    # Write manifest
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(manifest_json, encoding="utf-8")
+    print(
+        f"Wrote {len(manifest)} voices to {output_path}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/image/scripts/prewarm-kokoro.py
+++ b/image/scripts/prewarm-kokoro.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+"""Pre-warm the default Kokoro voice (if_sara) at image build time.
+
+Materialises .pt weight files and verifies kokoro can synthesise without
+network access at runtime. Called from the Containerfile.
+"""
+from kokoro import KPipeline
+
+pipeline = KPipeline(lang_code="e", device="cpu")
+chunks = list(pipeline("Hola sistema, voz lista.", voice="if_sara"))
+assert chunks, "No audio chunks produced — voice pre-warm failed"
+print("Kokoro pre-warm OK: if_sara voice loaded")

--- a/scripts/assert-no-piper.sh
+++ b/scripts/assert-no-piper.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# assert-no-piper.sh
+# Asserts that a filesystem tree or individual files do NOT contain any Piper
+# TTS artifacts that must never appear in production LifeOS images after the
+# migration to Kokoro TTS.
+#
+# Usage:
+#   assert-no-piper.sh <file-or-dir> [file-or-dir ...]
+#
+# Arguments:
+#   One or more files or directories to check.
+#   - Files are scanned for forbidden strings using rg.
+#   - Directories are walked recursively with fd (all files).
+#
+# Exit codes:
+#   0 — No Piper artifacts found.
+#   1 — One or more forbidden Piper artifacts found (offending lines printed).
+#   2 — Usage error (no argument provided).
+#
+# Forbidden filesystem paths (presence in a directory tree → exit 1):
+#   usr/local/bin/lifeos-piper
+#   usr/share/lifeos/models/piper/
+#   opt/lifeos/piper-tts/
+#   etc/systemd/user/lifeosd.service.d/LIFEOS_TTS_*.conf
+#
+# Forbidden strings in files (any match → exit 1):
+#   piper-voice-builder
+#   piper-runtime-builder
+#   lifeos-piper
+#   es_MX-claude
+#   LIFEOS_TTS_BIN
+#   LIFEOS_TTS_MODEL
+#   LIFEOS_TTS_FALLBACK_BIN
+
+set -euo pipefail
+
+# ── Forbidden filesystem path suffixes ───────────────────────────────────────
+readonly FORBIDDEN_PATH_PATTERNS=(
+    "usr/local/bin/lifeos-piper"
+    "usr/share/lifeos/models/piper"
+    "opt/lifeos/piper-tts"
+    "etc/systemd/user/lifeosd.service.d/LIFEOS_TTS_"
+)
+
+# ── Forbidden strings in file content ────────────────────────────────────────
+# These are matched as literal strings (not regex) via rg -F
+readonly FORBIDDEN_STRINGS=(
+    "piper-voice-builder"
+    "piper-runtime-builder"
+    "lifeos-piper"
+    "es_MX-claude"
+    "LIFEOS_TTS_BIN"
+    "LIFEOS_TTS_MODEL"
+    "LIFEOS_TTS_FALLBACK_BIN"
+)
+
+# ── Usage ─────────────────────────────────────────────────────────────────────
+usage() {
+    cat >&2 <<'EOF'
+Usage: assert-no-piper.sh <file-or-dir> [file-or-dir ...]
+
+Assert that LifeOS image files / Containerfile contain no Piper TTS artifacts.
+
+Arguments:
+  One or more files or directories. Directories are walked recursively.
+
+Exit codes:
+  0  No Piper artifacts found.
+  1  One or more Piper artifacts found (offending paths/lines printed to stdout).
+  2  Usage error.
+
+Forbidden filesystem paths:
+  usr/local/bin/lifeos-piper
+  usr/share/lifeos/models/piper/
+  opt/lifeos/piper-tts/
+  etc/systemd/user/lifeosd.service.d/LIFEOS_TTS_*.conf
+
+Forbidden strings in files:
+  piper-voice-builder, piper-runtime-builder, lifeos-piper, es_MX-claude,
+  LIFEOS_TTS_BIN, LIFEOS_TTS_MODEL, LIFEOS_TTS_FALLBACK_BIN
+EOF
+}
+
+if [ $# -eq 0 ]; then
+    usage
+    exit 2
+fi
+
+FOUND=0
+
+# ── Build rg pattern from forbidden strings ───────────────────────────────────
+# Join with | for a single rg pass per file (faster than multiple rg invocations)
+RG_PATTERN=""
+for s in "${FORBIDDEN_STRINGS[@]}"; do
+    if [ -z "${RG_PATTERN}" ]; then
+        RG_PATTERN="${s}"
+    else
+        RG_PATTERN="${RG_PATTERN}|${s}"
+    fi
+done
+
+# ── Scan a single regular file ─────────────────────────────────────────────────
+scan_file() {
+    local file="$1"
+
+    # Skip binary files — rg handles this automatically with --text not set
+    # (rg skips binary by default unless a match is in a binary file, then it
+    # just notes "binary file matches". We use -l to avoid that output and
+    # then a second pass for line-level output.)
+
+    set +e
+    matches=$(rg -n --no-heading -e "${RG_PATTERN}" -- "${file}" 2>/dev/null)
+    rg_rc=$?
+    set -e
+
+    if [ "${rg_rc}" -eq 0 ] && [ -n "${matches}" ]; then
+        echo "FAIL: piper string found in ${file}:"
+        while IFS= read -r line; do
+            echo "  ${line}"
+        done <<< "${matches}"
+        FOUND=$((FOUND + 1))
+    fi
+}
+
+# ── Check forbidden paths under a directory root ───────────────────────────────
+check_forbidden_paths() {
+    local root="$1"
+
+    for pattern in "${FORBIDDEN_PATH_PATTERNS[@]}"; do
+        # Use fd to find any path that contains the pattern as a substring
+        # fd returns exit 0 whether or not it found anything; capture output
+        set +e
+        hits=$(fd --unrestricted --type f --type d . "${root}" 2>/dev/null \
+               | { grep -F "${pattern}" || true; })
+        set -e
+
+        if [ -n "${hits}" ]; then
+            echo "FAIL: forbidden Piper path found:"
+            while IFS= read -r hit; do
+                echo "  ${hit}"
+            done <<< "${hits}"
+            FOUND=$((FOUND + 1))
+        fi
+    done
+
+    # Also check for the LIFEOS_TTS_*.conf glob pattern (fd glob)
+    set +e
+    conf_hits=$(fd --unrestricted 'LIFEOS_TTS_.*\.conf$' "${root}" 2>/dev/null || true)
+    set -e
+    if [ -n "${conf_hits}" ]; then
+        echo "FAIL: forbidden LIFEOS_TTS_*.conf drop-in found:"
+        while IFS= read -r hit; do
+            echo "  ${hit}"
+        done <<< "${conf_hits}"
+        FOUND=$((FOUND + 1))
+    fi
+}
+
+# ── Process each argument ──────────────────────────────────────────────────────
+for target in "$@"; do
+    if [ -d "${target}" ]; then
+        # Directory: check forbidden paths and scan all regular files
+        check_forbidden_paths "${target}"
+
+        # Walk all regular files and scan for forbidden strings
+        while IFS= read -r -d '' file; do
+            scan_file "${file}"
+        done < <(fd --unrestricted --type f . "${target}" --print0 2>/dev/null || true)
+
+    elif [ -f "${target}" ]; then
+        scan_file "${target}"
+    else
+        echo "WARNING: target does not exist or is not a file/dir: ${target}" >&2
+    fi
+done
+
+# ── Result ─────────────────────────────────────────────────────────────────────
+if [ "${FOUND}" -gt 0 ]; then
+    echo ""
+    echo "FAIL: ${FOUND} piper artifact(s) found — see above."
+    exit 1
+fi
+
+echo "PASS: no piper artifacts found."
+exit 0

--- a/scripts/tests/test-assert-no-piper.sh
+++ b/scripts/tests/test-assert-no-piper.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# scripts/tests/test-assert-no-piper.sh
+# TDD test suite for scripts/assert-no-piper.sh
+# Run with: bash scripts/tests/test-assert-no-piper.sh
+# Exit 0 = all tests passed, non-zero = one or more failures.
+
+SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/scripts/assert-no-piper.sh"
+PASS=0
+FAIL=0
+ERRORS=()
+
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); ERRORS+=("$1"); }
+
+get_rc() {
+    set +e
+    bash "${SCRIPT}" "$@" >/dev/null 2>&1
+    _rc=$?
+    set -e
+    echo "${_rc}"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# T1: No-args exits 2 (usage error)
+# ─────────────────────────────────────────────────────────────────────────────
+rc=$(get_rc)
+if [ "${rc}" -eq 2 ]; then
+    pass "T1: no-args exits 2 (usage error)"
+else
+    fail "T1: expected exit 2 on no args, got ${rc}"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# T2: Clean directory (no piper) exits 0
+# ─────────────────────────────────────────────────────────────────────────────
+CLEAN_DIR=$(mktemp -d)
+rc=$(get_rc "${CLEAN_DIR}")
+if [ "${rc}" -eq 0 ]; then
+    pass "T2: clean directory exits 0"
+else
+    fail "T2: clean directory expected exit 0, got ${rc}"
+fi
+rm -rf "${CLEAN_DIR}"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# T3: Forbidden path /usr/local/bin/lifeos-piper detected, exits 1
+# ─────────────────────────────────────────────────────────────────────────────
+DIRTY_BIN=$(mktemp -d)
+mkdir -p "${DIRTY_BIN}/usr/local/bin"
+touch "${DIRTY_BIN}/usr/local/bin/lifeos-piper"
+rc=$(get_rc "${DIRTY_BIN}")
+if [ "${rc}" -eq 1 ]; then
+    pass "T3: forbidden path lifeos-piper exits 1"
+else
+    fail "T3: expected exit 1 for lifeos-piper path, got ${rc}"
+fi
+rm -rf "${DIRTY_BIN}"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# T4: Forbidden path /usr/share/lifeos/models/piper/ detected, exits 1
+# ─────────────────────────────────────────────────────────────────────────────
+DIRTY_MODELS=$(mktemp -d)
+mkdir -p "${DIRTY_MODELS}/usr/share/lifeos/models/piper"
+touch "${DIRTY_MODELS}/usr/share/lifeos/models/piper/es_MX-claude.onnx"
+rc=$(get_rc "${DIRTY_MODELS}")
+if [ "${rc}" -eq 1 ]; then
+    pass "T4: forbidden path piper models dir exits 1"
+else
+    fail "T4: expected exit 1 for piper models dir, got ${rc}"
+fi
+rm -rf "${DIRTY_MODELS}"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# T5: Forbidden path /opt/lifeos/piper-tts/ detected, exits 1
+# ─────────────────────────────────────────────────────────────────────────────
+DIRTY_OPT=$(mktemp -d)
+mkdir -p "${DIRTY_OPT}/opt/lifeos/piper-tts"
+touch "${DIRTY_OPT}/opt/lifeos/piper-tts/piper"
+rc=$(get_rc "${DIRTY_OPT}")
+if [ "${rc}" -eq 1 ]; then
+    pass "T5: forbidden path /opt/lifeos/piper-tts exits 1"
+else
+    fail "T5: expected exit 1 for /opt/lifeos/piper-tts, got ${rc}"
+fi
+rm -rf "${DIRTY_OPT}"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# T6: Containerfile with LIFEOS_TTS_BIN string detected, exits 1
+# ─────────────────────────────────────────────────────────────────────────────
+TMP_CF=$(mktemp --suffix=.Containerfile)
+printf 'FROM fedora:41\nENV LIFEOS_TTS_BIN=/usr/local/bin/lifeos-piper\nRUN echo ok\n' > "${TMP_CF}"
+rc=$(get_rc "${TMP_CF}")
+if [ "${rc}" -eq 1 ]; then
+    pass "T6: Containerfile with LIFEOS_TTS_BIN exits 1"
+else
+    fail "T6: expected exit 1 for LIFEOS_TTS_BIN in Containerfile, got ${rc}"
+fi
+rm -f "${TMP_CF}"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# T7: Containerfile with piper-voice-builder string detected, exits 1
+# ─────────────────────────────────────────────────────────────────────────────
+TMP_CF2=$(mktemp --suffix=.Containerfile)
+printf 'FROM fedora:41 AS piper-voice-builder\nRUN echo building piper\n' > "${TMP_CF2}"
+rc=$(get_rc "${TMP_CF2}")
+if [ "${rc}" -eq 1 ]; then
+    pass "T7: Containerfile with piper-voice-builder exits 1"
+else
+    fail "T7: expected exit 1 for piper-voice-builder in Containerfile, got ${rc}"
+fi
+rm -f "${TMP_CF2}"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# T8: Clean Containerfile exits 0
+# ─────────────────────────────────────────────────────────────────────────────
+TMP_CF3=$(mktemp --suffix=.Containerfile)
+printf 'FROM fedora:41\nRUN dnf install -y ffmpeg\nRUN echo kokoro\n' > "${TMP_CF3}"
+rc=$(get_rc "${TMP_CF3}")
+if [ "${rc}" -eq 0 ]; then
+    pass "T8: clean Containerfile exits 0"
+else
+    fail "T8: expected exit 0 for clean Containerfile, got ${rc}"
+fi
+rm -f "${TMP_CF3}"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# T9: .service file with lifeos-piper string detected, exits 1
+# ─────────────────────────────────────────────────────────────────────────────
+TMP_SVC_DIR=$(mktemp -d)
+mkdir -p "${TMP_SVC_DIR}/etc/systemd/system"
+printf '[Unit]\nDescription=test\n[Service]\nExecStart=/usr/local/bin/lifeos-piper --model /usr/share/lifeos/models/piper/es_MX-claude.onnx\n' \
+    > "${TMP_SVC_DIR}/etc/systemd/system/lifeos-piper.service"
+rc=$(get_rc "${TMP_SVC_DIR}")
+if [ "${rc}" -eq 1 ]; then
+    pass "T9: .service file with lifeos-piper exits 1"
+else
+    fail "T9: expected exit 1 for lifeos-piper in .service, got ${rc}"
+fi
+rm -rf "${TMP_SVC_DIR}"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# T10: .env file with LIFEOS_TTS_MODEL string detected, exits 1
+# ─────────────────────────────────────────────────────────────────────────────
+TMP_ENV_DIR=$(mktemp -d)
+mkdir -p "${TMP_ENV_DIR}/etc/lifeos"
+printf 'LIFEOS_TTS_MODEL=/usr/share/lifeos/models/piper/es_MX-claude.onnx\n' \
+    > "${TMP_ENV_DIR}/etc/lifeos/lifeosd.env"
+rc=$(get_rc "${TMP_ENV_DIR}")
+if [ "${rc}" -eq 1 ]; then
+    pass "T10: .env file with LIFEOS_TTS_MODEL exits 1"
+else
+    fail "T10: expected exit 1 for LIFEOS_TTS_MODEL in .env, got ${rc}"
+fi
+rm -rf "${TMP_ENV_DIR}"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# T11: Offending file path/line appears in output
+# ─────────────────────────────────────────────────────────────────────────────
+TMP_CF4=$(mktemp --suffix=.Containerfile)
+printf 'FROM fedora:41\nENV LIFEOS_TTS_BIN=/usr/local/bin/lifeos-piper\n' > "${TMP_CF4}"
+set +e
+output=$(bash "${SCRIPT}" "${TMP_CF4}" 2>&1)
+set -e
+if echo "${output}" | grep -q "LIFEOS_TTS_BIN\|lifeos-piper"; then
+    pass "T11: offending pattern appears in output"
+else
+    fail "T11: offending pattern not in output. Got: ${output}"
+fi
+rm -f "${TMP_CF4}"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# T12: Success message on clean input
+# ─────────────────────────────────────────────────────────────────────────────
+CLEAN2=$(mktemp -d)
+set +e
+output=$(bash "${SCRIPT}" "${CLEAN2}" 2>&1)
+rc=$?
+set -e
+if [ "${rc}" -eq 0 ] && echo "${output}" | grep -qi "pass\|no piper"; then
+    pass "T12: clean dir prints success message"
+else
+    fail "T12: clean dir rc=${rc}, output: ${output}"
+fi
+rm -rf "${CLEAN2}"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Summary
+# ─────────────────────────────────────────────────────────────────────────────
+TOTAL=$((PASS + FAIL))
+echo ""
+echo "Results: ${PASS}/${TOTAL} passed"
+if [ "${FAIL}" -gt 0 ]; then
+    echo "FAILED tests:"
+    for e in "${ERRORS[@]}"; do echo "  - ${e}"; done
+    exit 1
+fi
+echo "All tests passed."
+exit 0

--- a/scripts/tests/test-lifeos-tts-server.sh
+++ b/scripts/tests/test-lifeos-tts-server.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+# scripts/tests/test-lifeos-tts-server.sh
+# Shell integration tests for lifeos-tts-server.py
+#
+# Requires:
+#   - kokoro and aiohttp installed in /opt/lifeos/kokoro-env (or on PATH)
+#   - LIFEOS_TTS_SERVER_URL or defaults to http://127.0.0.1:8083
+#
+# The script starts the server (if not already running), runs assertions,
+# then stops the server it started.
+#
+# Usage:
+#   bash scripts/tests/test-lifeos-tts-server.sh
+#   LIFEOS_TTS_SERVER_URL=http://127.0.0.1:8083 bash scripts/tests/test-lifeos-tts-server.sh
+#
+# Exit 0 = all tests passed; non-zero = failures.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SERVER_SCRIPT="${REPO_ROOT}/image/files/usr/local/bin/lifeos-tts-server.py"
+SERVER_URL="${LIFEOS_TTS_SERVER_URL:-http://127.0.0.1:8083}"
+VENV_PYTHON="${LIFEOS_TTS_VENV_PYTHON:-/opt/lifeos/kokoro-env/bin/python3}"
+WAIT_TIMEOUT=60   # seconds to wait for /health to become 200
+SERVER_PID=""
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); ERRORS+=("$1"); }
+
+# ---------------------------------------------------------------------------
+# Server lifecycle helpers
+# ---------------------------------------------------------------------------
+
+start_server() {
+    local python="${VENV_PYTHON}"
+    if ! command -v "${python}" >/dev/null 2>&1; then
+        # Fallback: system python3 (may not have kokoro)
+        python="python3"
+    fi
+
+    LIFEOS_TTS_ENGINE_PORT=8083 \
+    LIFEOS_TTS_DEFAULT_VOICE=if_sara \
+    LIFEOS_TTS_DEVICE=cpu \
+    HF_HUB_OFFLINE=1 \
+    TRANSFORMERS_OFFLINE=1 \
+        "${python}" "${SERVER_SCRIPT}" &
+    SERVER_PID=$!
+    echo "Started lifeos-tts-server.py as PID ${SERVER_PID}"
+}
+
+# stop_server is invoked via trap EXIT — shellcheck can't see indirect invocations
+# shellcheck disable=SC2329
+stop_server() {
+    if [ -n "${SERVER_PID}" ] && kill -0 "${SERVER_PID}" 2>/dev/null; then
+        echo "Stopping server PID ${SERVER_PID}"
+        kill "${SERVER_PID}" 2>/dev/null || true
+        wait "${SERVER_PID}" 2>/dev/null || true
+    fi
+}
+
+wait_for_health() {
+    local elapsed=0
+    while [ "${elapsed}" -lt "${WAIT_TIMEOUT}" ]; do
+        http_code=$(curl -s -o /dev/null -w '%{http_code}' "${SERVER_URL}/health" 2>/dev/null || echo "000")
+        if [ "${http_code}" = "200" ]; then
+            echo "Server healthy after ${elapsed}s"
+            return 0
+        fi
+        sleep 2
+        elapsed=$((elapsed + 2))
+    done
+    echo "Timeout waiting for server health after ${WAIT_TIMEOUT}s"
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# Determine if server is already running or needs to be started
+# ---------------------------------------------------------------------------
+
+SERVER_STARTED_BY_US=false
+http_code=$(curl -s -o /dev/null -w '%{http_code}' "${SERVER_URL}/health" 2>/dev/null || echo "000")
+if [ "${http_code}" = "200" ]; then
+    echo "Server already running at ${SERVER_URL}"
+else
+    echo "Server not detected — starting..."
+    if [ ! -f "${SERVER_SCRIPT}" ]; then
+        echo "ERROR: server script not found at ${SERVER_SCRIPT}" >&2
+        exit 1
+    fi
+    start_server
+    # shellcheck disable=SC2034
+    SERVER_STARTED_BY_US=true
+    trap 'stop_server' EXIT
+    if ! wait_for_health; then
+        echo "ERROR: Server failed to become healthy" >&2
+        exit 1
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# T1: GET /health returns 200 + JSON with status=ok
+# ---------------------------------------------------------------------------
+response=$(curl -s -o /tmp/tts-health.json -w '%{http_code}' "${SERVER_URL}/health")
+if [ "${response}" = "200" ]; then
+    status=$(python3 -c "import json,sys; d=json.load(open('/tmp/tts-health.json')); print(d.get('status',''))" 2>/dev/null || echo "")
+    if [ "${status}" = "ok" ]; then
+        pass "T1: /health returns 200 + status=ok"
+    else
+        fail "T1: /health status not 'ok', got '${status}'"
+    fi
+else
+    fail "T1: /health HTTP ${response}, expected 200"
+fi
+
+# ---------------------------------------------------------------------------
+# T2: GET /health JSON has model=Kokoro-82M and voices_loaded>=1
+# ---------------------------------------------------------------------------
+voices_loaded=$(python3 -c "import json; d=json.load(open('/tmp/tts-health.json')); print(d.get('voices_loaded',0))" 2>/dev/null || echo "0")
+model=$(python3 -c "import json; d=json.load(open('/tmp/tts-health.json')); print(d.get('model',''))" 2>/dev/null || echo "")
+if [ "${model}" = "Kokoro-82M" ] && [ "${voices_loaded}" -ge 1 ] 2>/dev/null; then
+    pass "T2: /health has model=Kokoro-82M and voices_loaded=${voices_loaded}"
+else
+    fail "T2: /health model='${model}' voices_loaded=${voices_loaded} (want model=Kokoro-82M, voices_loaded>=1)"
+fi
+
+# ---------------------------------------------------------------------------
+# T3: GET /voices returns 200 + non-empty array
+# ---------------------------------------------------------------------------
+response=$(curl -s -o /tmp/tts-voices.json -w '%{http_code}' "${SERVER_URL}/voices")
+if [ "${response}" = "200" ]; then
+    count=$(python3 -c "import json; v=json.load(open('/tmp/tts-voices.json')); print(len(v))" 2>/dev/null || echo "0")
+    if [ "${count}" -ge 1 ] 2>/dev/null; then
+        pass "T3: /voices returns 200 + ${count} voices"
+    else
+        fail "T3: /voices returned empty array"
+    fi
+else
+    fail "T3: /voices HTTP ${response}, expected 200"
+fi
+
+# ---------------------------------------------------------------------------
+# T4: GET /voices each item has required fields
+# ---------------------------------------------------------------------------
+valid=$(python3 -c "
+import json
+data = json.load(open('/tmp/tts-voices.json'))
+required = {'name', 'language', 'gender', 'is_default'}
+bad = [v for v in data if not required.issubset(v.keys())]
+print(len(bad))
+" 2>/dev/null || echo "999")
+if [ "${valid}" = "0" ]; then
+    pass "T4: all voice entries have required fields (name, language, gender, is_default)"
+else
+    fail "T4: ${valid} voice entries missing required fields"
+fi
+
+# ---------------------------------------------------------------------------
+# T5: POST /tts with valid voice returns 200 + non-empty WAV body
+# ---------------------------------------------------------------------------
+http_code=$(curl -s -X POST \
+    -H 'Content-Type: application/json' \
+    -d '{"text":"Hola sistema, prueba de voz.","voice":"if_sara"}' \
+    -o /tmp/tts-output.wav \
+    -w '%{http_code}' \
+    "${SERVER_URL}/tts")
+if [ "${http_code}" = "200" ]; then
+    wav_size=$(wc -c < /tmp/tts-output.wav)
+    # Validate WAV header: first 4 bytes = "RIFF"
+    riff_header=$(python3 -c "
+f=open('/tmp/tts-output.wav','rb')
+h=f.read(4)
+f.close()
+print(h)
+" 2>/dev/null || echo "")
+    if [ "${wav_size}" -gt 1000 ] && echo "${riff_header}" | grep -q "RIFF"; then
+        pass "T5: POST /tts returns 200 + valid WAV (${wav_size} bytes)"
+    else
+        fail "T5: POST /tts returned ${wav_size} bytes, RIFF header check: ${riff_header}"
+    fi
+else
+    fail "T5: POST /tts HTTP ${http_code}, expected 200"
+fi
+
+# ---------------------------------------------------------------------------
+# T6: POST /tts with format=ogg returns 200 + non-empty OGG body
+# ---------------------------------------------------------------------------
+http_code=$(curl -s -X POST \
+    -H 'Content-Type: application/json' \
+    -d '{"text":"Prueba OGG Vorbis.","voice":"if_sara","format":"ogg"}' \
+    -o /tmp/tts-output.ogg \
+    -w '%{http_code}' \
+    "${SERVER_URL}/tts")
+if [ "${http_code}" = "200" ]; then
+    ogg_size=$(wc -c < /tmp/tts-output.ogg)
+    # OGG header: first 4 bytes = "OggS"
+    ogg_header=$(python3 -c "
+f=open('/tmp/tts-output.ogg','rb')
+h=f.read(4)
+f.close()
+print(h)
+" 2>/dev/null || echo "")
+    if [ "${ogg_size}" -gt 500 ] && echo "${ogg_header}" | grep -q "OggS"; then
+        pass "T6: POST /tts format=ogg returns 200 + valid OGG (${ogg_size} bytes)"
+    else
+        fail "T6: POST /tts OGG: ${ogg_size} bytes, header check: ${ogg_header}"
+    fi
+else
+    fail "T6: POST /tts format=ogg HTTP ${http_code}, expected 200"
+fi
+
+# ---------------------------------------------------------------------------
+# T7: POST /tts with unknown voice returns 400 + error=unknown_voice
+# ---------------------------------------------------------------------------
+http_code=$(curl -s -X POST \
+    -H 'Content-Type: application/json' \
+    -d '{"text":"test","voice":"nonexistent_voice_xyz_abc"}' \
+    -o /tmp/tts-bad-voice.json \
+    -w '%{http_code}' \
+    "${SERVER_URL}/tts")
+if [ "${http_code}" = "400" ]; then
+    error=$(python3 -c "import json; d=json.load(open('/tmp/tts-bad-voice.json')); print(d.get('error',''))" 2>/dev/null || echo "")
+    if [ "${error}" = "unknown_voice" ]; then
+        pass "T7: POST /tts unknown voice returns 400 + error=unknown_voice"
+    else
+        fail "T7: POST /tts unknown voice: HTTP 400 but error='${error}' (want unknown_voice)"
+    fi
+else
+    fail "T7: POST /tts unknown voice HTTP ${http_code}, expected 400"
+fi
+
+# ---------------------------------------------------------------------------
+# T8: POST /tts with empty text returns 400
+# ---------------------------------------------------------------------------
+http_code=$(curl -s -X POST \
+    -H 'Content-Type: application/json' \
+    -d '{"text":"","voice":"if_sara"}' \
+    -o /tmp/tts-empty-text.json \
+    -w '%{http_code}' \
+    "${SERVER_URL}/tts")
+if [ "${http_code}" = "400" ]; then
+    pass "T8: POST /tts empty text returns 400"
+else
+    fail "T8: POST /tts empty text HTTP ${http_code}, expected 400"
+fi
+
+# ---------------------------------------------------------------------------
+# T9: GET /health before warm-up returns 503 (verified indirectly via timing)
+# Note: We cannot easily restart server mid-test, so we verify the /health
+# endpoint DOES return the warming_up structure when status != ok.
+# ---------------------------------------------------------------------------
+# This is a structural check: the /health response JSON must have the right keys
+has_model=$(python3 -c "import json; d=json.load(open('/tmp/tts-health.json')); print('model' in d)" 2>/dev/null || echo "False")
+if [ "${has_model}" = "True" ]; then
+    pass "T9: /health JSON includes 'model' field (structure check)"
+else
+    fail "T9: /health JSON missing 'model' field"
+fi
+
+# ---------------------------------------------------------------------------
+# Cleanup temp files
+# ---------------------------------------------------------------------------
+rm -f /tmp/tts-health.json /tmp/tts-voices.json /tmp/tts-output.wav /tmp/tts-output.ogg \
+       /tmp/tts-bad-voice.json /tmp/tts-empty-text.json
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+TOTAL=$((PASS + FAIL))
+echo ""
+echo "Results: ${PASS}/${TOTAL} passed"
+if [ "${FAIL}" -gt 0 ]; then
+    echo "FAILED tests:"
+    for e in "${ERRORS[@]}"; do echo "  - ${e}"; done
+    exit 1
+fi
+echo "All tests passed."
+exit 0

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -402,3 +402,51 @@ fn test_phase2_model_catalog_exists_and_has_signature() {
 // v0.4.1: llm_debate + matrix_bridge unit tests are inline in their modules.
 // v0.4.2: simplex_bridge unit tests are inline in the module.
 // (unit test that doesn't require the compiled binary).
+
+// ─────────────────────────────────────────────────────────────────────────────
+// v0.7.0: Piper TTS removal guard (migrate-tts-to-kokoro, Batch C)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// C5: Verify scripts/assert-no-piper.sh exists and is executable.
+/// Mirrors test_assert_no_dev_artifacts_script_exists_and_is_executable.
+#[test]
+fn test_assert_no_piper_script_exists_and_is_executable() {
+    let script = project_root().join("scripts/assert-no-piper.sh");
+    assert!(
+        script.exists(),
+        "scripts/assert-no-piper.sh must exist at repo root (task C2)"
+    );
+    let metadata = std::fs::metadata(&script).expect("could not stat assert-no-piper.sh");
+    use std::os::unix::fs::PermissionsExt;
+    let mode = metadata.permissions().mode();
+    assert!(
+        mode & 0o111 != 0,
+        "scripts/assert-no-piper.sh must be executable (chmod +x)"
+    );
+}
+
+/// C6: Compile-time regression guard — asserts that synthesize_with_piper has
+/// been removed from daemon/src/sensory_pipeline.rs after Agent 3 (Batch D)
+/// completes the Rust daemon refactor.
+///
+/// NOTE: This test WILL FAIL until Agent 3 removes synthesize_with_piper
+/// (task D5). Mark as known-failing until D5 is complete.
+/// After D5: this test must pass and must never be removed.
+#[test]
+fn test_sensory_pipeline_has_no_piper_synthesizer() {
+    let source_path = project_root().join("daemon/src/sensory_pipeline.rs");
+    assert!(
+        source_path.exists(),
+        "daemon/src/sensory_pipeline.rs must exist"
+    );
+
+    let content = std::fs::read_to_string(&source_path)
+        .expect("could not read daemon/src/sensory_pipeline.rs");
+
+    assert!(
+        !content.contains("synthesize_with_piper"),
+        "daemon/src/sensory_pipeline.rs must NOT contain 'synthesize_with_piper' \
+        after migrate-tts-to-kokoro (task D5). Remove the Piper synthesizer \
+        function and all call sites before merging v0.7.0."
+    );
+}


### PR DESCRIPTION
## Summary
- Replace Piper TTS with Kokoro-82M server (127.0.0.1:8083) across direct voice, SimpleX voice notes, and dashboard
- Add global per-user voice selector + persisted preference via `UserModel.tts_voice`
- Remove Piper completely from image, daemon, CLI; add `assert-no-piper` CI guard
- Three independent audit passes + fixes to ensure production readiness

## Key changes
- **daemon**: Kokoro HTTP integration in `sensory_pipeline`, split probe/synth reqwest singletons, `should_probe` throttle helper, `validate_tts_voice` on PATCH /user/preferences
- **SimpleX bridge**: voice-note replies (OGG, ≤600 chars, ≤1 MB, 60s cleanup) with correct path guard
- **dashboard**: Kokoro voices dropdown + diagnostic row, loads persisted voice from `/user/profile`
- **image**: `lifeos-tts-server.service` with full hardening (ProtectSystem, PrivateTmp, PrivateDevices, IPAddressAllow/Deny), Kokoro env at `/opt/lifeos/kokoro-env/`
- **tests**: 16+ new unit tests, 642/643 passing suite (1 pre-existing unrelated failure)

## Test plan
- [x] `cargo test -p lifeosd --all-features` passes (642/643; home_assistant test pre-existed)
- [x] `cargo clippy` clean with CI feature set (`dbus,http-api,ui-overlay,wake-word,messaging`)
- [x] Three independent fresh audits confirm SHIP-READY
- [ ] CI workflows green on this PR
- [ ] Manual verification on deploy: TTS direct voice, SimpleX voice note, dashboard voice selector