### PR TITLE
feat(dashboard): Vida Plena detail views — pillars, shopping, vault

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "life"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2626,7 +2626,7 @@ dependencies = [
 
 [[package]]
 name = "lifeos-integration-tests"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "life",
  "serde_json",
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "lifeosd"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.5"
+version = "0.8.6"
 
 [workspace.metadata.lifeos]
 codename = "Axolotl"

--- a/daemon/static/dashboard/app.js
+++ b/daemon/static/dashboard/app.js
@@ -3814,12 +3814,18 @@ async function refreshVidaPlena() {
         if (!pillarData) return '';
         let detail = '';
         try { detail = p.stat(pillarData); } catch {}
-        return `<div class="vida-plena-card">
+        return `<div class="vida-plena-card clickable" data-pillar="${p.key}" data-label="${p.label}" role="button" tabindex="0">
           <span class="pillar-name">${p.label}</span>
           <span class="pillar-detail">${detail || 'Sin datos'}</span>
         </div>`;
       }).filter(Boolean);
       summaryEl.innerHTML = cards.join('') || '<p class="task-empty">Sin datos de vida plena aun</p>';
+      summaryEl.querySelectorAll('.vida-plena-card.clickable').forEach(el => {
+        el.addEventListener('click', () => openVpPillarDetail(el.dataset.pillar, el.dataset.label));
+        el.addEventListener('keydown', (ev) => {
+          if (ev.key === 'Enter' || ev.key === ' ') { ev.preventDefault(); openVpPillarDetail(el.dataset.pillar, el.dataset.label); }
+        });
+      });
     } else {
       summaryEl.innerHTML = '<p class="task-empty">Sin datos de vida plena aun</p>';
     }
@@ -3854,6 +3860,277 @@ async function refreshVidaPlena() {
     } catch { moodEl.innerHTML = ''; }
   }
 }
+
+// --- Vida Plena: per-pillar detail view ---
+const VP_PILLAR_PATHS = {
+  health:        '/vida-plena/health/summary',
+  growth:        '/vida-plena/growth/summary',
+  exercise:      '/vida-plena/exercise/summary',
+  nutrition:     '/vida-plena/nutrition/summary',
+  social:        '/vida-plena/social/summary',
+  sleep:         '/vida-plena/sleep/summary',
+  spiritual:     '/vida-plena/spiritual/summary',
+  financial:     '/vida-plena/financial/summary',
+  relationships: '/vida-plena/relationships/summary',
+};
+
+function escapeHtml(s) {
+  return String(s == null ? '' : s).replace(/[&<>"']/g, c => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+  }[c]));
+}
+
+function renderPillarDetail(label, summary) {
+  if (!summary || typeof summary !== 'object') {
+    return `<p class="task-empty">Sin datos para ${escapeHtml(label)}.</p>`;
+  }
+  const entries = Object.entries(summary);
+  if (entries.length === 0) {
+    return `<p class="task-empty">Sin datos para ${escapeHtml(label)}.</p>`;
+  }
+  const rows = entries.map(([k, v]) => {
+    let display;
+    if (Array.isArray(v)) {
+      display = `<em>${v.length} elementos</em>`;
+      if (v.length > 0 && v.length <= 25) {
+        display += `<pre>${escapeHtml(JSON.stringify(v, null, 2))}</pre>`;
+      }
+    } else if (v && typeof v === 'object') {
+      display = `<pre>${escapeHtml(JSON.stringify(v, null, 2))}</pre>`;
+    } else {
+      display = escapeHtml(v);
+    }
+    return `<div class="vp-detail-row"><strong>${escapeHtml(k)}:</strong> ${display}</div>`;
+  });
+  return `<div class="vp-detail-body">${rows.join('')}</div>`;
+}
+
+async function openVpPillarDetail(pillarKey, label) {
+  const panel = document.getElementById('vida-plena-pillar-detail');
+  const titleEl = document.getElementById('vp-detail-title');
+  const bodyEl = document.getElementById('vp-detail-body');
+  const path = VP_PILLAR_PATHS[pillarKey];
+  if (!panel || !titleEl || !bodyEl) return;
+  panel.hidden = false;
+  titleEl.textContent = label || pillarKey;
+  bodyEl.innerHTML = '<p class="task-empty">Cargando...</p>';
+  if (!path) {
+    bodyEl.innerHTML = '<p class="task-empty">Pilar sin endpoint asociado.</p>';
+    return;
+  }
+  try {
+    const data = await api('GET', path);
+    bodyEl.innerHTML = renderPillarDetail(label, data && data.summary);
+  } catch (e) {
+    bodyEl.innerHTML = `<p class="task-empty">Error: ${escapeHtml(e.message || 'desconocido')}</p>`;
+  }
+  panel.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+}
+
+(function wireVpPillarDetailClose() {
+  const btn = document.getElementById('vp-detail-close');
+  const panel = document.getElementById('vida-plena-pillar-detail');
+  if (btn && panel) {
+    btn.addEventListener('click', () => { panel.hidden = true; });
+  }
+})();
+
+// --- Vida Plena: Shopping lists ---
+let vpActiveShoppingList = null;
+
+function vpShoppingStatus(msg, kind) {
+  const el = document.getElementById('vp-shopping-status');
+  if (!el) return;
+  el.className = 'vp-status' + (kind ? ' ' + kind : '');
+  el.textContent = msg || '';
+}
+
+function renderShoppingList(list) {
+  const container = document.getElementById('vp-shopping-list');
+  if (!container) return;
+  if (!list) {
+    container.innerHTML = '<p class="task-empty">Sin lista activa.</p>';
+    return;
+  }
+  const items = Array.isArray(list.items) ? list.items : [];
+  const header = `<div class="vp-shopping-header"><strong>${escapeHtml(list.name || list.id || 'Lista')}</strong> <span class="pillar-detail">${items.length} items</span></div>`;
+  if (items.length === 0) {
+    container.innerHTML = header + '<p class="task-empty">Lista vacia.</p>';
+    return;
+  }
+  const rows = items.map((it, idx) => {
+    const checked = !!(it.checked || it.completed || it.done);
+    const name = it.name || it.label || it.product || 'item';
+    const qty = (it.quantity != null) ? `${it.quantity}${it.unit ? ' ' + it.unit : ''}` : '';
+    return `<div class="vp-shopping-item${checked ? ' done' : ''}">
+      <input type="checkbox" data-vp-shop-name="${escapeHtml(name)}" ${checked ? 'checked' : ''}>
+      <span class="vp-item-name">${escapeHtml(name)}</span>
+      <span class="pillar-detail">${escapeHtml(qty)}</span>
+      <button type="button" class="quick-action-btn" data-vp-shop-del="${idx}">x</button>
+    </div>`;
+  }).join('');
+  container.innerHTML = header + rows;
+  container.querySelectorAll('input[type="checkbox"][data-vp-shop-name]').forEach(cb => {
+    cb.addEventListener('change', async () => {
+      if (!vpActiveShoppingList) return;
+      const needle = cb.getAttribute('data-vp-shop-name');
+      try {
+        await api('POST', `/vida-plena/shopping/lists/${encodeURIComponent(vpActiveShoppingList.id)}/check-by-name`, {
+          needle, checked: cb.checked,
+        });
+        vpShoppingStatus('Item actualizado', 'ok');
+        await refreshVpShopping();
+      } catch (e) {
+        vpShoppingStatus('Error: ' + (e.message || 'falla'), 'error');
+      }
+    });
+  });
+  container.querySelectorAll('button[data-vp-shop-del]').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      if (!vpActiveShoppingList) return;
+      const idx = btn.getAttribute('data-vp-shop-del');
+      try {
+        await api('DELETE', `/vida-plena/shopping/lists/${encodeURIComponent(vpActiveShoppingList.id)}/items/${idx}`);
+        vpShoppingStatus('Item eliminado', 'ok');
+        await refreshVpShopping();
+      } catch (e) {
+        vpShoppingStatus('Error: ' + (e.message || 'falla'), 'error');
+      }
+    });
+  });
+}
+
+async function refreshVpShopping() {
+  try {
+    const data = await api('GET', '/vida-plena/shopping/active');
+    vpActiveShoppingList = data && data.list ? data.list : null;
+    renderShoppingList(vpActiveShoppingList);
+  } catch (e) {
+    vpShoppingStatus('Error cargando lista activa: ' + (e.message || ''), 'error');
+    renderShoppingList(null);
+  }
+}
+
+(function wireVpShopping() {
+  const refreshBtn = document.getElementById('vp-shopping-refresh');
+  const genBtn = document.getElementById('vp-shopping-generate');
+  const clearBtn = document.getElementById('vp-shopping-clear');
+  const addBtn = document.getElementById('vp-shopping-add');
+  if (refreshBtn) refreshBtn.addEventListener('click', refreshVpShopping);
+  if (genBtn) genBtn.addEventListener('click', async () => {
+    const name = prompt('Nombre de la lista semanal:', 'Lista semanal');
+    if (!name) return;
+    try {
+      await api('POST', '/vida-plena/shopping/generate-weekly', { name });
+      vpShoppingStatus('Lista generada', 'ok');
+      await refreshVpShopping();
+    } catch (e) {
+      vpShoppingStatus('Error generando: ' + (e.message || ''), 'error');
+    }
+  });
+  if (clearBtn) clearBtn.addEventListener('click', async () => {
+    if (!vpActiveShoppingList) { vpShoppingStatus('Sin lista activa', 'error'); return; }
+    try {
+      const r = await api('POST', `/vida-plena/shopping/lists/${encodeURIComponent(vpActiveShoppingList.id)}/clear-completed`);
+      vpShoppingStatus(`Eliminados: ${r && r.removed != null ? r.removed : 0}`, 'ok');
+      await refreshVpShopping();
+    } catch (e) {
+      vpShoppingStatus('Error: ' + (e.message || ''), 'error');
+    }
+  });
+  if (addBtn) addBtn.addEventListener('click', async () => {
+    if (!vpActiveShoppingList) { vpShoppingStatus('Sin lista activa', 'error'); return; }
+    const nameEl = document.getElementById('vp-shopping-add-name');
+    const qtyEl = document.getElementById('vp-shopping-add-qty');
+    const unitEl = document.getElementById('vp-shopping-add-unit');
+    const name = nameEl && nameEl.value.trim();
+    if (!name) { vpShoppingStatus('Nombre requerido', 'error'); return; }
+    const item = { name };
+    if (qtyEl && qtyEl.value !== '') item.quantity = parseFloat(qtyEl.value);
+    if (unitEl && unitEl.value.trim()) item.unit = unitEl.value.trim();
+    try {
+      await api('POST', `/vida-plena/shopping/lists/${encodeURIComponent(vpActiveShoppingList.id)}/items`, { item });
+      vpShoppingStatus('Item agregado', 'ok');
+      if (nameEl) nameEl.value = '';
+      if (qtyEl) qtyEl.value = '';
+      if (unitEl) unitEl.value = '';
+      await refreshVpShopping();
+    } catch (e) {
+      vpShoppingStatus('Error: ' + (e.message || ''), 'error');
+    }
+  });
+})();
+
+// --- Vida Plena: Vault control ---
+function vpVaultMsg(msg, kind) {
+  const el = document.getElementById('vp-vault-msg');
+  if (!el) return;
+  el.className = 'vp-status' + (kind ? ' ' + kind : '');
+  el.textContent = msg || '';
+}
+
+function renderVaultStatus(v) {
+  const el = document.getElementById('vp-vault-status');
+  if (!el) return;
+  if (!v) { el.textContent = 'Estado desconocido'; return; }
+  const parts = [];
+  if (v.configured != null) parts.push(`configurado: ${v.configured}`);
+  if (v.unlocked != null) parts.push(`desbloqueado: ${v.unlocked}`);
+  if (v.idle_timeout_secs != null) parts.push(`idle: ${v.idle_timeout_secs}s`);
+  if (v.locked_at) parts.push(`locked_at: ${v.locked_at}`);
+  el.textContent = parts.length ? parts.join(' | ') : JSON.stringify(v);
+}
+
+async function refreshVpVault() {
+  try {
+    const data = await api('GET', '/vida-plena/vault/status');
+    renderVaultStatus(data && data.vault);
+  } catch (e) {
+    vpVaultMsg('Error cargando estado: ' + (e.message || ''), 'error');
+  }
+}
+
+(function wireVpVault() {
+  const statusBtn = document.getElementById('vp-vault-status-btn');
+  const lockBtn = document.getElementById('vp-vault-lock-btn');
+  const resetBtn = document.getElementById('vp-vault-reset-btn');
+  const setBtn = document.getElementById('vp-vault-set-btn');
+  const unlockBtn = document.getElementById('vp-vault-unlock-btn');
+  const passEl = document.getElementById('vp-vault-passphrase');
+  const idleEl = document.getElementById('vp-vault-idle');
+  if (statusBtn) statusBtn.addEventListener('click', refreshVpVault);
+  if (lockBtn) lockBtn.addEventListener('click', async () => {
+    try { await api('POST', '/vida-plena/vault/lock'); vpVaultMsg('Vault bloqueado', 'ok'); refreshVpVault(); }
+    catch (e) { vpVaultMsg('Error: ' + (e.message || ''), 'error'); }
+  });
+  if (resetBtn) resetBtn.addEventListener('click', async () => {
+    if (!confirm('Reset borra la passphrase del vault. Continuar?')) return;
+    try { await api('POST', '/vida-plena/vault/reset'); vpVaultMsg('Vault reseteado', 'ok'); refreshVpVault(); }
+    catch (e) { vpVaultMsg('Error: ' + (e.message || ''), 'error'); }
+  });
+  if (setBtn) setBtn.addEventListener('click', async () => {
+    const passphrase = passEl && passEl.value;
+    if (!passphrase) { vpVaultMsg('Passphrase requerida', 'error'); return; }
+    const body = { passphrase };
+    if (idleEl && idleEl.value !== '') body.idle_timeout_secs = parseInt(idleEl.value, 10);
+    try {
+      await api('POST', '/vida-plena/vault/set-passphrase', body);
+      vpVaultMsg('Passphrase configurada', 'ok');
+      if (passEl) passEl.value = '';
+      refreshVpVault();
+    } catch (e) { vpVaultMsg('Error: ' + (e.message || ''), 'error'); }
+  });
+  if (unlockBtn) unlockBtn.addEventListener('click', async () => {
+    const passphrase = passEl && passEl.value;
+    if (!passphrase) { vpVaultMsg('Passphrase requerida', 'error'); return; }
+    try {
+      await api('POST', '/vida-plena/vault/unlock', { passphrase });
+      vpVaultMsg('Vault desbloqueado', 'ok');
+      if (passEl) passEl.value = '';
+      refreshVpVault();
+    } catch (e) { vpVaultMsg('Error: ' + (e.message || ''), 'error'); }
+  });
+})();
 
 // --- TTS Voice Selector ---
 async function loadTtsVoiceSelector() {
@@ -3973,6 +4250,8 @@ async function loadTtsVoiceSelector() {
   refreshWorkers();
   refreshSystemHealth();
   refreshVidaPlena();
+  refreshVpShopping();
+  refreshVpVault();
   loadMeetings();
   loadCalendar();
   loadTtsVoiceSelector();

--- a/daemon/static/dashboard/index.html
+++ b/daemon/static/dashboard/index.html
@@ -675,9 +675,50 @@
         <section class="vida-plena-section" data-subsection="bienestar">
           <h2>Vida Plena</h2>
           <div id="vida-plena-summary" class="vida-plena-grid"><p class="task-empty">Cargando resumen...</p></div>
+          <div id="vida-plena-pillar-detail" class="vida-plena-pillar-detail" hidden>
+            <div class="vp-detail-header">
+              <h3 id="vp-detail-title">Pilar</h3>
+              <button type="button" class="quick-action-btn" id="vp-detail-close">Cerrar</button>
+            </div>
+            <div id="vp-detail-body"><p class="task-empty">Cargando...</p></div>
+          </div>
           <div id="vida-plena-pillars" class="vida-plena-pillars"></div>
           <div id="vida-plena-habits" class="vida-plena-habits"></div>
           <div id="vida-plena-mood" class="vida-plena-mood"></div>
+
+          <div class="vp-subsection" id="vp-shopping">
+            <h3>Listas de compras</h3>
+            <div class="vp-row">
+              <button type="button" class="quick-action-btn" id="vp-shopping-refresh">Recargar lista activa</button>
+              <button type="button" class="quick-action-btn" id="vp-shopping-generate">Generar semanal</button>
+              <button type="button" class="quick-action-btn" id="vp-shopping-clear">Quitar marcados</button>
+            </div>
+            <div class="vp-row">
+              <input type="text" id="vp-shopping-add-name" placeholder="Nuevo item (nombre)">
+              <input type="number" id="vp-shopping-add-qty" placeholder="Cant." min="0" step="any" style="max-width:90px">
+              <input type="text" id="vp-shopping-add-unit" placeholder="Unidad" style="max-width:90px">
+              <button type="button" class="quick-action-btn" id="vp-shopping-add">Agregar</button>
+            </div>
+            <div id="vp-shopping-status" class="vp-status"></div>
+            <div id="vp-shopping-list"><p class="task-empty">Sin lista activa.</p></div>
+          </div>
+
+          <div class="vp-subsection" id="vp-vault">
+            <h3>Vault cifrado</h3>
+            <div id="vp-vault-status" class="vp-status">Cargando...</div>
+            <div class="vp-row">
+              <button type="button" class="quick-action-btn" id="vp-vault-status-btn">Estado</button>
+              <button type="button" class="quick-action-btn" id="vp-vault-lock-btn">Bloquear</button>
+              <button type="button" class="quick-action-btn vp-danger" id="vp-vault-reset-btn">Reset</button>
+            </div>
+            <div class="vp-row">
+              <input type="password" id="vp-vault-passphrase" placeholder="Passphrase" autocomplete="off">
+              <input type="number" id="vp-vault-idle" placeholder="Idle (s)" min="0" style="max-width:110px">
+              <button type="button" class="quick-action-btn" id="vp-vault-set-btn">Configurar</button>
+              <button type="button" class="quick-action-btn" id="vp-vault-unlock-btn">Desbloquear</button>
+            </div>
+            <div id="vp-vault-msg" class="vp-status"></div>
+          </div>
         </section>
       </div>
     </main>

--- a/daemon/static/dashboard/style.css
+++ b/daemon/static/dashboard/style.css
@@ -2119,6 +2119,82 @@ section { scroll-margin-top: 24px; }
 .vida-plena-pillars { margin-top: 12px; }
 .vida-plena-habits { margin-top: 12px; }
 .vida-plena-mood { margin-top: 12px; }
+
+.vida-plena-card.clickable {
+  cursor: pointer;
+  transition: transform 0.12s ease, background 0.12s ease;
+}
+.vida-plena-card.clickable:hover {
+  transform: translateY(-1px);
+  background: var(--bg-card-alt-hover, rgba(255, 255, 255, 0.08));
+}
+
+.vida-plena-pillar-detail {
+  margin-top: 16px;
+  padding: 12px;
+  background: var(--bg-card-alt, rgba(255, 255, 255, 0.04));
+  border-radius: var(--radius);
+}
+.vp-detail-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+.vp-detail-body pre {
+  white-space: pre-wrap;
+  word-break: break-word;
+  background: rgba(0, 0, 0, 0.25);
+  padding: 8px;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  max-height: 360px;
+  overflow: auto;
+}
+
+.vp-subsection {
+  margin-top: 18px;
+  padding-top: 12px;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+.vp-row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+  margin: 8px 0;
+}
+.vp-row input[type="text"],
+.vp-row input[type="password"],
+.vp-row input[type="number"] {
+  padding: 6px 8px;
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(0, 0, 0, 0.25);
+  color: inherit;
+}
+.vp-status {
+  font-size: 0.85rem;
+  color: var(--text-muted, #aaa);
+  margin: 6px 0;
+  min-height: 1em;
+}
+.vp-status.error { color: #ff8a8a; }
+.vp-status.ok { color: #8aff8a; }
+.vp-shopping-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  font-size: 0.9rem;
+}
+.vp-shopping-item.done {
+  opacity: 0.55;
+  text-decoration: line-through;
+}
+.vp-shopping-item .vp-item-name { flex: 1; }
+.vp-danger { background: rgba(220, 60, 60, 0.18); }
 .habit-item, .mood-item {
   display: flex;
   align-items: center;

--- a/docs/user/user-guide.md
+++ b/docs/user/user-guide.md
@@ -380,3 +380,24 @@ The local dashboard at `http://127.0.0.1:8081/dashboard` now manages three resou
 - **LLM Providers** — the *Proveedores* card lets you add a new provider (name + API base + model + env var holding the key), toggle existing user-defined providers on/off, and delete entries. Built-in providers shipped with the OS image are read-only because `/usr` is immutable on bootc. Edits are persisted to `~/.config/lifeos/llm-providers.toml` (active) and `~/.config/lifeos/llm-providers.disabled.toml` (stash for toggled-off entries). Backed by `POST /api/v1/llm/providers`, `POST /api/v1/llm/providers/:name/toggle`, and `DELETE /api/v1/llm/providers/:name`.
 
 All endpoints require the `x-bootstrap-token` header that the dashboard already injects automatically.
+
+---
+
+## Vida Plena: detail views, shopping lists, vault
+
+The *Vida Plena* section of the dashboard now exposes three interactive surfaces (no terminal needed):
+
+- **Per-pillar detail views** — every pilar card in the unified summary (Salud, Crecimiento, Ejercicio, Nutricion, Social, Sueno, Espiritual, Finanzas, Relaciones) is now clickable. Selecting a card opens a detail panel underneath that fetches the corresponding `GET /api/v1/vida-plena/<pillar>/summary` and renders the full structured payload (counts, recent entries, raw fields). Use the *Cerrar* button to dismiss.
+- **Shopping lists** — manage the live editable list end-to-end:
+  - *Recargar lista activa* refreshes from `GET /api/v1/vida-plena/shopping/active`.
+  - *Generar semanal* prompts for a name and calls `POST /api/v1/vida-plena/shopping/generate-weekly`.
+  - The inline form adds items via `POST /api/v1/vida-plena/shopping/lists/:id/items` (name + quantity + unit).
+  - Each row has a checkbox (toggles via `POST .../check-by-name`) and a delete button (`DELETE .../items/:idx`).
+  - *Quitar marcados* clears completed items via `POST .../clear-completed`.
+- **Vault control** — the encrypted vault that protects sensitive Vida Plena data is now driven from the UI:
+  - *Estado* fetches `GET /api/v1/vida-plena/vault/status` and shows configured/unlocked flags plus idle timeout.
+  - *Configurar* sets a passphrase (and optional idle-timeout-secs) via `POST .../vault/set-passphrase`.
+  - *Desbloquear* / *Bloquear* call `POST .../vault/unlock` and `POST .../vault/lock` respectively.
+  - *Reset* (with confirmation) calls `POST .../vault/reset` to clear the configured passphrase.
+
+All Vida Plena endpoints require the same `x-bootstrap-token` header. Vault errors map to `403` (locked / wrong passphrase) and `400` (missing/invalid input) so the UI surfaces the actual reason on failure.


### PR DESCRIPTION
## Summary

Wires the dashboard UI for the Vida Plena pillar to the already-implemented backend endpoints in \`daemon/src/api/vida_plena.rs\`. No new backend endpoints — backend was already feature-complete; this PR is pure frontend wireup plus a docs entry.

### Three new dashboard surfaces

- **Per-pillar detail views** — every Vida Plena summary card (Salud, Crecimiento, Ejercicio, Nutricion, Social, Sueno, Espiritual, Finanzas, Relaciones) is now clickable and opens an inline detail panel that fetches \`GET /api/v1/vida-plena/<pillar>/summary\` and renders the structured payload.
- **Shopping lists** — load active list (\`GET /shopping/active\`), generate a weekly list (\`POST /shopping/generate-weekly\`), add items, delete by index, toggle checked-by-name, clear completed (\`POST /shopping/lists/:id/clear-completed\`).
- **Vault control** — status, set passphrase (with optional idle timeout), unlock, lock, reset, all hitting \`/vida-plena/vault/*\`. Errors map to clear UI messages (403 = locked / wrong passphrase, 400 = bad input).

## Files changed

- \`daemon/static/dashboard/index.html\` — new sub-sections (detail panel, shopping form, vault form)
- \`daemon/static/dashboard/app.js\` — handlers \`openVpPillarDetail\`, \`refreshVpShopping\`, \`refreshVpVault\` + IIFE wireups
- \`daemon/static/dashboard/style.css\` — styles for detail panel, shopping rows, vault controls
- \`docs/user/user-guide.md\` — new section documenting the three surfaces
- \`Cargo.toml\` / \`Cargo.lock\` — version bump to 0.8.6

## Test plan

- [x] cargo fmt --check passes
- [x] cargo clippy --features "dbus,http-api,ui-overlay,wake-word,messaging" passes with -D warnings
- [x] cargo test vida_plena passes (17/17 existing tests)
- [ ] Manual: open dashboard, click pillar card → detail loads
- [ ] Manual: add/check/delete shopping item
- [ ] Manual: vault set passphrase → unlock → lock → reset cycle