### PR TITLE
fix(security): mcp_server hardening — gate clipboard + a11y, allowlist app launch (PR 1/3 of P1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2591,7 +2591,7 @@ dependencies = [
 
 [[package]]
 name = "life"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2617,7 +2617,7 @@ dependencies = [
 
 [[package]]
 name = "lifeos-integration-tests"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "life",
  "serde_json",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "lifeosd"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.2"
+version = "0.8.3"
 
 [workspace.metadata.lifeos]
 codename = "Axolotl"

--- a/daemon/src/mcp_server.rs
+++ b/daemon/src/mcp_server.rs
@@ -378,8 +378,7 @@ pub async fn call_tool(
                 std::path::PathBuf::from(&home).join(".local/share/applications"),
                 std::path::PathBuf::from("/var/lib/flatpak/exports/share/applications"),
             ];
-            let mut names: std::collections::BTreeSet<String> =
-                std::collections::BTreeSet::new();
+            let mut names: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
             for dir in &dirs {
                 let Ok(entries) = std::fs::read_dir(dir) else {
                     continue;
@@ -1219,7 +1218,9 @@ pub async fn call_tool(
         "lifeos_a11y_find" => {
             if !a11y_enabled() {
                 log::warn!("[mcp_server] lifeos_a11y_find blocked — set LIFEOS_MCP_A11Y_ENABLE=1 to opt in");
-                return Err("lifeos_a11y_find is disabled. Set LIFEOS_MCP_A11Y_ENABLE=1 to opt in.".into());
+                return Err(
+                    "lifeos_a11y_find is disabled. Set LIFEOS_MCP_A11Y_ENABLE=1 to opt in.".into(),
+                );
             }
             log::warn!("[mcp_server] lifeos_a11y_find EXEC (opt-in)");
             let app = arguments
@@ -1587,8 +1588,7 @@ mod tests {
     async fn clipboard_get_blocked_by_default() {
         // Ensure the gate is off (some other test may have toggled it).
         std::env::remove_var("LIFEOS_MCP_CLIPBOARD_ENABLE");
-        let result =
-            call_tool("lifeos_clipboard_get", &serde_json::json!({}), None).await;
+        let result = call_tool("lifeos_clipboard_get", &serde_json::json!({}), None).await;
         let err = result.expect_err("clipboard_get must be gated by default");
         assert!(
             err.contains("LIFEOS_MCP_CLIPBOARD_ENABLE"),

--- a/daemon/src/mcp_server.rs
+++ b/daemon/src/mcp_server.rs
@@ -18,6 +18,63 @@
 
 #![allow(dead_code)]
 
+// ---------------------------------------------------------------------------
+// Security gates
+// ---------------------------------------------------------------------------
+//
+// Every tool that can read user-controlled state from outside the daemon
+// (clipboard, accessibility tree of other apps, generic shell) is opt-in.
+// Defaults are OFF so a compromised or jailbroken MCP client cannot reach
+// these surfaces silently. Enabling each gate is an explicit operator
+// decision and is logged on every invocation.
+//
+// See `docs/operations/mcp-server-security.md` for the threat model.
+
+const MAX_TEXT_OUTPUT_BYTES: usize = 64 * 1024;
+
+fn env_flag(key: &str) -> bool {
+    std::env::var(key)
+        .map(|v| matches!(v.as_str(), "1" | "true" | "yes" | "on"))
+        .unwrap_or(false)
+}
+
+fn a11y_enabled() -> bool {
+    env_flag("LIFEOS_MCP_A11Y_ENABLE")
+}
+
+fn clipboard_enabled() -> bool {
+    env_flag("LIFEOS_MCP_CLIPBOARD_ENABLE")
+}
+
+/// Validate a launchable app name. Allows alphanumerics, dot, underscore,
+/// and dash. Rejects path separators, shell metacharacters, whitespace,
+/// and anything outside ASCII.
+///
+/// This is intentionally narrow — `tokio::process::Command::new(name)` will
+/// still resolve `name` against `$PATH`, but we limit the shape so an MCP
+/// caller cannot pass `../../bin/sh`, `;evil`, embedded newlines, or names
+/// the user would not recognise from a desktop entry.
+fn is_valid_app_name(name: &str) -> bool {
+    if name.is_empty() || name.len() > 64 {
+        return false;
+    }
+    name.chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
+}
+
+/// Truncate a text output to MAX_TEXT_OUTPUT_BYTES, breaking on a UTF-8
+/// boundary. Returns the truncated text and a flag indicating truncation.
+fn truncate_output(text: &str) -> (String, bool) {
+    if text.len() <= MAX_TEXT_OUTPUT_BYTES {
+        return (text.to_string(), false);
+    }
+    let mut end = MAX_TEXT_OUTPUT_BYTES;
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    (text[..end].to_string(), true)
+}
+
 /// Process an MCP tool call and return the result.
 /// This is a dispatcher — actual execution delegates to the appropriate module.
 ///
@@ -289,10 +346,16 @@ pub async fn call_tool(
                     .await;
                 cmd_result(output, "Launch app via gtk-launch")
             } else if let Some(app) = arguments.get("app").and_then(|v| v.as_str()) {
-                // Validate app name to prevent command injection
-                if app.contains('/') || app.contains(';') || app.contains('&') || app.contains('|')
-                {
-                    return Err("Invalid app name".into());
+                // Tight allowlist of name shape: alphanumerics + . _ -.
+                // No path separators, no shell metacharacters, no whitespace,
+                // no embedded newlines, no Unicode tricks. tokio::Command
+                // uses execvp so this is the only place we can constrain
+                // what binary the caller can launch via $PATH lookup.
+                if !is_valid_app_name(app) {
+                    return Err(format!(
+                        "Invalid app name '{}'. Allowed shape: 1-64 chars of [A-Za-z0-9._-]",
+                        app.chars().take(40).collect::<String>()
+                    ));
                 }
                 let _child = tokio::process::Command::new(app)
                     .spawn()
@@ -304,25 +367,44 @@ pub async fn call_tool(
         }
 
         "lifeos_apps_list_installed" => {
-            let output = tokio::process::Command::new("sh")
-                .args([
-                    "-c",
-                    r#"for f in /usr/share/applications/*.desktop ~/.local/share/applications/*.desktop /var/lib/flatpak/exports/share/applications/*.desktop; do [ -f "$f" ] && grep -m1 '^Name=' "$f" | cut -d= -f2; done | sort -u"#,
-                ])
-                .output()
-                .await;
-            match output {
-                Ok(o) if o.status.success() => {
-                    let raw = String::from_utf8_lossy(&o.stdout);
-                    let apps: Vec<&str> = raw.lines().filter(|l| !l.is_empty()).collect();
-                    Ok(serde_json::json!({ "installed_apps": apps, "count": apps.len() }))
+            // Walk the standard XDG desktop-entry directories directly in
+            // Rust instead of shelling out to `sh -c`. The previous shell
+            // version was safe because the command string was static, but
+            // it leaves a foot-gun for any future refactor that splices
+            // user input into the same string.
+            let home = std::env::var("HOME").unwrap_or_else(|_| "/home/lifeos".into());
+            let dirs: [std::path::PathBuf; 3] = [
+                std::path::PathBuf::from("/usr/share/applications"),
+                std::path::PathBuf::from(&home).join(".local/share/applications"),
+                std::path::PathBuf::from("/var/lib/flatpak/exports/share/applications"),
+            ];
+            let mut names: std::collections::BTreeSet<String> =
+                std::collections::BTreeSet::new();
+            for dir in &dirs {
+                let Ok(entries) = std::fs::read_dir(dir) else {
+                    continue;
+                };
+                for entry in entries.flatten() {
+                    let path = entry.path();
+                    if path.extension().and_then(|e| e.to_str()) != Some("desktop") {
+                        continue;
+                    }
+                    let Ok(content) = std::fs::read_to_string(&path) else {
+                        continue;
+                    };
+                    if let Some(name) = content
+                        .lines()
+                        .find_map(|l| l.strip_prefix("Name="))
+                        .map(|s| s.trim().to_string())
+                    {
+                        if !name.is_empty() {
+                            names.insert(name);
+                        }
+                    }
                 }
-                Ok(o) => Err(format!(
-                    "Failed to list apps: {}",
-                    String::from_utf8_lossy(&o.stderr)
-                )),
-                Err(e) => Err(format!("Command failed: {}", e)),
             }
+            let apps: Vec<String> = names.into_iter().collect();
+            Ok(serde_json::json!({ "installed_apps": apps, "count": apps.len() }))
         }
 
         "lifeos_apps_running" => {
@@ -381,6 +463,14 @@ pub async fn call_tool(
         }
 
         "lifeos_clipboard_get" => {
+            // Gate: the clipboard frequently holds passwords, 2FA codes,
+            // session tokens and freshly copied secrets. A jailbroken MCP
+            // client could exfiltrate them silently otherwise.
+            if !clipboard_enabled() {
+                log::warn!("[mcp_server] lifeos_clipboard_get blocked — set LIFEOS_MCP_CLIPBOARD_ENABLE=1 to opt in");
+                return Err("lifeos_clipboard_get is disabled. Set LIFEOS_MCP_CLIPBOARD_ENABLE=1 to opt in. The clipboard often contains passwords and 2FA codes; enabling this lets any MCP caller read them.".into());
+            }
+            log::warn!("[mcp_server] lifeos_clipboard_get EXEC (opt-in)");
             let output = tokio::process::Command::new("wl-paste")
                 .arg("--no-newline")
                 .output()
@@ -399,6 +489,14 @@ pub async fn call_tool(
         }
 
         "lifeos_clipboard_set" => {
+            // Gate: writing the clipboard lets a malicious caller plant
+            // commands the user might paste into a terminal. Treat as
+            // privileged.
+            if !clipboard_enabled() {
+                log::warn!("[mcp_server] lifeos_clipboard_set blocked — set LIFEOS_MCP_CLIPBOARD_ENABLE=1 to opt in");
+                return Err("lifeos_clipboard_set is disabled. Set LIFEOS_MCP_CLIPBOARD_ENABLE=1 to opt in. Writing the clipboard can plant commands the user pastes into a terminal.".into());
+            }
+            log::warn!("[mcp_server] lifeos_clipboard_set EXEC (opt-in)");
             let content = arguments
                 .get("content")
                 .and_then(|v| v.as_str())
@@ -699,12 +797,14 @@ pub async fn call_tool(
             ));
             match ba.fetch_html(url).await {
                 Ok(html) => {
-                    // Strip HTML tags for a rough text extraction
                     let text = strip_html_tags(&html);
+                    let original_len = text.len();
+                    let (text, truncated) = truncate_output(&text);
                     Ok(serde_json::json!({
                         "url": url,
                         "text": text,
-                        "length": text.len(),
+                        "length": original_len,
+                        "truncated": truncated,
                     }))
                 }
                 Err(e) => Err(format!("Text extraction failed: {}", e)),
@@ -1087,7 +1187,19 @@ pub async fn call_tool(
         }
 
         // ----- AT-SPI2 Accessibility Layer (AY.4) -----
+        // Every a11y_* tool is gated. AT-SPI exposes the live text content
+        // and actionable controls of every accessible app on the desktop —
+        // browser tabs, email clients, terminals, password managers. A
+        // jailbroken MCP caller could read banking pages, chat history,
+        // 1Password, then exfiltrate via its response channel. The gate is
+        // defence in depth alongside any per-app permission the user has
+        // granted to AT-SPI itself.
         "lifeos_a11y_tree" => {
+            if !a11y_enabled() {
+                log::warn!("[mcp_server] lifeos_a11y_tree blocked — set LIFEOS_MCP_A11Y_ENABLE=1 to opt in");
+                return Err("lifeos_a11y_tree is disabled. Set LIFEOS_MCP_A11Y_ENABLE=1 to opt in. AT-SPI exposes live text from every accessible app (browser, email, terminal, password manager).".into());
+            }
+            log::warn!("[mcp_server] lifeos_a11y_tree EXEC (opt-in)");
             let app = arguments
                 .get("app")
                 .and_then(|v| v.as_str())
@@ -1105,6 +1217,11 @@ pub async fn call_tool(
         }
 
         "lifeos_a11y_find" => {
+            if !a11y_enabled() {
+                log::warn!("[mcp_server] lifeos_a11y_find blocked — set LIFEOS_MCP_A11Y_ENABLE=1 to opt in");
+                return Err("lifeos_a11y_find is disabled. Set LIFEOS_MCP_A11Y_ENABLE=1 to opt in.".into());
+            }
+            log::warn!("[mcp_server] lifeos_a11y_find EXEC (opt-in)");
             let app = arguments
                 .get("app")
                 .and_then(|v| v.as_str())
@@ -1122,6 +1239,11 @@ pub async fn call_tool(
         }
 
         "lifeos_a11y_activate" => {
+            if !a11y_enabled() {
+                log::warn!("[mcp_server] lifeos_a11y_activate blocked — set LIFEOS_MCP_A11Y_ENABLE=1 to opt in");
+                return Err("lifeos_a11y_activate is disabled. Set LIFEOS_MCP_A11Y_ENABLE=1 to opt in. Activating arbitrary controls in other apps can submit forms, send messages, click confirmation dialogs.".into());
+            }
+            log::warn!("[mcp_server] lifeos_a11y_activate EXEC (opt-in)");
             let bus = arguments
                 .get("bus_name")
                 .and_then(|v| v.as_str())
@@ -1141,6 +1263,11 @@ pub async fn call_tool(
         }
 
         "lifeos_a11y_get_text" => {
+            if !a11y_enabled() {
+                log::warn!("[mcp_server] lifeos_a11y_get_text blocked — set LIFEOS_MCP_A11Y_ENABLE=1 to opt in");
+                return Err("lifeos_a11y_get_text is disabled. Set LIFEOS_MCP_A11Y_ENABLE=1 to opt in. This reads live text from any accessible app — banking, email, password manager.".into());
+            }
+            log::warn!("[mcp_server] lifeos_a11y_get_text EXEC (opt-in)");
             let bus = arguments
                 .get("bus_name")
                 .and_then(|v| v.as_str())
@@ -1150,17 +1277,27 @@ pub async fn call_tool(
                 .and_then(|v| v.as_str())
                 .ok_or("Missing 'path' parameter")?;
             match crate::atspi_layer::get_text(bus, path).await {
-                Ok(text) => Ok(serde_json::json!({
-                    "bus_name": bus,
-                    "path": path,
-                    "text": text,
-                    "length": text.len(),
-                })),
+                Ok(text) => {
+                    let (text, truncated) = truncate_output(&text);
+                    let total_len = text.len();
+                    Ok(serde_json::json!({
+                        "bus_name": bus,
+                        "path": path,
+                        "text": text,
+                        "length": total_len,
+                        "truncated": truncated,
+                    }))
+                }
                 Err(e) => Err(format!("AT-SPI2 get_text failed: {}", e)),
             }
         }
 
         "lifeos_a11y_set_text" => {
+            if !a11y_enabled() {
+                log::warn!("[mcp_server] lifeos_a11y_set_text blocked — set LIFEOS_MCP_A11Y_ENABLE=1 to opt in");
+                return Err("lifeos_a11y_set_text is disabled. Set LIFEOS_MCP_A11Y_ENABLE=1 to opt in. Writing into other apps can submit forms with attacker text.".into());
+            }
+            log::warn!("[mcp_server] lifeos_a11y_set_text EXEC (opt-in)");
             let bus = arguments
                 .get("bus_name")
                 .and_then(|v| v.as_str())
@@ -1356,5 +1493,134 @@ fn collect_windows(node: &serde_json::Value, out: &mut Vec<serde_json::Value>) {
         for child in nodes {
             collect_windows(child, out);
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn app_name_accepts_typical_binaries() {
+        assert!(is_valid_app_name("firefox"));
+        assert!(is_valid_app_name("cosmic-term"));
+        assert!(is_valid_app_name("LibreOffice"));
+        assert!(is_valid_app_name("app_v2.1"));
+        assert!(is_valid_app_name("a"));
+    }
+
+    #[test]
+    fn app_name_rejects_path_traversal() {
+        assert!(!is_valid_app_name("/usr/bin/sh"));
+        assert!(!is_valid_app_name("../bin/sh"));
+        assert!(!is_valid_app_name("./evil"));
+    }
+
+    #[test]
+    fn app_name_rejects_shell_metachars() {
+        for bad in [";rm", "&background", "a|b", "$(curl)", "`whoami`", "a\nb"] {
+            assert!(!is_valid_app_name(bad), "should reject: {bad:?}");
+        }
+    }
+
+    #[test]
+    fn app_name_rejects_whitespace_and_unicode() {
+        assert!(!is_valid_app_name(""));
+        assert!(!is_valid_app_name("with space"));
+        assert!(!is_valid_app_name("café"));
+        assert!(!is_valid_app_name(&"a".repeat(65)));
+    }
+
+    #[test]
+    fn truncate_output_passes_through_short() {
+        let (out, truncated) = truncate_output("hello");
+        assert_eq!(out, "hello");
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn truncate_output_caps_oversized() {
+        let big = "a".repeat(MAX_TEXT_OUTPUT_BYTES + 100);
+        let (out, truncated) = truncate_output(&big);
+        assert_eq!(out.len(), MAX_TEXT_OUTPUT_BYTES);
+        assert!(truncated);
+    }
+
+    #[test]
+    fn truncate_output_respects_utf8_boundary() {
+        // 4-byte char ('🦀') straddling the cap. Trim to a valid boundary.
+        let mut s = "a".repeat(MAX_TEXT_OUTPUT_BYTES - 1);
+        s.push('🦀');
+        let (out, truncated) = truncate_output(&s);
+        assert!(truncated);
+        assert!(out.is_char_boundary(out.len()));
+        assert!(out.len() <= MAX_TEXT_OUTPUT_BYTES);
+    }
+
+    #[test]
+    fn env_flag_truthy_values() {
+        // Use a unique env var name so parallel tests don't collide.
+        let key = "LIFEOS_TEST_ENV_FLAG_TRUTHY";
+        for v in ["1", "true", "yes", "on"] {
+            std::env::set_var(key, v);
+            assert!(env_flag(key), "should be true for {v}");
+        }
+        std::env::remove_var(key);
+    }
+
+    #[test]
+    fn env_flag_falsy_values() {
+        let key = "LIFEOS_TEST_ENV_FLAG_FALSY";
+        for v in ["", "0", "false", "no", "off", "TRUE", "YES"] {
+            std::env::set_var(key, v);
+            assert!(!env_flag(key), "should be false for {v:?}");
+        }
+        std::env::remove_var(key);
+        assert!(!env_flag(key), "should be false when unset");
+    }
+
+    #[tokio::test]
+    async fn clipboard_get_blocked_by_default() {
+        // Ensure the gate is off (some other test may have toggled it).
+        std::env::remove_var("LIFEOS_MCP_CLIPBOARD_ENABLE");
+        let result =
+            call_tool("lifeos_clipboard_get", &serde_json::json!({}), None).await;
+        let err = result.expect_err("clipboard_get must be gated by default");
+        assert!(
+            err.contains("LIFEOS_MCP_CLIPBOARD_ENABLE"),
+            "error must name the opt-in env var: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a11y_get_text_blocked_by_default() {
+        std::env::remove_var("LIFEOS_MCP_A11Y_ENABLE");
+        let result = call_tool(
+            "lifeos_a11y_get_text",
+            &serde_json::json!({"bus_name": "x", "path": "y"}),
+            None,
+        )
+        .await;
+        let err = result.expect_err("a11y_get_text must be gated by default");
+        assert!(
+            err.contains("LIFEOS_MCP_A11Y_ENABLE"),
+            "error must name the opt-in env var: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn apps_launch_rejects_path_in_app_name() {
+        let result = call_tool(
+            "lifeos_apps_launch",
+            &serde_json::json!({"app": "/usr/bin/sh"}),
+            None,
+        )
+        .await;
+        let err = result.expect_err("must reject path-shaped app names");
+        assert!(err.contains("Invalid app name"), "got: {err}");
     }
 }

--- a/docs/operations/mcp-server-security.md
+++ b/docs/operations/mcp-server-security.md
@@ -1,0 +1,53 @@
+# MCP Server — Security Model
+
+LifeOS exposes a set of `lifeos_*` tools to MCP clients (Claude Desktop, VS Code Copilot, in-process Axi router, Dashboard chat). This document captures which tools are gated, why, and how to opt in.
+
+## Threat model
+
+Vectors that can reach the MCP dispatcher:
+
+- **SimpleX inbound** — a contact crafts a message that nudges the LLM into calling a sensitive tool.
+- **Dashboard chat** — same surface, browser-side.
+- **Compromised MCP client** — a third-party MCP client (extension supply chain) sends raw tool calls.
+
+Tools that read or modify state outside the daemon's own data must therefore default OFF and require an explicit operator opt-in. Defaults are conservative, gates are documented in error messages, and every gated invocation logs at `warn!` level.
+
+## Gates
+
+| Tool(s) | Env var (set to `1`/`true`/`yes`/`on`) | Why it's gated |
+|---|---|---|
+| `lifeos_shell` | `LIFEOS_MCP_SHELL_ENABLE` | Pipes a string from the MCP caller into `sh -c`. A blocklist cannot make this safe; opting in accepts the risk. |
+| `lifeos_clipboard_get`, `lifeos_clipboard_set` | `LIFEOS_MCP_CLIPBOARD_ENABLE` | Clipboard frequently holds passwords, 2FA codes, session tokens. Writing it lets a caller plant commands the user later pastes into a terminal. |
+| `lifeos_a11y_tree`, `lifeos_a11y_find`, `lifeos_a11y_activate`, `lifeos_a11y_get_text`, `lifeos_a11y_set_text` | `LIFEOS_MCP_A11Y_ENABLE` | AT-SPI exposes the live text and actionable controls of every accessible app on the desktop — browser, email, password manager, terminal. Reading is exfiltration; activating/setting can submit forms with attacker text. |
+
+`lifeos_a11y_apps` (listing applications) is intentionally **not** gated — it returns a list comparable to `ps`, which is already broadly visible.
+
+## Validation
+
+- `lifeos_apps_launch` requires the `app` argument to match `[A-Za-z0-9._-]{1,64}`. Path separators, shell metacharacters, whitespace, embedded newlines, and non-ASCII are rejected. `tokio::Command::new` uses `execvp`, so the only way to constrain *which* binary the caller can launch is to constrain the shape of the name.
+- `lifeos_workspaces_*` and `lifeos_display_resolution` keep their existing per-arg metacharacter checks — they invoke `swaymsg`/`cosmic-randr` via `execvp` (no shell), but the upstream tools have their own command grammar that we don't want callers smuggling into.
+
+## Output caps
+
+`lifeos_browser_extract_text` and `lifeos_a11y_get_text` truncate their `text` field at **64 KiB** on a UTF-8 boundary. Truncation is signalled by `"truncated": true`; the original `length` is reported in bytes. This is a defence against accidental memory bombs (a 100 MB page) and against using these tools to relay full-document exfiltration in a single response.
+
+## What changed (vs. previous behaviour)
+
+- Previously: `lifeos_clipboard_*` and all five `lifeos_a11y_*` tools (except `apps`) were callable without gating.
+- Previously: `lifeos_apps_launch` only blocked `;`, `&`, `|`, and `/` — leaving `$()`, backticks, newlines, IFS tricks, and Unicode lookalikes wide open.
+- Previously: `lifeos_apps_list_installed` and `lifeos_brightness_*` paths shelled out via `sh -c` with static command strings (safe today, but a footgun for any future refactor that splices user input). `lifeos_apps_list_installed` now walks the XDG dirs in pure Rust.
+- Previously: `lifeos_browser_extract_text` returned the full extracted text with no length cap.
+
+## Opting in
+
+To enable a gated tool for the running daemon, set the env var in the systemd drop-in for the user-session unit and reload:
+
+```
+mkdir -p ~/.config/systemd/user/lifeosd.service.d
+printf '[Service]\nEnvironment=LIFEOS_MCP_CLIPBOARD_ENABLE=1\n' \
+  > ~/.config/systemd/user/lifeosd.service.d/50-mcp-gates.conf
+systemctl --user daemon-reload
+systemctl --user restart lifeosd
+```
+
+Each enabled gate appears in `journalctl --user -u lifeosd` on every invocation as `[mcp_server] <tool> EXEC (opt-in)`. If you no longer want a tool exposed, remove the line and restart.


### PR DESCRIPTION
## Summary

PR 1 of 3 from the P1 security audit. Hardens \`daemon/src/mcp_server.rs\`. Independent of PRs 2 (\`self_improving.rs\`) and 3 (\`skill_generator.rs\`).

### Threat model (post-Telegram removal)

The MCP dispatcher is reachable from:
- SimpleX inbound messages
- Dashboard chat
- In-process Axi router (LLM tool-use)
- Any third-party MCP client (Claude Desktop, VS Code Copilot — supply chain risk)

Tools that read or modify state outside the daemon's own data must default OFF.

### What changed

**Gates (default OFF, opt-in via env var)**
- \`lifeos_clipboard_get/set\` → \`LIFEOS_MCP_CLIPBOARD_ENABLE\`. Clipboard often holds passwords, 2FA codes, freshly copied tokens. Writing it can plant commands the user pastes into a terminal.
- \`lifeos_a11y_tree/find/activate/get_text/set_text\` → \`LIFEOS_MCP_A11Y_ENABLE\`. AT-SPI exposes live text and controls of every accessible app (browser, email, password manager, terminal). Reading is exfiltration; activating/setting can submit forms with attacker text.
- \`lifeos_a11y_apps\` (listing) stays open — comparable to \`ps\`.

**Validation**
- \`lifeos_apps_launch\` allowlist tightened from \`[;&|/]\`-blocklist to \`[A-Za-z0-9._-]{1,64}\` allowlist. Closes \`\$()\`, backticks, newlines, IFS, Unicode lookalike vectors. \`tokio::Command\` uses \`execvp\`, so name shape is the only knob.

**Output caps (64 KiB on UTF-8 boundary)**
- \`lifeos_browser_extract_text\`
- \`lifeos_a11y_get_text\`

Defence against memory bombs and single-response document exfil. Truncation flagged in the response (\`\"truncated\": true\`).

**Future-refactor footgun removed**
- \`lifeos_apps_list_installed\` no longer shells out via \`sh -c\` with a static command string. Replaced with a pure-Rust walk of XDG desktop-entry directories.

**Audit trail**
- Every gated invocation logs at \`warn!\` with the tool name.

### Tests

- App-name allowlist: typical binaries, path traversal, shell metachars, whitespace, length.
- Output truncation respects UTF-8 boundary on multibyte chars (4-byte char straddling cap).
- \`env_flag\` accepts \`1/true/yes/on\`, rejects \`0/false/no/off/TRUE/YES/empty/unset\`.
- \`call_tool\` dispatch returns gate-named errors when env vars are unset (\`clipboard_get\`, \`a11y_get_text\`).
- \`call_tool\` rejects path-shaped app names in \`apps_launch\`.

### Docs

New \`docs/operations/mcp-server-security.md\` captures the threat model, the gate matrix, validation rules, output caps, and the systemd opt-in recipe.

### Out of scope (next PRs)

- PR 2: \`self_improving.rs\` — HMAC on \`workflow_actions.json\`, presence anti-spoof, \`check_auto_trigger\` opt-in, \`symlink_metadata\` for cleanup walk.
- PR 3: \`skill_generator.rs\` — \`requires_review\` flag, \`systemd-run --user --scope\` sandbox, size cap, atomic writes.

## Test plan

- [ ] CI green on this PR (Build CLI/Daemon, Security Audit, Integration, smoke-test, Build and Push Image)
- [ ] After merge: confirm laptop \`lifeosd\` continues to dispatch un-gated tools normally
- [ ] Optional: enable one gate via systemd drop-in and verify \`journalctl --user -u lifeosd | rg 'EXEC \(opt-in\)'\` fires