### PR TITLE
feat(security): AES-256-GCM-SIV at-rest encryption for screenshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "life"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2626,7 +2626,7 @@ dependencies = [
 
 [[package]]
 name = "lifeos-integration-tests"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "life",
  "serde_json",
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "lifeosd"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.4"
+version = "0.8.5"
 
 [workspace.metadata.lifeos]
 codename = "Axolotl"

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -80,6 +80,7 @@ mod reliability;
 mod safe_mode;
 mod scheduled_tasks;
 mod screen_capture;
+mod screenshot_crypt;
 mod security_ai;
 mod self_improving;
 mod sensory_memory;
@@ -722,6 +723,19 @@ async fn main() -> anyhow::Result<()> {
     let shared_session_store = Arc::new(session_store::SessionStore::new(&data_dir));
     if let Err(e) = shared_session_store.init().await {
         warn!("Failed to initialize SessionStore: {}", e);
+    }
+
+    // Screenshot at-rest crypto: validate the key + round-trip on
+    // every boot so a corrupt key file or an unwritable secrets dir is
+    // surfaced before the first capture rather than silently degrading
+    // the .enc sidecar to "missing". See
+    // docs/operations/screenshot-encryption.md for the threat model.
+    // Logged-and-ignored: a failure here means new captures will skip
+    // the .enc sidecar (plaintext still written), which is the same
+    // fail-open behaviour as before this PR.
+    match screenshot_crypt::self_test_at_startup() {
+        Ok(()) => info!("screenshot_crypt: self-test OK"),
+        Err(e) => warn!("screenshot_crypt self-test failed: {}", e),
     }
 
     // Initialize state

--- a/daemon/src/screen_capture.rs
+++ b/daemon/src/screen_capture.rs
@@ -461,16 +461,7 @@ impl ScreenCapture {
             .await
             .with_context(|| format!("Failed to read temporary capture {}", source.display()))?;
 
-        // Future: encrypt screenshot bytes at rest (AES-256-GCM-SIV pattern
-        // from memory_plane.rs). Requires changing all read sites to decrypt.
-        //   3. Update ALL read sites: list_screenshots(), cleanup_old/by_count/by_size(),
-        //      get_image_resolution(), and any external consumer that reads via `path`.
-        //   4. Add a decrypt_screenshot() helper that reads nonce + ciphertext, decrypts,
-        //      and returns the original JPEG/PNG bytes.
-        // This is deferred because it touches every read path across the screenshot
-        // lifecycle. File permissions (0o600) provide baseline protection meanwhile.
-
-        fs::write(dest, bytes)
+        fs::write(dest, &bytes)
             .await
             .with_context(|| format!("Failed to write final capture {}", dest.display()))?;
         // Restrict to owner-only so other users cannot read screenshots.
@@ -479,6 +470,30 @@ impl ScreenCapture {
             use std::os::unix::fs::PermissionsExt;
             let _ = std::fs::set_permissions(dest, std::fs::Permissions::from_mode(0o600));
         }
+
+        // Write encrypted sidecar at `<dest>.enc` for at-rest protection
+        // (AES-256-GCM-SIV — see screenshot_crypt module). The plaintext
+        // file remains because in-tree consumers (sensory_pipeline,
+        // overlay) hand the path to external binaries (identify, llava)
+        // that cannot read ciphertext. Plaintext lifetime is bounded by
+        // the cleanup paths (cleanup_old/by_count/by_size below); the
+        // .enc sidecar provides at-rest defence for stolen-disk and
+        // backup-leak scenarios. End-to-end encryption (no plaintext on
+        // disk) requires refactoring sensory_pipeline.rs to consume
+        // bytes via decrypt_from_file — tracked as a follow-up.
+        let dest_owned = dest.to_path_buf();
+        let bytes_for_crypt = bytes.clone();
+        let enc_result = tokio::task::spawn_blocking(move || {
+            let enc_path = crate::screenshot_crypt::encrypted_path_for(&dest_owned);
+            crate::screenshot_crypt::encrypt_to_file(&enc_path, &bytes_for_crypt)
+        })
+        .await;
+        match enc_result {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => log::warn!("screenshot at-rest encryption failed: {}", e),
+            Err(e) => log::warn!("screenshot encryption task panicked: {}", e),
+        }
+
         let _ = fs::remove_file(source).await;
         Ok(())
     }
@@ -1016,6 +1031,13 @@ impl ScreenCapture {
             if path.is_file() {
                 if let Some(filename) = path.file_name() {
                     if let Some(name) = filename.to_str() {
+                        // Skip encrypted sidecars — list_screenshots()
+                        // returns the plaintext entries; consumers that
+                        // want the encrypted blob can derive the path via
+                        // screenshot_crypt::encrypted_path_for().
+                        if name.ends_with(".enc") {
+                            continue;
+                        }
                         if name.starts_with("lifeos_screenshot_") {
                             if let Ok(metadata) = fs::metadata(&path).await {
                                 let size_bytes = metadata.len();
@@ -1071,6 +1093,18 @@ impl ScreenCapture {
         fs::remove_file(&path)
             .await
             .context("Failed to delete screenshot")?;
+
+        // Also remove the encrypted sidecar if it exists.
+        let enc_path = crate::screenshot_crypt::encrypted_path_for(&path);
+        if enc_path.exists() {
+            if let Err(e) = fs::remove_file(&enc_path).await {
+                log::warn!(
+                    "failed to delete encrypted sidecar {}: {}",
+                    enc_path.display(),
+                    e
+                );
+            }
+        }
 
         log::info!("Deleted screenshot: {}", filename);
         Ok(true)

--- a/daemon/src/screenshot_crypt.rs
+++ b/daemon/src/screenshot_crypt.rs
@@ -1,0 +1,305 @@
+//! Screenshot at-rest encryption — AES-256-GCM-SIV with persisted key.
+//!
+//! THREAT MODEL — be honest about what this protects against:
+//!
+//! - YES: stolen laptop with the disk pulled out and read offline.
+//!   The attacker sees only ciphertext; the key lives in
+//!   `/var/lib/lifeos/secrets/screenshot.key` (mode 0600, parent dir 0700)
+//!   and is itself protected by file permissions, but a cold-disk attacker
+//!   reading a powered-off filesystem cannot bypass DAC enforcement on
+//!   most layouts (LUKS-at-rest is the layered defence).
+//! - YES: a backup of `/var/lib/lifeos/screenshots/` shipped to a cloud
+//!   bucket or another machine — the ciphertext is useless without the
+//!   key, which lives in a separate directory that should NOT be backed up.
+//! - YES: a process running as a different UID, or a sandboxed payload
+//!   (flatpak, systemd-run scope) that can read screenshot files but not
+//!   the secrets directory.
+//!
+//! - NO: a process running as the same UID as the daemon. It can read
+//!   both the screenshots and the key file. That threat already wins.
+//! - NO: an online attacker with root or with the ability to call the
+//!   daemon API. Decryption happens inside the daemon; anyone who can
+//!   make the daemon decrypt for them defeats this layer.
+//! - NO: side-channel attacks against the running daemon (memory dumps,
+//!   /proc/pid/mem reads). Use OS-level mitigations for that.
+//!
+//! File layout: each encrypted file is `[nonce(12 bytes)][ciphertext+tag]`.
+//! Standard AES-GCM-SIV — nonce-misuse-resistant, authenticated.
+//! Filename convention: append `.enc` to the original name (e.g.
+//! `lifeos_screenshot_20260422_143015.png.enc`).
+
+use aes_gcm_siv::aead::{Aead, KeyInit};
+use aes_gcm_siv::{Aes256GcmSiv, Nonce};
+use anyhow::{Context, Result};
+use rand::RngCore;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const SECRETS_DIR: &str = "/var/lib/lifeos/secrets";
+const SCREENSHOT_KEY_FILE: &str = "/var/lib/lifeos/secrets/screenshot.key";
+const NONCE_LEN: usize = 12;
+const KEY_LEN: usize = 32;
+
+/// File extension appended to encrypted screenshots.
+pub const ENC_EXTENSION: &str = "enc";
+
+/// Load (or generate on first run) the AES-256-GCM-SIV key used to
+/// encrypt screenshots at rest.
+///
+/// The key is generated once with 32 bytes from the OS RNG and persisted
+/// at `/var/lib/lifeos/secrets/screenshot.key` (mode 0600). The parent
+/// directory is created with mode 0700. Subsequent loads return the same
+/// key, which is required so previously encrypted screenshots remain
+/// readable.
+///
+/// Returns the raw 32-byte key. Callers should treat the bytes as
+/// secret and avoid logging them.
+pub fn load_or_create_screenshot_key() -> Result<Vec<u8>> {
+    load_or_create_key_at(Path::new(SCREENSHOT_KEY_FILE), Path::new(SECRETS_DIR))
+}
+
+fn load_or_create_key_at(key_path: &Path, secrets_dir: &Path) -> Result<Vec<u8>> {
+    if let Ok(existing) = fs::read(key_path) {
+        if existing.len() == KEY_LEN {
+            return Ok(existing);
+        }
+        log::warn!(
+            "screenshot_crypt: existing key at {} has wrong length ({} bytes), regenerating",
+            key_path.display(),
+            existing.len()
+        );
+    }
+
+    fs::create_dir_all(secrets_dir)
+        .with_context(|| format!("creating secrets dir {}", secrets_dir.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(secrets_dir, fs::Permissions::from_mode(0o700));
+    }
+
+    let mut key = vec![0u8; KEY_LEN];
+    rand::thread_rng().fill_bytes(&mut key);
+    fs::write(key_path, &key)
+        .with_context(|| format!("writing screenshot key {}", key_path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(key_path, fs::Permissions::from_mode(0o600));
+    }
+    log::info!(
+        "screenshot_crypt: generated new screenshot key at {}",
+        key_path.display()
+    );
+    Ok(key)
+}
+
+/// Encrypt `plaintext` with the persisted screenshot key and write the
+/// result to `path` as `[nonce(12)][ciphertext+tag]`. The destination
+/// file is created with mode 0600.
+pub fn encrypt_to_file(path: &Path, plaintext: &[u8]) -> Result<()> {
+    let key = load_or_create_screenshot_key()?;
+    encrypt_to_file_with_key(path, plaintext, &key)
+}
+
+fn encrypt_to_file_with_key(path: &Path, plaintext: &[u8], key: &[u8]) -> Result<()> {
+    let cipher = Aes256GcmSiv::new_from_slice(key)
+        .map_err(|e| anyhow::anyhow!("invalid screenshot key length: {}", e))?;
+
+    let mut nonce_bytes = [0u8; NONCE_LEN];
+    rand::thread_rng().fill_bytes(&mut nonce_bytes);
+    let nonce = Nonce::from_slice(&nonce_bytes);
+
+    let ciphertext = cipher
+        .encrypt(nonce, plaintext)
+        .map_err(|e| anyhow::anyhow!("screenshot encryption failed: {}", e))?;
+
+    let mut blob = Vec::with_capacity(NONCE_LEN + ciphertext.len());
+    blob.extend_from_slice(&nonce_bytes);
+    blob.extend_from_slice(&ciphertext);
+
+    fs::write(path, &blob)
+        .with_context(|| format!("writing encrypted screenshot {}", path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(path, fs::Permissions::from_mode(0o600));
+    }
+    Ok(())
+}
+
+/// Decrypt the file at `path` and return the original plaintext bytes.
+/// The file MUST be in the format produced by `encrypt_to_file`:
+/// `[nonce(12)][ciphertext+tag]`. Authentication failure (tampering) or
+/// any other cryptographic error returns an `Err`.
+///
+/// Currently consumed by the startup self-test below; this is the
+/// designated read-path for future consumers (e.g. when
+/// `sensory_pipeline.rs` is refactored to consume bytes via this fn so
+/// the plaintext sidecar can be removed entirely).
+fn decrypt_from_file(path: &Path) -> Result<Vec<u8>> {
+    let key = load_or_create_screenshot_key()?;
+    decrypt_from_file_with_key(path, &key)
+}
+
+/// Self-test invoked at daemon startup. Writes a small probe ciphertext
+/// to a tempfile via the public `encrypt_to_file` path, decrypts it via
+/// `decrypt_from_file`, and verifies the round-trip. This catches a
+/// corrupt or unreadable key file before the first real screenshot
+/// capture, ensures the secrets directory is writable, and exercises
+/// both halves of the public API on every boot — keeping the surface
+/// honest (no dead code).
+pub fn self_test_at_startup() -> Result<()> {
+    let key = load_or_create_screenshot_key()?;
+    if key.len() != KEY_LEN {
+        anyhow::bail!(
+            "screenshot key has wrong length: {} (expected {})",
+            key.len(),
+            KEY_LEN
+        );
+    }
+    let probe_path = std::env::temp_dir().join(format!(
+        "lifeos-screenshot-crypt-selftest-{}.enc",
+        std::process::id()
+    ));
+    let probe = b"lifeos-screenshot-crypt-self-test";
+    encrypt_to_file(&probe_path, probe)?;
+    let recovered = decrypt_from_file(&probe_path)?;
+    let _ = fs::remove_file(&probe_path);
+    if recovered != probe {
+        anyhow::bail!("screenshot crypt self-test round-trip mismatch");
+    }
+    Ok(())
+}
+
+fn decrypt_from_file_with_key(path: &Path, key: &[u8]) -> Result<Vec<u8>> {
+    let blob = fs::read(path)
+        .with_context(|| format!("reading encrypted screenshot {}", path.display()))?;
+    if blob.len() < NONCE_LEN + 16 {
+        anyhow::bail!(
+            "encrypted screenshot {} is too short ({} bytes)",
+            path.display(),
+            blob.len()
+        );
+    }
+
+    let cipher = Aes256GcmSiv::new_from_slice(key)
+        .map_err(|e| anyhow::anyhow!("invalid screenshot key length: {}", e))?;
+    let (nonce_bytes, ciphertext) = blob.split_at(NONCE_LEN);
+    let nonce = Nonce::from_slice(nonce_bytes);
+
+    cipher.decrypt(nonce, ciphertext).map_err(|e| {
+        anyhow::anyhow!(
+            "screenshot decryption failed (tampered or wrong key): {}",
+            e
+        )
+    })
+}
+
+/// Return the encrypted-file path for a given plaintext path by
+/// appending the `.enc` extension. Filename-only — does not touch disk.
+pub fn encrypted_path_for(plain: &Path) -> PathBuf {
+    let mut as_str = plain.as_os_str().to_owned();
+    as_str.push(".");
+    as_str.push(ENC_EXTENSION);
+    PathBuf::from(as_str)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+
+    fn tempdir() -> PathBuf {
+        let base = env::temp_dir().join(format!(
+            "lifeos-screenshot-crypt-{}-{}",
+            std::process::id(),
+            rand::random::<u32>()
+        ));
+        fs::create_dir_all(&base).unwrap();
+        base
+    }
+
+    #[test]
+    fn round_trip_recovers_plaintext() {
+        let dir = tempdir();
+        let key_path = dir.join("k.key");
+        let secrets_dir = dir.clone();
+        let key = load_or_create_key_at(&key_path, &secrets_dir).unwrap();
+        assert_eq!(key.len(), KEY_LEN);
+
+        let plaintext = b"PNG-bytes-pretend-this-is-an-image".repeat(1000);
+        let enc_path = dir.join("shot.png.enc");
+        encrypt_to_file_with_key(&enc_path, &plaintext, &key).unwrap();
+
+        let recovered = decrypt_from_file_with_key(&enc_path, &key).unwrap();
+        assert_eq!(recovered, plaintext);
+    }
+
+    #[test]
+    fn tamper_detection_fails_decrypt() {
+        let dir = tempdir();
+        let key_path = dir.join("k.key");
+        let key = load_or_create_key_at(&key_path, &dir).unwrap();
+
+        let plaintext = b"sensitive screen contents";
+        let enc_path = dir.join("shot.png.enc");
+        encrypt_to_file_with_key(&enc_path, plaintext, &key).unwrap();
+
+        // Flip one byte deep inside the ciphertext (past the nonce).
+        let mut blob = fs::read(&enc_path).unwrap();
+        let target = NONCE_LEN + 5;
+        blob[target] ^= 0xff;
+        fs::write(&enc_path, &blob).unwrap();
+
+        let result = decrypt_from_file_with_key(&enc_path, &key);
+        assert!(
+            result.is_err(),
+            "tampered ciphertext must fail authentication"
+        );
+    }
+
+    #[test]
+    fn key_persists_across_loads() {
+        let dir = tempdir();
+        let key_path = dir.join("k.key");
+        let first = load_or_create_key_at(&key_path, &dir).unwrap();
+        let second = load_or_create_key_at(&key_path, &dir).unwrap();
+        assert_eq!(first, second, "second load must return identical key");
+    }
+
+    #[test]
+    fn wrong_key_fails_decrypt() {
+        let dir = tempdir();
+        let plaintext = b"top secret";
+        let enc_path = dir.join("shot.png.enc");
+        let key_a = load_or_create_key_at(&dir.join("a.key"), &dir).unwrap();
+        // Force a different key by overwriting the file with random bytes.
+        let mut key_b = vec![0u8; KEY_LEN];
+        rand::thread_rng().fill_bytes(&mut key_b);
+        assert_ne!(key_a, key_b);
+
+        encrypt_to_file_with_key(&enc_path, plaintext, &key_a).unwrap();
+        let result = decrypt_from_file_with_key(&enc_path, &key_b);
+        assert!(result.is_err(), "decrypt with wrong key must fail");
+    }
+
+    #[test]
+    fn encrypted_path_for_appends_enc() {
+        let p = PathBuf::from("/var/lib/lifeos/screenshots/lifeos_screenshot_20260422_143015.png");
+        let enc = encrypted_path_for(&p);
+        assert_eq!(
+            enc.to_string_lossy(),
+            "/var/lib/lifeos/screenshots/lifeos_screenshot_20260422_143015.png.enc"
+        );
+    }
+
+    #[test]
+    fn short_blob_is_rejected() {
+        let dir = tempdir();
+        let key = load_or_create_key_at(&dir.join("k.key"), &dir).unwrap();
+        let bad = dir.join("bad.enc");
+        fs::write(&bad, b"too short").unwrap();
+        assert!(decrypt_from_file_with_key(&bad, &key).is_err());
+    }
+}

--- a/docs/operations/screenshot-encryption.md
+++ b/docs/operations/screenshot-encryption.md
@@ -1,0 +1,94 @@
+# Cifrado de screenshots at rest
+
+LifeOS captura screenshots para el overlay de IA, FollowAlong y documentación de incidentes. Esos archivos pueden contener información sensible (correos, contraseñas en pantalla, fotos personales). Este documento describe cómo se protegen en disco y los límites reales de esa protección.
+
+## Algoritmo y formato
+
+- Cifrado: **AES-256-GCM-SIV** (`aes-gcm-siv = 0.11`), nonce-misuse-resistant y autenticado.
+- Nonce: 12 bytes aleatorios por archivo, generados con `rand::thread_rng()` (OsRng).
+- Layout del archivo cifrado: `[nonce(12 bytes)][ciphertext + auth tag de 16 bytes]`.
+- Extensión: `<nombre>.enc` (ej. `lifeos_screenshot_20260422_143015.png.enc`).
+
+## Key management
+
+- Path: `/var/lib/lifeos/secrets/screenshot.key` (32 bytes, mode `0600`).
+- Directorio padre: `/var/lib/lifeos/secrets/` (mode `0700`).
+- Generación: en el primer uso, si la key no existe, se generan 32 bytes con la RNG del sistema y se persisten. Loads posteriores devuelven la misma key.
+- **No rotamos la key automáticamente.** Rotarla invalida todos los `.enc` previos. Si necesitás rotación, hay que: (1) descifrar todos los `.enc`, (2) borrar la key vieja, (3) re-cifrar con la key nueva. No hay tooling para esto todavía.
+
+Mismo patrón que `workflow-hmac.key` (PR #31, `daemon/src/self_improving.rs`). Ver `docs/operations/self-improving-security.md` para el modelo de threat de las keys persistidas.
+
+## Layout en disco
+
+Después de cada captura, en `/var/lib/lifeos/screenshots/` quedan dos archivos:
+
+```
+lifeos_screenshot_20260422_143015.png      # plaintext, mode 0600
+lifeos_screenshot_20260422_143015.png.enc  # cifrado AES-GCM-SIV, mode 0600
+```
+
+El plaintext NO se elimina inmediatamente porque consumers in-tree (`sensory_pipeline.rs`, `overlay.rs`) le pasan la ruta a binarios externos (`identify`, llava, etc.) que no entienden el formato `.enc`. El plaintext es ephemeral: las rutinas de cleanup (`cleanup_old`, `cleanup_by_count`, `cleanup_by_size` y `storage_housekeeping`) lo purgan junto con el `.enc` por mtime / count / size.
+
+## Self-test al startup
+
+`lifeosd` ejecuta `screenshot_crypt::self_test_at_startup()` en cada boot. Esto:
+
+1. Carga (o genera) la key en `/var/lib/lifeos/secrets/screenshot.key`.
+2. Escribe un probe ciphertext en un tempfile via `encrypt_to_file`.
+3. Lo descifra via `decrypt_from_file` y valida el round-trip.
+4. Loggea `screenshot_crypt: self-test OK` o el error específico.
+
+Si el self-test falla, el daemon sigue arrancando — solo se loggea un warning. El efecto práctico es que las nuevas capturas omitirán el sidecar `.enc` (el plaintext sigue escribiéndose como antes de este PR), comportamiento fail-open.
+
+## Threat model — qué SÍ protege
+
+- **Laptop robada con el disco extraído** y leído offline (cold-disk attack). El atacante ve solo ciphertext; sin la key (que vive en `/var/lib/lifeos/secrets/`, fuera del directorio de screenshots), no puede recuperar las imágenes. Defensa en profundidad sobre LUKS-at-rest.
+- **Backup-leak**: si alguien hace `tar cf` de `/var/lib/lifeos/screenshots/` y lo sube a una nube, lo que se filtra son solo `.enc`. La key NO está en ese directorio, por eso un backup del directorio de screenshots no compromete las imágenes.
+- **Proceso bajo otro UID** o sandboxed (flatpak, systemd-run scope) con read sobre el directorio de screenshots pero sin acceso a `/var/lib/lifeos/secrets/` (mode 0700).
+
+## Threat model — qué NO protege
+
+- **Atacante same-UID con acceso al daemon en runtime.** Si está corriendo bajo el mismo UID que `lifeosd`, puede leer la key y descifrar todo. Esa amenaza ya gana, este layer no la frena.
+- **Ataque online con root.** Quien tiene root puede leer la key, los plaintext frescos, o llamar al daemon API para que descifre por él.
+- **Side-channels contra el daemon en runtime** (memory dumps, `/proc/$pid/mem`). Mitigaciones a nivel SO (kernel hardening, ptrace_scope=2) son ortogonales.
+- **Plaintexts vivos durante la ventana de retención.** Mientras el archivo `.png` plaintext exista en disco (entre la captura y el siguiente cleanup tick), un atacante que pueda leer ese path lo ve en claro. Para encryption end-to-end (sin plaintext en disco) hay que refactorizar `sensory_pipeline.rs` para consumir bytes vía `decrypt_from_file` — tracked como follow-up.
+
+## Migración de screenshots existentes
+
+**No se migran automáticamente.** Screenshots capturadas antes de esta versión solo existen como `.png`/`.jpg`/`.webp` planos. Las nuevas capturas escriben tanto plaintext como `.enc`. Las rutinas de cleanup van a barrer los archivos viejos por edad (`EPHEMERAL_RETENTION_DAYS`, ~7 días) y count, así que el dataset se "auto-cifra" naturalmente al rotar.
+
+Si querés forzar la migración, podés:
+
+```bash
+# Manual one-shot — solo en máquinas con LifeOS instalada
+sudo systemctl stop lifeosd
+# (no hay tooling oficial todavía; la opción más simple es borrar
+#  los archivos legacy, que se regenerarán cifrados al próximo uso)
+sudo find /var/lib/lifeos/screenshots -maxdepth 1 -type f \
+    \( -name "*.png" -o -name "*.jpg" -o -name "*.webp" \) -delete
+sudo systemctl start lifeosd
+```
+
+## Tests
+
+- Round-trip plaintext → ciphertext → plaintext (`screenshot_crypt::tests::round_trip_recovers_plaintext`).
+- Tamper detection: flip de 1 byte en el ciphertext hace fallar el decrypt (`tamper_detection_fails_decrypt`).
+- Persistencia de key entre loads (`key_persists_across_loads`).
+- Decrypt con key incorrecta falla (`wrong_key_fails_decrypt`).
+- Detección de blob demasiado corto (`short_blob_is_rejected`).
+
+Correr: `cargo test screenshot_crypt --features "dbus,http-api,wake-word,messaging" --locked --manifest-path daemon/Cargo.toml`.
+
+## Limitaciones conocidas
+
+1. **Plaintext sigue en disco hasta el cleanup.** Documentado arriba.
+2. **No hay key rotation tooling.** Rotar a mano implica descifrar todo y re-cifrar.
+3. **No hay key escrow.** Si el archivo de key se pierde o corrompe (y se regenera), todos los `.enc` previos son irrecuperables.
+4. **No protege contra el daemon comprometido.** El daemon tiene la key en memoria al cifrar/descifrar. Un atacante que controle el daemon ya ganó.
+
+## Referencias
+
+- Implementación: `daemon/src/screenshot_crypt.rs`
+- Wire-up: `daemon/src/screen_capture.rs::finalize_capture_file` y `daemon/src/main.rs::main` (self-test).
+- Patrón de key persistente: `daemon/src/self_improving.rs::load_or_create_hmac_key`
+- Crate: `aes-gcm-siv = "0.11"` (ya en `daemon/Cargo.toml`)

--- a/docs/operations/screenshot-encryption.md
+++ b/docs/operations/screenshot-encryption.md
@@ -61,12 +61,13 @@ Si querés forzar la migración, podés:
 
 ```bash
 # Manual one-shot — solo en máquinas con LifeOS instalada
-sudo systemctl stop lifeosd
+# lifeosd corre en --user scope (no system scope).
+systemctl --user stop lifeosd
 # (no hay tooling oficial todavía; la opción más simple es borrar
 #  los archivos legacy, que se regenerarán cifrados al próximo uso)
 sudo find /var/lib/lifeos/screenshots -maxdepth 1 -type f \
     \( -name "*.png" -o -name "*.jpg" -o -name "*.webp" \) -delete
-sudo systemctl start lifeosd
+systemctl --user start lifeosd
 ```
 
 ## Tests


### PR DESCRIPTION
## Summary

Adds at-rest encryption for screenshots captured by `lifeosd` using **AES-256-GCM-SIV**. Each capture now produces a `<name>.enc` sidecar alongside the plaintext file. The plaintext lives only until the existing cleanup paths purge it; the `.enc` sidecar is what survives at rest.

### Key management

- Path: `/var/lib/lifeos/secrets/screenshot.key` (32 bytes, mode `0600`).
- Parent dir mode `0700`.
- Generated once with `rand::thread_rng().fill_bytes`; persisted thereafter.
- Same pattern as `workflow-hmac.key` from PR #31 (`self_improving.rs::load_or_create_hmac_key`).

### Wire-up

- `screen_capture.rs::finalize_capture_file` writes the `.enc` sidecar via `tokio::task::spawn_blocking` (fail-open: warns on error, plaintext still written).
- `screen_capture.rs::list_screenshots` skips `.enc` entries.
- `screen_capture.rs::delete_screenshot` removes the sidecar too.
- `main.rs::main` runs `screenshot_crypt::self_test_at_startup()` on every boot to validate key load + round-trip BEFORE the first capture.

### Why plaintext stays around

`sensory_pipeline.rs` and `overlay.rs` hand the screenshot path to external binaries (`identify`, llava). They cannot read AES ciphertext. End-to-end encryption (no plaintext on disk) requires refactoring `sensory_pipeline.rs` to consume bytes via `decrypt_from_file` — tracked as a follow-up.

## Threat model (full doc in `docs/operations/screenshot-encryption.md`)

**Protects against:**
- Stolen laptop with disk extracted and read offline (cold-disk).
- Backup-leak: `tar`-ing `/var/lib/lifeos/screenshots/` only exposes ciphertext — the key lives in a separate directory.
- Other-UID and sandboxed processes that can read screenshots but not `/var/lib/lifeos/secrets/`.

**Does NOT protect against:**
- Same-UID attacker (can read both key and screenshots).
- Online attacker with root.
- Daemon side-channels (memory dumps).
- Plaintext window between capture and next cleanup tick.

## Test plan

- [x] cargo fmt --check (laptop, FMT_OK)
- [x] cargo clippy with full feature set, -D warnings (laptop, CLIPPY_OK)
- [x] cargo test screenshot_crypt — 6/6 pass: round-trip, tamper detection, key persistence, wrong-key failure, path derivation, short-blob rejection
- [ ] CI green