### PR TITLE
feat(nvidia): switch driver source to lifeos-nvidia-drivers (595.58.03)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2591,7 +2591,7 @@ dependencies = [
 
 [[package]]
 name = "life"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2617,7 +2617,7 @@ dependencies = [
 
 [[package]]
 name = "lifeos-integration-tests"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "life",
  "serde_json",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "lifeosd"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.0"
+version = "0.8.1"
 
 [workspace.metadata.lifeos]
 codename = "Axolotl"

--- a/docs/architecture/ai-runtime.md
+++ b/docs/architecture/ai-runtime.md
@@ -845,7 +845,7 @@ RUN dnf -y install cargo gcc ... && cargo build --release
 FROM quay.io/fedora/fedora-bootc:42
 RUN dnf -y install cosmic-desktop ...
 # + llama-server (binario pre-compilado o compilado desde fuente)
-# + Nvidia drivers (akmod-nvidia, supergfxctl)
+# + Nvidia drivers (lifeos-nvidia-drivers OCI image + supergfxctl)
 # + Herramientas del sistema (toolbox, podman, fish, bat, ripgrep...)
 COPY --from=builder life lifeosd  # Binarios Rust compilados
 ```
@@ -2251,7 +2251,12 @@ RUN dnf -y install cosmic-desktop cosmic-files cosmic-terminal \
     NetworkManager bluez pipewire wireplumber && dnf clean all
 
 # --- Nvidia Optimus (GPU hibrida) ---
-RUN dnf -y install akmod-nvidia xorg-x11-drv-nvidia-cuda supergfxctl && dnf clean all
+# NVIDIA driver RPMs provienen de hectormr206/lifeos-nvidia-drivers
+# (Production Branch, Blackwell-ready, actualizado semanalmente).
+FROM ghcr.io/hectormr206/lifeos-nvidia-drivers:latest-f43-x86_64 AS nvidia-rpms
+# (en stage final)
+RUN --mount=type=bind,from=nvidia-rpms,source=/,target=/mnt/nvidia-rpms,ro \
+    dnf -y install /mnt/nvidia-rpms/*.rpm supergfxctl && dnf clean all
 
 # --- Steam/Proton (default via RPM Fusion) ---
 RUN dnf -y install steam steam-devices && dnf clean all

--- a/image/Containerfile
+++ b/image/Containerfile
@@ -36,7 +36,7 @@ ARG LIFEOS_PRELOAD_MODEL=false
 #                        nvidia-persistenced enabled. Backwards
 #                        compatible with the pre-split build.
 #   "amd"             — lean image for AMD / Intel / ARM hosts.
-#                       Skips the nvidia-kmod-builder stage inputs,
+#                       Skips the nvidia-rpms stage inputs,
 #                       skips nvidia-persistenced enablement, and
 #                       does not install the NVIDIA userspace packages.
 #                       (Full skip wiring is tracked as follow-up; this
@@ -287,46 +287,18 @@ RUN set -eux && \
     dnf clean all
 
 # ============================================================================
-# Stage 6a: Pre-build NVIDIA kernel modules (isolated — pattern from UBlue)
+# Stage 6a: NVIDIA driver RPMs from lifeos-nvidia-drivers upstream
 # ============================================================================
-# This stage compiles NVIDIA akmods against the exact kernel in fedora-bootc.
-# Pre-built RPMs are COPYed into the final stage, keeping the main build fast
-# and cacheable when only non-kernel layers change.
-FROM quay.io/fedora/fedora-bootc:${FEDORA_MAJOR} AS nvidia-kmod-builder
-
-RUN dnf -y install dnf5-plugins && \
-    dnf -y install distribution-gpg-keys && \
-    rpm --import \
-      /usr/share/distribution-gpg-keys/rpmfusion/RPM-GPG-KEY-rpmfusion-free-fedora-2020 \
-      /usr/share/distribution-gpg-keys/rpmfusion/RPM-GPG-KEY-rpmfusion-nonfree-fedora-2020 && \
-    dnf -y --setopt=localpkg_gpgcheck=1 install \
-      "https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm" \
-      "https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm" && \
-    dnf -y install \
-        kernel-devel akmod-nvidia xorg-x11-drv-nvidia-cuda \
-        xorg-x11-drv-nvidia-power nvidia-settings nvidia-modprobe \
-        akmods gcc && \
-    if dnf -q repoquery --available --qf '%{name}' akmod-wl 2>/dev/null | grep -Fxq akmod-wl; then \
-        dnf -y install broadcom-wl akmod-wl; \
-    fi && \
-    for modules_dir in /usr/lib/modules/*; do \
-        [ -d "${modules_dir}" ] || continue; \
-        kernel_ver="$(basename "${modules_dir}")"; \
-        if [ ! -d "/usr/src/kernels/${kernel_ver}" ]; then \
-            echo "WARNING: kernel-devel missing for ${kernel_ver}; skipping"; \
-            continue; \
-        fi; \
-        akmods --force --kernels "${kernel_ver}" || \
-            echo "WARNING: akmods failed for ${kernel_ver}"; \
-    done && \
-    NVIDIA_FOUND=0; \
-    for d in /usr/lib/modules/*/extra/nvidia/nvidia.ko; do \
-        [ -f "$d" ] && NVIDIA_FOUND=1 && break; \
-    done; \
-    if [ "$NVIDIA_FOUND" -eq 0 ]; then \
-        echo "WARNING: No nvidia.ko modules found after akmods build (expected in CI without GPU headers)"; \
-    fi && \
-    dnf clean all
+# Pre-built NVIDIA proprietary driver RPMs (Production Branch — currently
+# 595.58.03, Blackwell-ready), packaged by hectormr206/lifeos-nvidia-drivers
+# via GitHub Actions mock builds. Replaces the previous RPMFusion akmod-nvidia
+# compile stage which lagged 1-2 NVIDIA branches behind upstream.
+#
+# Includes: nvidia-driver, nvidia-kmod (pre-compiled .ko for Fedora's shipping
+# kernel), nvidia-kmod-common, nvidia-modprobe, nvidia-settings,
+# nvidia-persistenced, nvidia-driver-selinux, nvidia-container-toolkit,
+# libnvidia-container.
+FROM ghcr.io/hectormr206/lifeos-nvidia-drivers:latest-f43-x86_64 AS nvidia-rpms
 
 # ============================================================================
 # Stage 6: Sistema Final
@@ -388,13 +360,18 @@ RUN dnf -y install --skip-unavailable \
     fwupd \
     && dnf clean all
 
-# --- Soporte Nvidia Optimus (pre-built kmods from Stage 6a) ---
-# Install NVIDIA userspace packages, then COPY the pre-compiled kernel
-# modules from the nvidia-kmod-builder stage. This avoids compiling
-# akmods in the final image and makes the build cacheable.
-RUN dnf -y install --skip-unavailable \
-        xorg-x11-drv-nvidia-cuda xorg-x11-drv-nvidia-power \
-        nvidia-settings nvidia-modprobe && \
+# --- NVIDIA driver (userspace + pre-built kmods) from nvidia-rpms ---
+# All NVIDIA packages come from the lifeos-nvidia-drivers upstream image —
+# a Bazzite-pattern fork pinned to the NVIDIA Production Branch. The kernel
+# modules are pre-compiled against Fedora's shipping kernel inside the
+# nvidia-rpms build pipeline.
+#
+# supergfxctl (Optimus hybrid-switch helper) still comes from RPMFusion.
+# akmod-wl / broadcom-wl (Broadcom proprietary WiFi) still comes from RPMFusion.
+# kernel-devel is installed temporarily for module signing below, then removed.
+RUN --mount=type=bind,from=nvidia-rpms,source=/,target=/mnt/nvidia-rpms,ro \
+    dnf -y install /mnt/nvidia-rpms/*.rpm && \
+    dnf -y install kernel-devel && \
     if dnf -q repoquery --available --qf '%{name}' supergfxctl 2>/dev/null | grep -Fxq supergfxctl; then \
         dnf -y install supergfxctl; \
     else \
@@ -406,10 +383,6 @@ RUN dnf -y install --skip-unavailable \
         echo "INFO: broadcom-wl/akmod-wl not available; continuing without Broadcom proprietary module"; \
     fi && \
     dnf clean all
-
-# Copy pre-built NVIDIA kernel modules and kernel-devel headers (for Secure Boot signing) from the builder stage.
-COPY --from=nvidia-kmod-builder /usr/lib/modules/ /usr/lib/modules/
-COPY --from=nvidia-kmod-builder /usr/src/kernels/ /usr/src/kernels/
 
 # Regenerate module dependency maps for every kernel present.
 RUN for modules_dir in /usr/lib/modules/*; do \


### PR DESCRIPTION
## Summary

Migrate NVIDIA driver source from RPMFusion `akmod-nvidia` (lagged at 580.126.18, unsigned in current image 0.8.0) to a pre-built OCI image: [`hectormr206/lifeos-nvidia-drivers`](https://github.com/hectormr206/lifeos-nvidia-drivers) pinned to **595.58.03 Production Branch**.

- New repo replicates the Bazzite pattern (Fedora mock → RPMs → flat OCI image).
- Weekly cron rebuild in the new repo picks up new Fedora kernels so kmods stay current.
- LifeOS Containerfile stage 6a is now a single `FROM ghcr.io/hectormr206/lifeos-nvidia-drivers:latest-f43-x86_64`.
- Signing block (MOK `LifeOS NVIDIA Kmod Secure Boot`) is **unchanged** and still signs the shipped `.ko`s.
- Fixes the GPU breakage observed on LifeOS 0.8.0 (unsigned nvidia.ko → Secure Boot blocked load).

## Why now

- Hector has an RTX 5070 Ti Mobile (Blackwell GB205M) — he wants the latest driver for new games.
- RPMFusion lags; Bazzite ships 590-595; our own pipeline lets us follow upstream.

## Changes

- \`image/Containerfile\`: stage 6a refactor (-27 net lines); final stage uses \`--mount=type=bind,from=nvidia-rpms\` + \`dnf install /mnt/nvidia-rpms/*.rpm\`. Signing & depmod logic untouched.
- \`docs/architecture/ai-runtime.md\`: 2 live pseudocode examples updated (historical evidence at L1147 intentionally untouched).
- \`Cargo.toml\` / \`Cargo.lock\`: version bump 0.8.0 → 0.8.1.

## Test plan

- [ ] CI green (LifeOS image build against ghcr.io/hectormr206/lifeos-nvidia-drivers:latest-f43-x86_64)
- [ ] After deploy: \`nvidia-smi -L\` succeeds on Hector's laptop
- [ ] \`modinfo nvidia | grep signer\` shows \`LifeOS NVIDIA Kmod Secure Boot\`
- [ ] Driver version reported: 595.58.03