### PR TITLE
fix(image): COPY nvidia-rpms instead of bind-mount (CI regression since #28)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2591,7 +2591,7 @@ dependencies = [
 
 [[package]]
 name = "life"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2617,7 +2617,7 @@ dependencies = [
 
 [[package]]
 name = "lifeos-integration-tests"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "life",
  "serde_json",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "lifeosd"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.1"
+version = "0.8.2"
 
 [workspace.metadata.lifeos]
 codename = "Axolotl"

--- a/docs/operations/nvidia-secure-boot.md
+++ b/docs/operations/nvidia-secure-boot.md
@@ -103,3 +103,16 @@ life status
 
 If `nvidia.ko signer` is empty, the image was built without module signing and must be rebuilt with signing secrets.
 If `LifeOS MOK cert` is missing, the image did not include signing cert material and `enroll` cannot fix it; pull/update to a signed image build first.
+
+## Driver source: lifeos-nvidia-drivers (since v0.8.0)
+
+NVIDIA driver RPMs ship from the upstream [`lifeos-nvidia-drivers`](https://github.com/hectormr206/lifeos-nvidia-drivers) image (Production Branch, currently 595.58.03), pulled in as the `nvidia-rpms` stage and consumed via `COPY --from=nvidia-rpms / /tmp/nvidia-rpms/` in `image/Containerfile`.
+
+Two upstream packages are intentionally excluded from the install set:
+
+- `libnvidia-container*`
+- `nvidia-container-toolkit*`
+
+These exist for GPU-in-container workloads (`podman --gpus`, `nvidia-ctk`) which LifeOS does not use — `llama-server` runs natively against the kernel module. Including them fails on plain `fedora-bootc` because they pull `libseccomp2`, a Bazzite/uBlue compat shim absent from the upstream Fedora base.
+
+If a future feature genuinely needs GPU-in-container, revisit the exclusion in the same `RUN` block and either ship a `libseccomp2` compat package in the LifeOS image, or request the upstream `lifeos-nvidia-drivers` build to drop the `libseccomp2` dependency for the `fedora-bootc` flavor.

--- a/image/Containerfile
+++ b/image/Containerfile
@@ -383,7 +383,7 @@ RUN find /tmp/nvidia-rpms -maxdepth 1 -name '*.rpm' \
         ! -name 'libnvidia-container*' \
         -print0 | xargs -0 dnf -y install && \
     rm -rf /tmp/nvidia-rpms && \
-    dnf -y install kernel-devel && \
+    dnf -y install kernel-devel akmods gcc && \
     if dnf -q repoquery --available --qf '%{name}' supergfxctl 2>/dev/null | grep -Fxq supergfxctl; then \
         dnf -y install supergfxctl; \
     else \
@@ -395,6 +395,33 @@ RUN find /tmp/nvidia-rpms -maxdepth 1 -name '*.rpm' \
         echo "INFO: broadcom-wl/akmod-wl not available; continuing without Broadcom proprietary module"; \
     fi && \
     dnf clean all
+
+# Compile NVIDIA kernel modules against the kernel(s) shipped in this image.
+# The lifeos-nvidia-drivers upstream installs akmod source (akmod-nvidia /
+# kmod-nvidia source RPMs), not pre-built `.ko` files. akmods turns the source
+# into kmod-nvidia-<kernel>.rpm and lays the modules under
+# /usr/lib/modules/<kernel>/extra/nvidia/ where the signing step finds them.
+# This mirrors what produced the verified working stack on the dev laptop
+# (NVRM 595.58.03, akmods@buildkitsandbox signature).
+RUN NVIDIA_BUILT=0 && \
+    for modules_dir in /usr/lib/modules/*; do \
+        [ -d "${modules_dir}" ] || continue; \
+        kernel_ver="$(basename "${modules_dir}")"; \
+        if [ ! -d "/usr/src/kernels/${kernel_ver}" ]; then \
+            echo "WARNING: kernel-devel missing for ${kernel_ver}; skipping akmods"; \
+            continue; \
+        fi; \
+        echo "INFO: building NVIDIA kmod for ${kernel_ver}"; \
+        akmods --force --kernels "${kernel_ver}"; \
+        if [ -f "${modules_dir}/extra/nvidia/nvidia.ko" ]; then \
+            NVIDIA_BUILT=$((NVIDIA_BUILT + 1)); \
+        fi; \
+    done && \
+    if [ "${NVIDIA_BUILT}" -eq 0 ]; then \
+        echo "ERROR: akmods produced no nvidia.ko for any kernel in /usr/lib/modules/"; \
+        exit 1; \
+    fi && \
+    echo "INFO: akmods built nvidia.ko for ${NVIDIA_BUILT} kernel(s)"
 
 # Regenerate module dependency maps for every kernel present.
 RUN for modules_dir in /usr/lib/modules/*; do \

--- a/image/Containerfile
+++ b/image/Containerfile
@@ -383,7 +383,7 @@ RUN find /tmp/nvidia-rpms -maxdepth 1 -name '*.rpm' \
         ! -name 'libnvidia-container*' \
         -print0 | xargs -0 dnf -y install && \
     rm -rf /tmp/nvidia-rpms && \
-    dnf -y install kernel-devel akmods gcc && \
+    dnf -y install kernel-devel akmods gcc gcc-c++ kmodtool elfutils-libelf-devel && \
     if dnf -q repoquery --available --qf '%{name}' supergfxctl 2>/dev/null | grep -Fxq supergfxctl; then \
         dnf -y install supergfxctl; \
     else \
@@ -403,22 +403,36 @@ RUN find /tmp/nvidia-rpms -maxdepth 1 -name '*.rpm' \
 # /usr/lib/modules/<kernel>/extra/nvidia/ where the signing step finds them.
 # This mirrors what produced the verified working stack on the dev laptop
 # (NVRM 595.58.03, akmods@buildkitsandbox signature).
-RUN NVIDIA_BUILT=0 && \
+RUN echo "=== akmods registered sources ===" && \
+    ls -la /usr/src/akmods/ 2>&1 | head -10 && \
+    echo "=== kernels present ===" && \
+    ls -la /usr/lib/modules/ 2>&1 | head -10 && \
+    NVIDIA_BUILT=0; \
     for modules_dir in /usr/lib/modules/*; do \
         [ -d "${modules_dir}" ] || continue; \
         kernel_ver="$(basename "${modules_dir}")"; \
         if [ ! -d "/usr/src/kernels/${kernel_ver}" ]; then \
-            echo "WARNING: kernel-devel missing for ${kernel_ver}; skipping akmods"; \
+            echo "WARNING: kernel-devel missing for ${kernel_ver}; skipping"; \
             continue; \
         fi; \
-        echo "INFO: building NVIDIA kmod for ${kernel_ver}"; \
-        akmods --force --kernels "${kernel_ver}"; \
+        echo "=== building NVIDIA kmod for ${kernel_ver} ==="; \
+        if ! akmods --force --kernels "${kernel_ver}" --akmod nvidia; then \
+            echo "ERROR: akmods --akmod nvidia failed for ${kernel_ver}"; \
+            echo "--- akmods log dump ---"; \
+            find /var/cache/akmods -type f -name '*.log' -exec sh -c 'echo "=== $1 ==="; cat "$1"' _ {} \; 2>&1 | tail -200; \
+            exit 1; \
+        fi; \
         if [ -f "${modules_dir}/extra/nvidia/nvidia.ko" ]; then \
             NVIDIA_BUILT=$((NVIDIA_BUILT + 1)); \
+            echo "INFO: nvidia.ko present at ${modules_dir}/extra/nvidia/"; \
+        else \
+            echo "WARNING: akmods exited 0 but nvidia.ko missing under ${modules_dir}/extra/nvidia/"; \
+            ls -la "${modules_dir}/extra/" 2>&1 | head; \
         fi; \
     done && \
     if [ "${NVIDIA_BUILT}" -eq 0 ]; then \
         echo "ERROR: akmods produced no nvidia.ko for any kernel in /usr/lib/modules/"; \
+        find /var/cache/akmods -type f -name '*.log' -exec sh -c 'echo "=== $1 ==="; cat "$1"' _ {} \; 2>&1 | tail -200; \
         exit 1; \
     fi && \
     echo "INFO: akmods built nvidia.ko for ${NVIDIA_BUILT} kernel(s)"

--- a/image/Containerfile
+++ b/image/Containerfile
@@ -403,11 +403,7 @@ RUN find /tmp/nvidia-rpms -maxdepth 1 -name '*.rpm' \
 # /usr/lib/modules/<kernel>/extra/nvidia/ where the signing step finds them.
 # This mirrors what produced the verified working stack on the dev laptop
 # (NVRM 595.58.03, akmods@buildkitsandbox signature).
-RUN echo "=== akmods registered sources ===" && \
-    ls -la /usr/src/akmods/ 2>&1 | head -10 && \
-    echo "=== kernels present ===" && \
-    ls -la /usr/lib/modules/ 2>&1 | head -10 && \
-    NVIDIA_BUILT=0; \
+RUN NVIDIA_BUILT=0; \
     for modules_dir in /usr/lib/modules/*; do \
         [ -d "${modules_dir}" ] || continue; \
         kernel_ver="$(basename "${modules_dir}")"; \
@@ -418,24 +414,39 @@ RUN echo "=== akmods registered sources ===" && \
         echo "=== building NVIDIA kmod for ${kernel_ver} ==="; \
         if ! akmods --force --kernels "${kernel_ver}" --akmod nvidia; then \
             echo "ERROR: akmods --akmod nvidia failed for ${kernel_ver}"; \
-            echo "--- akmods log dump ---"; \
-            find /var/cache/akmods -type f -name '*.log' -exec sh -c 'echo "=== $1 ==="; cat "$1"' _ {} \; 2>&1 | tail -200; \
+            find /var/cache/akmods -type f -name '*.log' -exec sh -c 'echo "=== $1 ==="; cat "$1"' _ {} \; 2>&1 | tail -100; \
             exit 1; \
         fi; \
+        # akmods builds an RPM but does not install it. Find and install the
+        # kmod-nvidia-<ver>-<kernel>.rpm it produced under /var/cache/akmods/.
+        BUILT_RPM="$(find /var/cache/akmods/nvidia -maxdepth 2 -type f \
+            -name "kmod-nvidia-*${kernel_ver}*.rpm" | head -1)"; \
+        if [ -z "${BUILT_RPM}" ]; then \
+            echo "ERROR: akmods reported success but produced no RPM for ${kernel_ver}"; \
+            find /var/cache/akmods -type f 2>&1 | head -20; \
+            exit 1; \
+        fi; \
+        echo "INFO: installing ${BUILT_RPM}"; \
+        dnf -y install "${BUILT_RPM}"; \
+        # Modules ship as .ko.xz from the RPM (Fedora default). Decompress in
+        # place so the secure-boot signing step (which globs *.ko) can sign
+        # them; sign-file does not handle xz wrappers.
+        find "${modules_dir}/extra/nvidia" -type f -name '*.ko.xz' \
+            -exec xz --decompress --force {} \; 2>/dev/null || true; \
         if [ -f "${modules_dir}/extra/nvidia/nvidia.ko" ]; then \
             NVIDIA_BUILT=$((NVIDIA_BUILT + 1)); \
-            echo "INFO: nvidia.ko present at ${modules_dir}/extra/nvidia/"; \
+            echo "INFO: nvidia.ko ready at ${modules_dir}/extra/nvidia/"; \
         else \
-            echo "WARNING: akmods exited 0 but nvidia.ko missing under ${modules_dir}/extra/nvidia/"; \
-            ls -la "${modules_dir}/extra/" 2>&1 | head; \
+            echo "ERROR: nvidia.ko still missing after install + decompress"; \
+            ls -la "${modules_dir}/extra/nvidia/" 2>&1 | head; \
+            exit 1; \
         fi; \
     done && \
     if [ "${NVIDIA_BUILT}" -eq 0 ]; then \
-        echo "ERROR: akmods produced no nvidia.ko for any kernel in /usr/lib/modules/"; \
-        find /var/cache/akmods -type f -name '*.log' -exec sh -c 'echo "=== $1 ==="; cat "$1"' _ {} \; 2>&1 | tail -200; \
+        echo "ERROR: no nvidia.ko produced for any kernel in /usr/lib/modules/"; \
         exit 1; \
     fi && \
-    echo "INFO: akmods built nvidia.ko for ${NVIDIA_BUILT} kernel(s)"
+    echo "INFO: nvidia.ko ready for ${NVIDIA_BUILT} kernel(s)"
 
 # Regenerate module dependency maps for every kernel present.
 RUN for modules_dir in /usr/lib/modules/*; do \

--- a/image/Containerfile
+++ b/image/Containerfile
@@ -369,8 +369,13 @@ RUN dnf -y install --skip-unavailable \
 # supergfxctl (Optimus hybrid-switch helper) still comes from RPMFusion.
 # akmod-wl / broadcom-wl (Broadcom proprietary WiFi) still comes from RPMFusion.
 # kernel-devel is installed temporarily for module signing below, then removed.
-RUN --mount=type=bind,from=nvidia-rpms,source=/,target=/mnt/nvidia-rpms,ro \
-    dnf -y install /mnt/nvidia-rpms/*.rpm && \
+# Stage `nvidia-rpms` is built `FROM scratch` upstream and contains only RPM
+# blobs at `/` — no shell, no `/mnt`, no filesystem layout. `RUN --mount=type=bind`
+# fails against scratch stages in rootless buildah ("openat2 mnt: No such file
+# or directory"), so we COPY the RPMs into a temp dir, install, then remove.
+COPY --from=nvidia-rpms / /tmp/nvidia-rpms/
+RUN dnf -y install /tmp/nvidia-rpms/*.rpm && \
+    rm -rf /tmp/nvidia-rpms && \
     dnf -y install kernel-devel && \
     if dnf -q repoquery --available --qf '%{name}' supergfxctl 2>/dev/null | grep -Fxq supergfxctl; then \
         dnf -y install supergfxctl; \

--- a/image/Containerfile
+++ b/image/Containerfile
@@ -374,7 +374,14 @@ RUN dnf -y install --skip-unavailable \
 # fails against scratch stages in rootless buildah ("openat2 mnt: No such file
 # or directory"), so we COPY the RPMs into a temp dir, install, then remove.
 COPY --from=nvidia-rpms / /tmp/nvidia-rpms/
-RUN dnf -y install /tmp/nvidia-rpms/*.rpm && \
+# Skip nvidia-container-toolkit + libnvidia-container — they target Bazzite/uBlue
+# bases (require `libseccomp2` compat shim that fedora-bootc doesn't ship) and
+# enable GPU-in-container workloads that LifeOS does not use (llama-server runs
+# natively, not under podman/docker --gpus). Install everything else.
+RUN find /tmp/nvidia-rpms -maxdepth 1 -name '*.rpm' \
+        ! -name 'nvidia-container-toolkit*' \
+        ! -name 'libnvidia-container*' \
+        -print0 | xargs -0 dnf -y install && \
     rm -rf /tmp/nvidia-rpms && \
     dnf -y install kernel-devel && \
     if dnf -q repoquery --available --qf '%{name}' supergfxctl 2>/dev/null | grep -Fxq supergfxctl; then \


### PR DESCRIPTION
## Summary

- Nightly + Release Channels CI broken since #28 (f802e5a, 2026-04-19) with `creating /mnt/nvidia-rpms: openat2 mnt: No such file or directory` in the container build.
- Root cause: the upstream `lifeos-nvidia-drivers` image is built `FROM scratch` (see [oci.sh](https://github.com/hectormr206/lifeos-nvidia-drivers/blob/master/oci.sh) — `buildah from scratch` + RPMs copied to root). It has no `/mnt`, no shell, no filesystem layout. `RUN --mount=type=bind` against scratch stages fails in rootless buildah / GitHub-hosted runners.
- Fix: switch to `COPY --from=nvidia-rpms / /tmp/nvidia-rpms/`, install, then `rm -rf`. Same effective result, no buildah scratch-stage edge case.
- Bumps version 0.8.1 → 0.8.2.

## Why this approach
`COPY --from=` is the canonical way to consume `FROM scratch` artifact stages and is what the previous `nvidia-kmod-builder` flow used. The `--mount=type=bind` pattern only works when the source stage is a real filesystem image. Two days of failing nightly + release runs is enough evidence.

## Test plan
- [ ] CI green on this PR (Docker Build, Nightly Tests, E2E Tests, Release Channels on merge)
- [ ] After merge: VPS skopeo cron mirrors new `edge` tag → `10.66.66.1:5001/lifeos:edge` within 2h
- [ ] Laptop bootc upgrade picks up 0.8.2