### PR TITLE
fix(ci): strip containers-storage prefix in assert-no-dev-artifacts

### DIFF
--- a/scripts/assert-no-dev-artifacts.sh
+++ b/scripts/assert-no-dev-artifacts.sh
@@ -131,6 +131,11 @@ check_oci_image() {
     local offenders=()
     local rc=0
 
+    # Strip the `containers-storage:` transport prefix if present — podman
+    # run does its own storage lookup and chokes on the explicit prefix when
+    # the name is unqualified (it gets re-resolved as docker.io/library/<name>).
+    local podman_ref="${image_ref#containers-storage:}"
+
     # Build a bash probe that prints `found:<path>` for each forbidden path
     # that exists inside the image. Unknown-size arrays are safe here because
     # FORBIDDEN_PATHS is a fixed readonly list defined above.
@@ -141,7 +146,7 @@ check_oci_image() {
     probe+="true"
 
     local probe_out
-    if ! probe_out=$(podman run --rm --entrypoint /bin/bash "${image_ref}" -lc "${probe}" 2>&1); then
+    if ! probe_out=$(podman run --rm --entrypoint /bin/bash "${podman_ref}" -lc "${probe}" 2>&1); then
         echo "ERROR: could not run probe inside image: ${image_ref}" >&2
         echo "${probe_out}" >&2
         return 2


### PR DESCRIPTION
## Summary
PR #21's podman-run-based approach was correct BUT the workflow passes \`containers-storage:lifeos-release:<sha>\` (with explicit transport prefix). \`podman run\` chokes on that because the unqualified name gets re-resolved as \`docker.io/library/lifeos-release\`.

## Fix
Strip the \`containers-storage:\` prefix in the script so \`podman run\` falls back to its default storage lookup — same path the earlier NVIDIA-signing \`podman run\` step uses in the same workflow and works.

## Test plan
- [x] 8/8 filesystem-mode tests pass
- [ ] Re-run Release Channels on main after merge