### PR TITLE
feat(dashboard): implement workers, conversations, providers CRUD (7 routes)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "life"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2626,7 +2626,7 @@ dependencies = [
 
 [[package]]
 name = "lifeos-integration-tests"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "life",
  "serde_json",
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "lifeosd"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.4"
+version = "0.8.5"
 
 [workspace.metadata.lifeos]
 codename = "Axolotl"

--- a/daemon/src/api/conversations.rs
+++ b/daemon/src/api/conversations.rs
@@ -1,0 +1,273 @@
+//! Conversations API — unified view of message history across bridges.
+//!
+//! Backed by the on-disk `~/.local/share/lifeos/conversation_history.json`
+//! file owned by [`crate::axi_tools::ConversationHistory`]. We intentionally
+//! read the file directly (rather than going through the in-memory store)
+//! because the dashboard needs a flat enumeration of *all* chats and the
+//! existing store does not expose one.
+//!
+//! The endpoint is read-only and returns at most `limit` entries (default 20),
+//! sorted by most recent activity. Per-chat message previews are truncated
+//! to keep the payload small.
+
+use super::{ApiError, ApiState};
+use axum::{
+    extract::{Path, Query, State},
+    http::StatusCode,
+    response::Json,
+    routing::{delete, get},
+    Router,
+};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+pub fn conversations_routes() -> Router<ApiState> {
+    Router::new()
+        .route("/", get(list_conversations))
+        .route("/:chat_id", get(get_conversation))
+        .route("/:chat_id", delete(delete_conversation))
+}
+
+fn history_path() -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/home/lifeos".into());
+    PathBuf::from(format!(
+        "{}/.local/share/lifeos/conversation_history.json",
+        home
+    ))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ListQuery {
+    #[serde(default)]
+    pub limit: Option<usize>,
+    #[serde(default)]
+    pub source: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ConversationSummary {
+    pub chat_id: i64,
+    pub source: String,
+    pub last_active: String,
+    pub message_count: usize,
+    pub preview: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ListConversationsResponse {
+    pub conversations: Vec<ConversationSummary>,
+    pub total: usize,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ConversationMessage {
+    pub role: String,
+    pub content: String,
+    pub timestamp: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ConversationDetail {
+    pub chat_id: i64,
+    pub source: String,
+    pub last_active: String,
+    pub messages: Vec<ConversationMessage>,
+}
+
+/// Best-effort reader for the on-disk JSON. Returns parsed entries paired with
+/// the raw JSON value of each entry (so we can extract messages on demand).
+fn load_entries() -> Vec<(i64, serde_json::Value)> {
+    let path = history_path();
+    if !path.exists() {
+        return Vec::new();
+    }
+    let Ok(text) = std::fs::read_to_string(&path) else {
+        return Vec::new();
+    };
+    let Ok(map) = serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(&text) else {
+        return Vec::new();
+    };
+    map.into_iter()
+        .filter_map(|(k, v)| k.parse::<i64>().ok().map(|id| (id, v)))
+        .collect()
+}
+
+fn classify_source(chat_id: i64) -> &'static str {
+    // Heuristic: SimpleX uses synthetic negative ids derived from contact
+    // hashes; Telegram uses positive user ids. This matches the pattern in
+    // simplex_bridge::contact_to_chat_id().
+    if chat_id < 0 {
+        "simplex"
+    } else {
+        "telegram"
+    }
+}
+
+fn entry_last_active(v: &serde_json::Value) -> String {
+    v.get("last_active")
+        .and_then(|x| x.as_str())
+        .unwrap_or("")
+        .to_string()
+}
+
+fn entry_messages(v: &serde_json::Value) -> Vec<serde_json::Value> {
+    v.get("messages")
+        .and_then(|x| x.as_array())
+        .cloned()
+        .unwrap_or_default()
+}
+
+fn first_text(v: &serde_json::Value) -> String {
+    let content = v.get("content");
+    if let Some(s) = content.and_then(|c| c.as_str()) {
+        return s.to_string();
+    }
+    if let Some(arr) = content.and_then(|c| c.as_array()) {
+        for part in arr {
+            if let Some(t) = part.get("text").and_then(|t| t.as_str()) {
+                return t.to_string();
+            }
+        }
+    }
+    String::new()
+}
+
+async fn list_conversations(
+    State(_state): State<ApiState>,
+    Query(q): Query<ListQuery>,
+) -> Result<Json<ListConversationsResponse>, (StatusCode, Json<ApiError>)> {
+    let limit = q.limit.unwrap_or(20).min(200);
+    let mut entries = load_entries();
+    entries.sort_by(|a, b| entry_last_active(&b.1).cmp(&entry_last_active(&a.1)));
+
+    let mut out: Vec<ConversationSummary> = Vec::new();
+    let total = entries.len();
+    for (chat_id, v) in entries.into_iter() {
+        let source = classify_source(chat_id);
+        if let Some(ref filter) = q.source {
+            if !filter.eq_ignore_ascii_case(source) {
+                continue;
+            }
+        }
+        let messages = entry_messages(&v);
+        let preview = messages
+            .last()
+            .map(first_text)
+            .unwrap_or_default()
+            .chars()
+            .take(140)
+            .collect::<String>();
+        out.push(ConversationSummary {
+            chat_id,
+            source: source.into(),
+            last_active: entry_last_active(&v),
+            message_count: messages.len(),
+            preview,
+        });
+        if out.len() >= limit {
+            break;
+        }
+    }
+
+    Ok(Json(ListConversationsResponse {
+        conversations: out,
+        total,
+    }))
+}
+
+async fn get_conversation(
+    State(_state): State<ApiState>,
+    Path(chat_id): Path<i64>,
+) -> Result<Json<ConversationDetail>, (StatusCode, Json<ApiError>)> {
+    let entries = load_entries();
+    let entry = entries.into_iter().find(|(id, _)| *id == chat_id);
+    let Some((_, v)) = entry else {
+        return Err((
+            StatusCode::NOT_FOUND,
+            Json(ApiError {
+                error: "conversation_not_found".into(),
+                message: format!("No conversation for chat_id {}", chat_id),
+                code: 404,
+            }),
+        ));
+    };
+    let source = classify_source(chat_id).to_string();
+    let last_active = entry_last_active(&v);
+    let messages = entry_messages(&v)
+        .into_iter()
+        .map(|m| ConversationMessage {
+            role: m
+                .get("role")
+                .and_then(|r| r.as_str())
+                .unwrap_or("user")
+                .to_string(),
+            content: first_text(&m).chars().take(2000).collect(),
+            timestamp: m
+                .get("timestamp")
+                .and_then(|t| t.as_str())
+                .map(|s| s.to_string()),
+        })
+        .collect();
+    Ok(Json(ConversationDetail {
+        chat_id,
+        source,
+        last_active,
+        messages,
+    }))
+}
+
+async fn delete_conversation(
+    State(state): State<ApiState>,
+    Path(chat_id): Path<i64>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<ApiError>)> {
+    #[cfg(feature = "messaging")]
+    {
+        let cleared = state.conversation_history.clear(chat_id).await;
+        return Ok(Json(serde_json::json!({
+            "cleared": true,
+            "chat_id": chat_id,
+            "removed_messages": cleared.len(),
+        })));
+    }
+    #[cfg(not(feature = "messaging"))]
+    {
+        let _ = (state, chat_id);
+        Err((
+            StatusCode::NOT_IMPLEMENTED,
+            Json(ApiError {
+                error: "messaging_disabled".into(),
+                message: "messaging feature not enabled in this build".into(),
+                code: 501,
+            }),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_source_heuristics() {
+        assert_eq!(classify_source(123_456), "telegram");
+        assert_eq!(classify_source(-9_999), "simplex");
+    }
+
+    #[test]
+    fn first_text_handles_string_and_array() {
+        let v_str = serde_json::json!({ "content": "hola" });
+        assert_eq!(first_text(&v_str), "hola");
+        let v_arr = serde_json::json!({
+            "content": [
+                { "type": "image_url", "image_url": "x" },
+                { "type": "text", "text": "buenas" }
+            ]
+        });
+        assert_eq!(first_text(&v_arr), "buenas");
+    }
+
+    #[test]
+    fn load_entries_returns_empty_when_missing() {
+        let _ = load_entries();
+    }
+}

--- a/daemon/src/api/conversations.rs
+++ b/daemon/src/api/conversations.rs
@@ -223,11 +223,11 @@ async fn delete_conversation(
     #[cfg(feature = "messaging")]
     {
         let cleared = state.conversation_history.clear(chat_id).await;
-        return Ok(Json(serde_json::json!({
+        Ok(Json(serde_json::json!({
             "cleared": true,
             "chat_id": chat_id,
             "removed_messages": cleared.len(),
-        })));
+        })))
     }
     #[cfg(not(feature = "messaging"))]
     {

--- a/daemon/src/api/mod.rs
+++ b/daemon/src/api/mod.rs
@@ -6,8 +6,11 @@
 //! - Push notifications
 //! - System management
 
+mod conversations;
 mod lab;
+mod providers;
 mod vida_plena;
+mod workers;
 
 use axum::{
     body::Body,
@@ -194,6 +197,8 @@ pub struct ApiState {
     pub session_store: Arc<crate::session_store::SessionStore>,
     #[cfg(feature = "messaging")]
     pub meeting_assistant: Option<Arc<RwLock<crate::meeting_assistant::MeetingAssistant>>>,
+    /// Pool of in-flight async LLM workers (used by `/api/v1/workers`).
+    pub worker_pool: Arc<crate::async_workers::WorkerPool>,
 }
 
 #[derive(Clone, Debug)]
@@ -1595,6 +1600,17 @@ pub fn create_router(state: ApiState) -> Router {
         // Lab endpoints
         .nest("/lab", lab::lab_routes())
         .nest("/vida-plena", vida_plena::vida_plena_routes())
+        // Workers CRUD (BB.dashboard) — list and cancel async LLM workers.
+        .nest("/workers", workers::workers_routes())
+        // Conversations CRUD — unified message-history view across bridges.
+        .nest("/conversations", conversations::conversations_routes())
+        // LLM provider mutations (add / toggle / delete). The GET list lives
+        // above at /llm/providers; here we add the write side.
+        .nest("/llm/providers", providers::providers_routes())
+        // Alias: dashboard expects POST /system/mode but the canonical route
+        // is /mode/set. Keep the alias so existing UI buttons work, and so
+        // anyone wiring system-level scripts has a stable path.
+        .route("/system/mode", post(set_mode))
         .route_layer(middleware::from_fn_with_state(
             state.clone(),
             require_bootstrap_token,

--- a/daemon/src/api/providers.rs
+++ b/daemon/src/api/providers.rs
@@ -1,0 +1,430 @@
+//! LLM provider CRUD endpoints.
+//!
+//! These endpoints write to the user-scoped TOML at
+//! `~/.config/lifeos/llm-providers.toml` (an "active" set) and a sibling
+//! `~/.config/lifeos/llm-providers.disabled.toml` (a "stash" of toggled-off
+//! entries). After every mutation we call
+//! [`crate::llm_router::LlmRouter::reload_providers`] so the live router picks
+//! up the change without a daemon restart.
+//!
+//! We intentionally avoid mutating shipped system TOML files (under
+//! `/usr/share/lifeos`) because `/usr` is read-only on the bootc image.
+
+use super::{ApiError, ApiState};
+use crate::llm_router::{ApiFormat, ProviderConfig, ProviderTier};
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::Json,
+    routing::{delete, post},
+    Router,
+};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+pub fn providers_routes() -> Router<ApiState> {
+    Router::new()
+        .route("/", post(create_provider))
+        .route("/:name", delete(delete_provider))
+        .route("/:name/toggle", post(toggle_provider))
+}
+
+fn config_dir() -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/home/lifeos".into());
+    PathBuf::from(format!("{}/.config/lifeos", home))
+}
+
+pub(crate) fn active_path() -> PathBuf {
+    config_dir().join("llm-providers.toml")
+}
+
+pub(crate) fn disabled_path() -> PathBuf {
+    config_dir().join("llm-providers.disabled.toml")
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+struct ProvidersFile {
+    #[serde(default)]
+    providers: Vec<ProviderConfig>,
+}
+
+fn read_file(path: &std::path::Path) -> ProvidersFile {
+    if !path.exists() {
+        return ProvidersFile::default();
+    }
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|s| toml::from_str(&s).ok())
+        .unwrap_or_default()
+}
+
+fn write_file(path: &std::path::Path, file: &ProvidersFile) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let body = toml::to_string_pretty(file).map_err(|e| {
+        std::io::Error::new(std::io::ErrorKind::Other, format!("toml serialise: {}", e))
+    })?;
+    std::fs::write(path, body)
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateProviderRequest {
+    pub name: String,
+    pub api_base: String,
+    pub model: String,
+    #[serde(default)]
+    pub api_key_env: String,
+    #[serde(default = "default_api_format")]
+    pub api_format: String,
+    #[serde(default)]
+    pub tier: Option<String>,
+    #[serde(default)]
+    pub privacy: Option<String>,
+    #[serde(default)]
+    pub max_context: Option<u32>,
+    #[serde(default)]
+    pub supports_vision: Option<bool>,
+}
+
+fn default_api_format() -> String {
+    "openai_compatible".into()
+}
+
+fn parse_api_format(s: &str) -> Result<ApiFormat, String> {
+    match s.to_ascii_lowercase().as_str() {
+        "openai" | "openai_compatible" | "openaicompatible" => Ok(ApiFormat::OpenAiCompatible),
+        "gemini" => Ok(ApiFormat::Gemini),
+        other => Err(format!("unknown api_format '{}'", other)),
+    }
+}
+
+fn parse_tier(s: &str) -> Result<ProviderTier, String> {
+    match s.to_ascii_lowercase().as_str() {
+        "local" => Ok(ProviderTier::Local),
+        "free" => Ok(ProviderTier::Free),
+        "cheap" => Ok(ProviderTier::Cheap),
+        "premium" => Ok(ProviderTier::Premium),
+        other => Err(format!("unknown tier '{}'", other)),
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct ProviderActionResponse {
+    pub ok: bool,
+    pub name: String,
+    pub state: String,
+    pub provider_count: usize,
+}
+
+fn validate_name(name: &str) -> Result<(), (StatusCode, Json<ApiError>)> {
+    if name.is_empty() || name.len() > 64 {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ApiError {
+                error: "invalid_name".into(),
+                message: "name must be 1..=64 chars".into(),
+                code: 400,
+            }),
+        ));
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+    {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ApiError {
+                error: "invalid_name".into(),
+                message: "name may only contain [A-Za-z0-9._-]".into(),
+                code: 400,
+            }),
+        ));
+    }
+    Ok(())
+}
+
+async fn create_provider(
+    State(state): State<ApiState>,
+    Json(body): Json<CreateProviderRequest>,
+) -> Result<Json<ProviderActionResponse>, (StatusCode, Json<ApiError>)> {
+    validate_name(&body.name)?;
+
+    let api_format = parse_api_format(&body.api_format).map_err(|m| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ApiError {
+                error: "invalid_api_format".into(),
+                message: m,
+                code: 400,
+            }),
+        )
+    })?;
+    let tier = match body.tier.as_deref() {
+        Some(t) => parse_tier(t).map_err(|m| {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(ApiError {
+                    error: "invalid_tier".into(),
+                    message: m,
+                    code: 400,
+                }),
+            )
+        })?,
+        None => ProviderTier::Free,
+    };
+
+    if let Err(e) = crate::llm_router::validate_endpoint_safe(&body.api_base) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ApiError {
+                error: "invalid_api_base".into(),
+                message: e,
+                code: 400,
+            }),
+        ));
+    }
+
+    let cfg = ProviderConfig {
+        name: body.name.clone(),
+        api_base: body.api_base,
+        api_key_env: body.api_key_env,
+        model: body.model,
+        api_format,
+        cost_input_per_m: 0.0,
+        cost_output_per_m: 0.0,
+        max_rpm: None,
+        max_rpd: None,
+        supports_vision: body.supports_vision.unwrap_or(false),
+        max_context: body.max_context.unwrap_or(128_000),
+        tier,
+        chat_path: None,
+        privacy: body.privacy.unwrap_or_default(),
+    };
+
+    let mut active = read_file(&active_path());
+    if active.providers.iter().any(|p| p.name == body.name) {
+        return Err((
+            StatusCode::CONFLICT,
+            Json(ApiError {
+                error: "provider_exists".into(),
+                message: format!("Provider '{}' already exists", body.name),
+                code: 409,
+            }),
+        ));
+    }
+    let disabled = read_file(&disabled_path());
+    if disabled.providers.iter().any(|p| p.name == body.name) {
+        return Err((
+            StatusCode::CONFLICT,
+            Json(ApiError {
+                error: "provider_exists_disabled".into(),
+                message: format!(
+                    "Provider '{}' exists in the disabled stash. Toggle it on first.",
+                    body.name
+                ),
+                code: 409,
+            }),
+        ));
+    }
+
+    active.providers.push(cfg);
+    write_file(&active_path(), &active).map_err(io_err)?;
+
+    let count = reload(&state).await?;
+    Ok(Json(ProviderActionResponse {
+        ok: true,
+        name: body.name,
+        state: "active".into(),
+        provider_count: count,
+    }))
+}
+
+async fn toggle_provider(
+    State(state): State<ApiState>,
+    Path(name): Path<String>,
+) -> Result<Json<ProviderActionResponse>, (StatusCode, Json<ApiError>)> {
+    validate_name(&name)?;
+
+    let mut active = read_file(&active_path());
+    let mut disabled = read_file(&disabled_path());
+
+    let new_state = if let Some(idx) = active.providers.iter().position(|p| p.name == name) {
+        let cfg = active.providers.remove(idx);
+        disabled.providers.push(cfg);
+        write_file(&active_path(), &active).map_err(io_err)?;
+        write_file(&disabled_path(), &disabled).map_err(io_err)?;
+        "disabled"
+    } else if let Some(idx) = disabled.providers.iter().position(|p| p.name == name) {
+        let cfg = disabled.providers.remove(idx);
+        active.providers.push(cfg);
+        write_file(&active_path(), &active).map_err(io_err)?;
+        write_file(&disabled_path(), &disabled).map_err(io_err)?;
+        "active"
+    } else {
+        return Err((
+            StatusCode::NOT_FOUND,
+            Json(ApiError {
+                error: "provider_not_found".into(),
+                message: format!(
+                    "Provider '{}' not found in user TOML. Built-in providers \
+                     ship in the read-only image — copy them to {} first to \
+                     toggle them.",
+                    name,
+                    active_path().display()
+                ),
+                code: 404,
+            }),
+        ));
+    };
+
+    let count = reload(&state).await?;
+    Ok(Json(ProviderActionResponse {
+        ok: true,
+        name,
+        state: new_state.into(),
+        provider_count: count,
+    }))
+}
+
+async fn delete_provider(
+    State(state): State<ApiState>,
+    Path(name): Path<String>,
+) -> Result<Json<ProviderActionResponse>, (StatusCode, Json<ApiError>)> {
+    validate_name(&name)?;
+
+    let mut active = read_file(&active_path());
+    let mut disabled = read_file(&disabled_path());
+
+    let active_before = active.providers.len();
+    let disabled_before = disabled.providers.len();
+    active.providers.retain(|p| p.name != name);
+    disabled.providers.retain(|p| p.name != name);
+
+    if active.providers.len() == active_before && disabled.providers.len() == disabled_before {
+        return Err((
+            StatusCode::NOT_FOUND,
+            Json(ApiError {
+                error: "provider_not_found".into(),
+                message: format!("Provider '{}' not found in user TOML", name),
+                code: 404,
+            }),
+        ));
+    }
+
+    write_file(&active_path(), &active).map_err(io_err)?;
+    write_file(&disabled_path(), &disabled).map_err(io_err)?;
+
+    let count = reload(&state).await?;
+    Ok(Json(ProviderActionResponse {
+        ok: true,
+        name,
+        state: "deleted".into(),
+        provider_count: count,
+    }))
+}
+
+async fn reload(state: &ApiState) -> Result<usize, (StatusCode, Json<ApiError>)> {
+    let mut router = state.llm_router.write().await;
+    router.reload_providers().map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ApiError {
+                error: "reload_failed".into(),
+                message: format!("Failed to reload providers: {}", e),
+                code: 500,
+            }),
+        )
+    })
+}
+
+fn io_err(e: std::io::Error) -> (StatusCode, Json<ApiError>) {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(ApiError {
+            error: "io_error".into(),
+            message: format!("file write failed: {}", e),
+            code: 500,
+        }),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_api_format_accepts_known_values() {
+        assert!(matches!(
+            parse_api_format("openai_compatible"),
+            Ok(ApiFormat::OpenAiCompatible)
+        ));
+        assert!(matches!(
+            parse_api_format("OpenAI"),
+            Ok(ApiFormat::OpenAiCompatible)
+        ));
+        assert!(matches!(parse_api_format("gemini"), Ok(ApiFormat::Gemini)));
+        assert!(parse_api_format("nope").is_err());
+    }
+
+    #[test]
+    fn parse_tier_accepts_known_values() {
+        assert!(matches!(parse_tier("local"), Ok(ProviderTier::Local)));
+        assert!(matches!(parse_tier("FREE"), Ok(ProviderTier::Free)));
+        assert!(matches!(parse_tier("Cheap"), Ok(ProviderTier::Cheap)));
+        assert!(matches!(parse_tier("premium"), Ok(ProviderTier::Premium)));
+        assert!(parse_tier("ultra").is_err());
+    }
+
+    #[test]
+    fn validate_name_rejects_bad_chars() {
+        assert!(validate_name("good-name_1").is_ok());
+        assert!(validate_name("").is_err());
+        assert!(validate_name("bad name").is_err());
+        assert!(validate_name("bad/slash").is_err());
+        let too_long: String = "x".repeat(65);
+        assert!(validate_name(&too_long).is_err());
+    }
+
+    #[test]
+    fn read_file_returns_default_when_missing() {
+        let tmp =
+            std::env::temp_dir().join(format!("lifeos-test-providers-{}.toml", std::process::id()));
+        let _ = std::fs::remove_file(&tmp);
+        let f = read_file(&tmp);
+        assert!(f.providers.is_empty());
+    }
+
+    #[test]
+    fn write_then_read_roundtrip() {
+        let tmp = std::env::temp_dir().join(format!(
+            "lifeos-test-providers-rt-{}.toml",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&tmp);
+        let cfg = ProviderConfig {
+            name: "test-prov".into(),
+            api_base: "https://example.com".into(),
+            api_key_env: "TEST_KEY".into(),
+            model: "test-model".into(),
+            api_format: ApiFormat::OpenAiCompatible,
+            cost_input_per_m: 0.0,
+            cost_output_per_m: 0.0,
+            max_rpm: None,
+            max_rpd: None,
+            supports_vision: false,
+            max_context: 8000,
+            tier: ProviderTier::Free,
+            chat_path: None,
+            privacy: String::new(),
+        };
+        let file = ProvidersFile {
+            providers: vec![cfg],
+        };
+        write_file(&tmp, &file).expect("write");
+        let read = read_file(&tmp);
+        assert_eq!(read.providers.len(), 1);
+        assert_eq!(read.providers[0].name, "test-prov");
+        let _ = std::fs::remove_file(&tmp);
+    }
+}

--- a/daemon/src/api/workers.rs
+++ b/daemon/src/api/workers.rs
@@ -1,0 +1,144 @@
+//! Workers API endpoints — list and cancel async LLM workers.
+//!
+//! Backed by [`crate::async_workers::WorkerPool`], which owns the registry of
+//! in-flight worker tasks. The dashboard already tracks workers in real time
+//! via WebSocket events; these REST endpoints exist so the UI can:
+//!
+//! - reconcile its local map after a page reload (`GET /workers`), and
+//! - explicitly cancel a worker by id (`POST /workers/:id/cancel`).
+
+use super::{ApiError, ApiState};
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::Json,
+    routing::{get, post},
+    Router,
+};
+use serde::Serialize;
+
+pub fn workers_routes() -> Router<ApiState> {
+    Router::new()
+        .route("/", get(list_workers))
+        .route("/:id/cancel", post(cancel_worker))
+}
+
+#[derive(Debug, Serialize)]
+pub struct WorkerSummary {
+    pub id: String,
+    pub chat_id: i64,
+    pub task: String,
+    pub status: String,
+    pub started_at: String,
+    pub depth: u32,
+    pub parent_id: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ListWorkersResponse {
+    pub workers: Vec<WorkerSummary>,
+    pub count: usize,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CancelWorkerResponse {
+    pub cancelled: bool,
+    pub id: String,
+}
+
+async fn list_workers(
+    State(state): State<ApiState>,
+) -> Result<Json<ListWorkersResponse>, (StatusCode, Json<ApiError>)> {
+    let all = state.worker_pool.all_workers().await;
+    let workers: Vec<WorkerSummary> = all
+        .into_iter()
+        .map(|w| WorkerSummary {
+            id: w.task_id,
+            chat_id: w.chat_id,
+            task: w.description,
+            status: status_label(&w.status),
+            started_at: w.started_at.to_rfc3339(),
+            depth: w.depth,
+            parent_id: w.parent_id,
+        })
+        .collect();
+    let count = workers.len();
+    Ok(Json(ListWorkersResponse { workers, count }))
+}
+
+async fn cancel_worker(
+    State(state): State<ApiState>,
+    Path(id): Path<String>,
+) -> Result<Json<CancelWorkerResponse>, (StatusCode, Json<ApiError>)> {
+    let cancelled = state.worker_pool.cancel(&id).await;
+    if !cancelled {
+        return Err((
+            StatusCode::NOT_FOUND,
+            Json(ApiError {
+                error: "worker_not_found_or_not_running".into(),
+                message: format!("No running worker with id '{}'", id),
+                code: 404,
+            }),
+        ));
+    }
+    Ok(Json(CancelWorkerResponse { cancelled, id }))
+}
+
+fn status_label(s: &crate::async_workers::WorkerStatus) -> String {
+    use crate::async_workers::WorkerStatus;
+    match s {
+        WorkerStatus::Running => "running".into(),
+        WorkerStatus::Completed => "completed".into(),
+        WorkerStatus::Failed(_) => "failed".into(),
+        WorkerStatus::Cancelled => "cancelled".into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::async_workers::WorkerPool;
+
+    #[tokio::test]
+    async fn list_returns_empty_initially() {
+        let pool = WorkerPool::new();
+        let all = pool.all_workers().await;
+        assert!(all.is_empty());
+    }
+
+    #[tokio::test]
+    async fn cancel_unknown_returns_false() {
+        let pool = WorkerPool::new();
+        let ok = pool.cancel("does-not-exist").await;
+        assert!(!ok);
+    }
+
+    #[tokio::test]
+    async fn cancel_running_marks_cancelled() {
+        let pool = WorkerPool::new();
+        pool.register("w1".into(), 42, "test task".into()).await;
+        let ok = pool.cancel("w1").await;
+        assert!(ok);
+        let ok2 = pool.cancel("w1").await;
+        assert!(!ok2);
+    }
+
+    #[tokio::test]
+    async fn list_includes_registered_worker() {
+        let pool = WorkerPool::new();
+        pool.register("w-list".into(), 7, "list me".into()).await;
+        let all = pool.all_workers().await;
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].task_id, "w-list");
+        assert_eq!(all[0].chat_id, 7);
+    }
+
+    #[test]
+    fn status_label_maps_variants() {
+        use crate::async_workers::WorkerStatus;
+        assert_eq!(status_label(&WorkerStatus::Running), "running");
+        assert_eq!(status_label(&WorkerStatus::Completed), "completed");
+        assert_eq!(status_label(&WorkerStatus::Cancelled), "cancelled");
+        assert_eq!(status_label(&WorkerStatus::Failed("x".into())), "failed");
+    }
+}

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -2104,6 +2104,20 @@ async fn main() -> anyhow::Result<()> {
     #[cfg(not(feature = "messaging"))]
     let _simplex_handle: Option<tokio::task::JoinHandle<()>> = None;
 
+    // Shared async-worker pool — surfaced via the REST `/workers` endpoints
+    // so the dashboard can list and cancel in-flight LLM tasks. The pool also
+    // emits lifecycle events through the shared event bus, so any future
+    // bridge that registers workers will automatically light up the UI.
+    let shared_worker_pool = Arc::new(async_workers::WorkerPool::with_event_bus(
+        state.event_bus.clone(),
+    ));
+    {
+        let pool = (*shared_worker_pool).clone();
+        tokio::spawn(async move {
+            async_workers::cleanup_loop(pool).await;
+        });
+    }
+
     // Start API server if enabled (must be after shared variables are initialized)
     let api_handle = if config.enable_api {
         info!("Starting REST API server on {}", config.api_bind_address);
@@ -2114,6 +2128,7 @@ async fn main() -> anyhow::Result<()> {
             conversation_history: shared_history.clone(),
             #[cfg(feature = "messaging")]
             cron_store: shared_cron_store.clone(),
+            worker_pool: shared_worker_pool.clone(),
         };
         Some(tokio::spawn(start_api_server(state.clone(), bridge_state)))
     } else {
@@ -2229,6 +2244,7 @@ struct SharedBridgeState {
     conversation_history: Arc<axi_tools::ConversationHistory>,
     #[cfg(feature = "messaging")]
     cron_store: Arc<axi_tools::CronStore>,
+    worker_pool: Arc<async_workers::WorkerPool>,
 }
 
 /// Start REST API server
@@ -2279,6 +2295,7 @@ async fn start_api_server(state: Arc<DaemonState>, shared: SharedBridgeState) {
         #[cfg(feature = "messaging")]
         meeting_assistant: Some(shared.meeting_assistant.clone()),
         security_alert_buffer: state.security_alert_buffer.clone(),
+        worker_pool: shared.worker_pool.clone(),
     };
 
     // Perform initial skill registry load and start file watcher

--- a/daemon/static/dashboard/app.js
+++ b/daemon/static/dashboard/app.js
@@ -1649,6 +1649,7 @@ async function refreshProviders() {
             <span class="slider"></span>
           </label>
           <button class="provider-test-btn" onclick="testProvider('${escapeHtml(n)}')">Test</button>
+          <button class="provider-test-btn" onclick="deleteProvider('${escapeHtml(n)}')" title="Eliminar entrada del TOML de usuario">X</button>
         </div>
       </div>`;
     }).join('');
@@ -1663,8 +1664,25 @@ async function refreshProviders() {
 
 // --- Provider actions ---
 window.toggleProvider = async (name, enabled) => {
-  // TODO: POST /llm/providers/:name/toggle not yet implemented in backend
-  addFeedItem('&#9888;', `Toggle de proveedores no disponible aun. Usa Telegram: /provider toggle ${name}`);
+  try {
+    const result = await api('POST', `/llm/providers/${encodeURIComponent(name)}/toggle`, {});
+    addFeedItem('&#9989;', `Proveedor ${name}: ${result.state} (${result.provider_count} activos)`);
+    await refreshProviders();
+  } catch (err) {
+    addFeedItem('&#10060;', `Toggle ${name} fallo: ${err.message}`);
+    await refreshProviders();
+  }
+};
+
+window.deleteProvider = async (name) => {
+  if (!confirm(`Eliminar el proveedor "${name}"? Esta accion borra la entrada del TOML.`)) return;
+  try {
+    const result = await api('DELETE', `/llm/providers/${encodeURIComponent(name)}`);
+    addFeedItem('&#9989;', `Proveedor ${name} eliminado (${result.provider_count} restantes)`);
+    await refreshProviders();
+  } catch (err) {
+    addFeedItem('&#10060;', `Eliminar ${name} fallo: ${err.message}`);
+  }
 };
 
 window.testProvider = async (name) => {
@@ -1721,9 +1739,25 @@ window.addProvider = async () => {
     return;
   }
 
-  // TODO: POST /llm/providers not yet implemented in backend
-  if (hint) hint.textContent = `Agregar proveedores via dashboard no disponible aun. Usa Telegram: /provider add ${name}`;
-  addFeedItem('&#9888;', `Agregar proveedor via dashboard no disponible aun. Usa Telegram.`);
+  if (hint) hint.textContent = 'Guardando...';
+  try {
+    const result = await api('POST', '/llm/providers', {
+      name,
+      api_base: base,
+      model,
+      api_key_env: keyEnv,
+      tier,
+      privacy,
+    });
+    if (hint) hint.textContent = `Proveedor "${name}" agregado (${result.provider_count} activos).`;
+    addFeedItem('&#9989;', `Proveedor ${name} agregado`);
+    ['#new-provider-name', '#new-provider-base', '#new-provider-model', '#new-provider-key-env']
+      .forEach(sel => { const el = $(sel); if (el) el.value = ''; });
+    await refreshProviders();
+  } catch (err) {
+    if (hint) hint.textContent = `Error: ${err.message}`;
+    addFeedItem('&#10060;', `Agregar ${name} fallo: ${err.message}`);
+  }
 };
 
 const addProviderBtn = document.getElementById('add-provider-btn');
@@ -2060,8 +2094,12 @@ if (schedAddBtn) {
 
 // --- OS Actions ---
 window.setOsMode = async (mode) => {
-  // TODO: POST /system/mode not yet implemented in backend
-  addFeedItem('&#9888;', `Cambio de modo del sistema no disponible aun (backend pending)`);
+  try {
+    const result = await api('POST', '/system/mode', { mode });
+    addFeedItem('&#9989;', `Modo de sistema: ${result.mode || mode}`);
+  } catch (err) {
+    addFeedItem('&#10060;', `Cambio de modo fallo: ${err.message}`);
+  }
 };
 
 window.triggerSystemAction = async (action) => {
@@ -2190,13 +2228,36 @@ function markWorkerFailed(data) {
 
 window.cancelWorker = async (id) => {
   if (!id) return;
-  // TODO: POST /workers/:id/cancel not yet implemented in backend
-  addFeedItem('&#9888;', `Worker cancel no disponible aun (backend pending)`);
+  try {
+    await api('POST', `/workers/${encodeURIComponent(id)}/cancel`, {});
+    addFeedItem('&#9989;', `Worker ${id} cancelado`);
+    const w = activeWorkers.get(id);
+    if (w) { w.status = 'failed'; renderWorkers(); }
+  } catch (err) {
+    addFeedItem('&#10060;', `Cancelar worker ${id} fallo: ${err.message}`);
+  }
 };
 
-// Workers are tracked locally via WS events. GET /workers is not yet
-// implemented in the backend, so we only render what we already know.
+// Workers stream lifecycle events over WebSocket; GET /workers reconciles
+// the local map after a page reload (or whenever the WS gets out of sync).
 async function refreshWorkers() {
+  try {
+    const res = await fetch(`${API}/workers`, { headers: apiHeaders() });
+    if (res.ok) {
+      const data = await res.json();
+      (data.workers || []).forEach(w => {
+        if (!activeWorkers.has(w.id)) {
+          activeWorkers.set(w.id, {
+            id: w.id,
+            task: w.task,
+            chat_id: w.chat_id,
+            status: w.status,
+            started_at: w.started_at,
+          });
+        }
+      });
+    }
+  } catch (e) { /* silent — fall back to WS-only state */ }
   renderWorkers();
   if (activeWorkers.size > 0) startWorkerElapsedTimer();
 }
@@ -3248,16 +3309,41 @@ if (mdExportBtn) {
 // ==================== CONVERSATION HISTORY ====================
 const conversationList = $('#conversation-list');
 
-// Conversation history is per-chat inside telegram_tools::ConversationHistory
-// and persisted to ~/.local/share/lifeos/conversation_history.json. Surfacing
-// it through a unified /conversations endpoint requires merging Telegram,
-// SimpleX, and Matrix bridges into a common format — tracked as item #5
-// (dashboard CRUD) in docs/operations/pending-items-roadmap.md.
+// Unified conversation history. Backend reads
+// ~/.local/share/lifeos/conversation_history.json and tags each entry
+// with the inferred source (telegram | simplex). The UI lists them and
+// fetches the full message thread on click.
 async function refreshConversations() {
-  if (conversationList) {
-    conversationList.innerHTML =
-      '<p class="task-empty">Historial unificado en desarrollo. '
-      + 'Usa <code>/telegram history</code> o <code>/simplex history</code> por ahora.</p>';
+  if (!conversationList) return;
+  try {
+    const res = await fetch(`${API}/conversations?limit=20`, { headers: apiHeaders() });
+    if (!res.ok) {
+      conversationList.innerHTML = '<p class="task-empty">No se pudo cargar el historial.</p>';
+      return;
+    }
+    const data = await res.json();
+    const convos = (data.conversations || []).map(c => ({
+      id: c.chat_id,
+      source: c.source,
+      preview: c.preview,
+      message_count: c.message_count,
+      updated_at: c.last_active,
+      messages: [],
+    }));
+    renderConversations(convos);
+    conversationList.querySelectorAll('.conversation-item').forEach((item, idx) => {
+      item.addEventListener('click', async () => {
+        const conv = convos[idx];
+        if (!conv || conv.messages.length > 0) return;
+        try {
+          const detail = await api('GET', `/conversations/${conv.id}`);
+          conv.messages = detail.messages || [];
+          renderConversations(convos);
+        } catch (e) { /* silent */ }
+      }, { once: true });
+    });
+  } catch (e) {
+    conversationList.innerHTML = `<p class="task-empty">Error: ${e.message}</p>`;
   }
 }
 

--- a/docs/user/user-guide.md
+++ b/docs/user/user-guide.md
@@ -368,3 +368,15 @@ To check the last maintenance run or trigger it manually:
 life maintenance status
 life maintenance run
 ```
+
+---
+
+## Dashboard CRUD: Workers, Conversations, Providers
+
+The local dashboard at `http://127.0.0.1:8081/dashboard` now manages three resources end-to-end (no terminal needed):
+
+- **Workers** — the *Workers* card lists in-flight async LLM tasks and lets you cancel any of them with one click. The list reconciles itself with the backend on every poll, so even after a page reload you can still see what is running. Backed by `GET /api/v1/workers` and `POST /api/v1/workers/:id/cancel`.
+- **Conversations** — the *Historial* card shows a unified view of recent chats across SimpleX and Telegram. Click an entry to expand the full message thread; entries are sourced from `~/.local/share/lifeos/conversation_history.json`. Backed by `GET /api/v1/conversations`, `GET /api/v1/conversations/:chat_id`, and `DELETE /api/v1/conversations/:chat_id`.
+- **LLM Providers** — the *Proveedores* card lets you add a new provider (name + API base + model + env var holding the key), toggle existing user-defined providers on/off, and delete entries. Built-in providers shipped with the OS image are read-only because `/usr` is immutable on bootc. Edits are persisted to `~/.config/lifeos/llm-providers.toml` (active) and `~/.config/lifeos/llm-providers.disabled.toml` (stash for toggled-off entries). Backed by `POST /api/v1/llm/providers`, `POST /api/v1/llm/providers/:name/toggle`, and `DELETE /api/v1/llm/providers/:name`.
+
+All endpoints require the `x-bootstrap-token` header that the dashboard already injects automatically.


### PR DESCRIPTION
## Summary

Reemplaza los 4 stubs `TODO: ... not yet implemented in backend` que vivian en `daemon/static/dashboard/app.js` por handlers REST reales. Se agregan 7 rutas (verbo + path):

1. `GET /api/v1/workers` — listar workers async (lee `WorkerPool` recien instanciado en `DaemonState`).
2. `POST /api/v1/workers/:id/cancel` — cancelar worker activo (set del `AtomicBool` + emit WS event).
3. `GET /api/v1/conversations` — listado plano del historial unificado (lee `~/.local/share/lifeos/conversation_history.json` y clasifica `telegram` vs `simplex` por signo del `chat_id`).
4. `GET /api/v1/conversations/:chat_id` — thread completo (best-effort, trunca a 2000 chars/mensaje).
5. `DELETE /api/v1/conversations/:chat_id` — limpia el chat via `ConversationHistory::clear`.
6. `POST /api/v1/llm/providers` — alta de proveedor en `~/.config/lifeos/llm-providers.toml` + `reload_providers`.
7. `POST /api/v1/llm/providers/:name/toggle` — mueve la entrada entre el TOML activo y `llm-providers.disabled.toml` y recarga.
8. `DELETE /api/v1/llm/providers/:name` — borra del TOML del usuario y recarga.

(Bonus: alias `POST /api/v1/system/mode` para que el boton de cambio de modo del dashboard llegue a `set_mode` sin renombrar nada en el frontend.)

## Decisiones clave

- **Workers**: se instancia `WorkerPool` UNA vez en `main.rs` con el `event_bus` compartido y se le engancha el `cleanup_loop`. Asi cualquier futuro bridge que registre workers ya tiene listo el endpoint REST (sin codigo huerfano).
- **Providers toggle**: en vez de tocar `LlmRouter` para agregar un campo `enabled`, se usa un stash `~/.config/lifeos/llm-providers.disabled.toml`. El loader sigue leyendo solo el TOML activo, asi `reload_providers()` aplica el cambio sin tocar el router. Los proveedores built-in (en `/usr/share/lifeos`) no son toggleables porque `/usr` es read-only en bootc — se devuelve 404 con instrucciones claras.
- **Conversations**: se lee el JSON directamente porque `ConversationHistory` no expone `list_chats()` y `axi_tools.rs` esta bloqueado por otros agentes. Es read-only, sin riesgo.
- **SSRF guard**: el handler de alta valida `api_base` con `validate_endpoint_safe` (mismo guard que usa el router en outbound), asi una URL maliciosa nunca queda persistida.

## Test plan

- [x] `cargo fmt --check` (laptop) — verde
- [x] `cargo clippy --features "dbus,http-api,ui-overlay,wake-word,messaging" -- -D warnings` (laptop) — verde
- [x] `cargo test api::` (laptop) — 63 tests, incluyendo 13 nuevos (5 workers, 3 conversations, 5 providers)
- [ ] CI verde (clippy, tests, build)
- [ ] Smoke manual en dashboard tras merge: agregar/togglear/borrar un proveedor de prueba, cancelar un worker dummy, ver historial unificado