### PR TITLE
feat(nutrition): photo/voice → nutrition_log pipeline (BI.3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "life"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2626,7 +2626,7 @@ dependencies = [
 
 [[package]]
 name = "lifeos-integration-tests"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "life",
  "serde_json",
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "lifeosd"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.6"
+version = "0.8.7"
 
 [workspace.metadata.lifeos]
 codename = "Axolotl"

--- a/daemon/src/api/vida_plena.rs
+++ b/daemon/src/api/vida_plena.rs
@@ -38,6 +38,15 @@ pub fn vida_plena_routes() -> Router<ApiState> {
         .route("/growth/summary", get(get_growth_summary))
         .route("/exercise/summary", get(get_exercise_summary))
         .route("/nutrition/summary", get(get_nutrition_summary))
+        // -- BI.3: photo/voice → nutrition_log pipeline --------------
+        .route(
+            "/nutrition/log/from-image",
+            post(post_nutrition_log_from_image),
+        )
+        .route(
+            "/nutrition/log/from-voice",
+            post(post_nutrition_log_from_voice),
+        )
         .route("/social/summary", get(get_social_summary))
         .route("/sleep/summary", get(get_sleep_summary))
         .route("/spiritual/summary", get(get_spiritual_summary))
@@ -891,6 +900,118 @@ async fn get_stale_relationships(
         "relationships": stale,
         "count": stale.len(),
     })))
+}
+
+// ----------------------------------------------------------------------
+// BI.3 — photo/voice → nutrition_log pipeline
+// ----------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+pub struct NutritionLogFromImagePayload {
+    /// Absolute path on disk to the food photo. The daemon reads it
+    /// directly; the image is encoded inline for the local llama-server
+    /// multimodal slot, NEVER uploaded to a remote service from this
+    /// endpoint.
+    pub image_path: String,
+    #[serde(default)]
+    pub photo_attachment_id: Option<String>,
+    #[serde(default)]
+    pub notes: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct NutritionLogFromVoicePayload {
+    /// Free-form transcript already produced by Whisper STT (or pasted
+    /// by the user). The endpoint runs LLM extraction on it and writes
+    /// the resulting entries to `nutrition_log`.
+    pub transcript: String,
+    #[serde(default)]
+    pub voice_attachment_id: Option<String>,
+    #[serde(default)]
+    pub notes: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct NutritionLogPipelineResponse {
+    extraction: crate::nutrition::NutritionExtraction,
+    logged_ids: Vec<String>,
+    /// Number of rows written to `nutrition_log`. Always equal to
+    /// `extraction.entries.len()` on success.
+    count: usize,
+}
+
+async fn post_nutrition_log_from_image(
+    State(state): State<ApiState>,
+    Json(payload): Json<NutritionLogFromImagePayload>,
+) -> Result<Json<NutritionLogPipelineResponse>, (StatusCode, Json<ApiError>)> {
+    if payload.image_path.trim().is_empty() {
+        return Err(err_to_http(anyhow::anyhow!("image_path is required")));
+    }
+    let ai = crate::ai::AiManager::new();
+    let extraction = crate::nutrition::extract_from_image(&ai, &payload.image_path)
+        .await
+        .map_err(err_to_http)?;
+    if extraction.entries.is_empty() {
+        return Ok(Json(NutritionLogPipelineResponse {
+            extraction,
+            logged_ids: Vec::new(),
+            count: 0,
+        }));
+    }
+    let mgr = state.memory_plane_manager.read().await;
+    let logged = crate::nutrition::persist_extraction(
+        &mgr,
+        &extraction,
+        payload.photo_attachment_id.as_deref(),
+        None,
+        payload.notes.as_deref().unwrap_or(""),
+    )
+    .await
+    .map_err(err_to_http)?;
+    let logged_ids: Vec<String> = logged.iter().map(|l| l.log_id.clone()).collect();
+    let count = logged_ids.len();
+    Ok(Json(NutritionLogPipelineResponse {
+        extraction,
+        logged_ids,
+        count,
+    }))
+}
+
+async fn post_nutrition_log_from_voice(
+    State(state): State<ApiState>,
+    Json(payload): Json<NutritionLogFromVoicePayload>,
+) -> Result<Json<NutritionLogPipelineResponse>, (StatusCode, Json<ApiError>)> {
+    if payload.transcript.trim().is_empty() {
+        return Err(err_to_http(anyhow::anyhow!("transcript is required")));
+    }
+    let ai = crate::ai::AiManager::new();
+    let extraction = crate::nutrition::extract_from_voice_transcript(&ai, &payload.transcript)
+        .await
+        .map_err(err_to_http)?;
+    if extraction.entries.is_empty() {
+        return Ok(Json(NutritionLogPipelineResponse {
+            extraction,
+            logged_ids: Vec::new(),
+            count: 0,
+        }));
+    }
+    let mgr = state.memory_plane_manager.read().await;
+    let logged = crate::nutrition::persist_extraction(
+        &mgr,
+        &extraction,
+        None,
+        payload.voice_attachment_id.as_deref(),
+        payload.notes.as_deref().unwrap_or(""),
+    )
+    .await
+    .map_err(err_to_http)?;
+    let logged_ids: Vec<String> = logged.iter().map(|l| l.log_id.clone()).collect();
+    let count = logged_ids.len();
+    Ok(Json(NutritionLogPipelineResponse {
+        extraction,
+        logged_ids,
+        count,
+    }))
 }
 
 #[cfg(test)]

--- a/daemon/src/axi_tools.rs
+++ b/daemon/src/axi_tools.rs
@@ -290,6 +290,10 @@ LifeOS lleva el registro completo de lo que el usuario come, sus preferencias/al
 11d. **nutrition_log_recent** — Devuelve los registros recientes. limit por defecto 20. meal_type opcional para filtrar.
     args: {"limit": 30, "meal_type": "dinner"} o {} para los ultimos 20
 
+11d-bis. **nutrition_log_from_capture** — Pipeline BI.3: dada una foto de comida o un transcript de voz, extrae items estructurados (nombre, cantidad, unidad, kcal estimadas) via el modelo local multimodal y los persiste en `nutrition_log`. Una sola llamada, una entrada por item. `kind` debe ser `image` o `voice`. Para `image` pasa `capture_path` con ruta absoluta a la foto. Para `voice` pasa `transcript` con el texto ya transcripto (Whisper STT) o un texto libre.
+    args (image): {"kind": "image", "capture_path": "/tmp/lifeos-captures/meal-2026-04-22.jpg", "notes": "post-entreno"}
+    args (voice): {"kind": "voice", "transcript": "comi tres tacos al pastor con agua mineral", "notes": ""}
+
 11e. **nutrition_recipe_add** — Guarda una receta. ingredients es una lista de objetos {name, amount, unit, notes}. steps es una lista de strings. tags ayuda a filtrar despues.
     args: {"name": "Bowl de pollo y arroz", "ingredients": [{"name":"pechuga de pollo","amount":150,"unit":"g"},{"name":"arroz integral","amount":80,"unit":"g"}], "steps": ["Cocer el arroz","Sazonar y asar el pollo","Servir junto"], "prep_time_min": 10, "cook_time_min": 25, "servings": 1, "tags": ["alto_proteina","cena"]}
 
@@ -2072,6 +2076,9 @@ REGLAS FIRMES:
             "nutrition_pref_list" => execute_nutrition_pref_list(&call.args, ctx).await,
             "nutrition_log_meal" => execute_nutrition_log_meal(&call.args, ctx).await,
             "nutrition_log_recent" => execute_nutrition_log_recent(&call.args, ctx).await,
+            "nutrition_log_from_capture" => {
+                execute_nutrition_log_from_capture(&call.args, ctx).await
+            }
             "nutrition_recipe_add" => execute_nutrition_recipe_add(&call.args, ctx).await,
             "nutrition_recipe_list" => execute_nutrition_recipe_list(&call.args, ctx).await,
             "nutrition_plan_add" => execute_nutrition_plan_add(&call.args, ctx).await,
@@ -4495,6 +4502,94 @@ REGLAS FIRMES:
             })
             .collect();
         Ok(format!("Comidas recientes:\n{}", lines.join("\n")))
+    }
+
+    /// BI.3 — photo/voice → nutrition_log pipeline tool.
+    ///
+    /// Routes the capture through the local multimodal model (image)
+    /// or text model (voice transcript), validates the LLM JSON,
+    /// and writes one row per detected entry into `nutrition_log`.
+    async fn execute_nutrition_log_from_capture(
+        args: &serde_json::Value,
+        ctx: &ToolContext,
+    ) -> Result<String> {
+        let kind = args["kind"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("Falta parametro 'kind' (image|voice)"))?
+            .trim()
+            .to_lowercase();
+        let notes = args["notes"].as_str().unwrap_or("");
+        let mem = require_memory(ctx).await?;
+        let ai = crate::ai::AiManager::new();
+
+        let extraction = match kind.as_str() {
+            "image" => {
+                let path = args["capture_path"]
+                    .as_str()
+                    .ok_or_else(|| anyhow::anyhow!("Falta 'capture_path' para kind=image"))?;
+                crate::nutrition::extract_from_image(&ai, path).await?
+            }
+            "voice" => {
+                let transcript = args["transcript"]
+                    .as_str()
+                    .ok_or_else(|| anyhow::anyhow!("Falta 'transcript' para kind=voice"))?;
+                // Cheap heuristic gate: if the transcript shows no food
+                // intent at all, skip the LLM call entirely. Saves a
+                // round-trip and prevents accidental writes when the
+                // tool is invoked on an unrelated utterance.
+                if !crate::nutrition::detect_food_intent(transcript) {
+                    return Ok(format!(
+                        "Transcript sin intencion de comida; nada registrado: \"{}\"",
+                        transcript.chars().take(120).collect::<String>()
+                    ));
+                }
+                crate::nutrition::extract_from_voice_transcript(&ai, transcript).await?
+            }
+            other => {
+                anyhow::bail!("kind invalido: '{}'. Usa 'image' o 'voice'.", other);
+            }
+        };
+
+        if extraction.entries.is_empty() {
+            return Ok(format!(
+                "No detecte comida en el capture (confianza {:.0}%). Nada registrado.",
+                extraction.confidence * 100.0
+            ));
+        }
+
+        let photo_id = if kind == "image" {
+            args["capture_path"].as_str()
+        } else {
+            None
+        };
+        let voice_id = if kind == "voice" {
+            args["voice_attachment_id"].as_str()
+        } else {
+            None
+        };
+
+        let logged =
+            crate::nutrition::persist_extraction(&mem, &extraction, photo_id, voice_id, notes)
+                .await?;
+        let summary = extraction
+            .entries
+            .iter()
+            .map(|e| {
+                let kcal = e
+                    .kcal_estimate
+                    .map(|k| format!(" (~{:.0} kcal)", k))
+                    .unwrap_or_default();
+                format!("- {} {} de {}{}", e.qty, e.unit, e.name, kcal)
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        Ok(format!(
+            "Registre {} item(s) en nutrition_log [{}] (confianza {:.0}%):\n{}",
+            logged.len(),
+            extraction.meal_type,
+            extraction.confidence * 100.0,
+            summary
+        ))
     }
 
     async fn execute_nutrition_recipe_add(

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -68,6 +68,7 @@ mod message_dedupe;
 mod mini_widget;
 mod models;
 mod notifications;
+mod nutrition;
 mod overlay;
 #[cfg(feature = "dbus")]
 mod permissions;

--- a/daemon/src/nutrition/extractor.rs
+++ b/daemon/src/nutrition/extractor.rs
@@ -55,6 +55,12 @@ pub struct NutritionExtraction {
 /// Keyword set used by [`detect_food_intent`]. Extra keywords (e.g.
 /// regional dishes) can be appended by callers without touching the
 /// extractor itself.
+///
+/// Gated behind `messaging` because the only call site lives inside the
+/// `messaging`-gated `execute_nutrition_log_from_capture` in axi_tools.
+/// Without the gate, builds without `messaging` (default features) flag
+/// it as dead code and clippy `-D warnings` fails CI.
+#[cfg(feature = "messaging")]
 const FOOD_KEYWORDS: &[&str] = &[
     // Spanish — verbs
     "comi",
@@ -95,6 +101,9 @@ const FOOD_KEYWORDS: &[&str] = &[
 /// something they ate or drank. Cheap heuristic — meant to gate the
 /// optional auto-trigger path so we don't spend an LLM call on every
 /// utterance.
+///
+/// Gated behind `messaging` (see `FOOD_KEYWORDS` doc above).
+#[cfg(feature = "messaging")]
 pub fn detect_food_intent(text: &str) -> bool {
     let lower = text.to_lowercase();
     FOOD_KEYWORDS.iter().any(|kw| lower.contains(kw))
@@ -424,6 +433,7 @@ mod tests {
         validate_entries(&[e]).expect("None kcal is allowed");
     }
 
+    #[cfg(feature = "messaging")]
     #[test]
     fn detect_food_intent_spanish_verbs() {
         assert!(detect_food_intent("hace rato comi unos tacos"));
@@ -432,12 +442,14 @@ mod tests {
         assert!(detect_food_intent("cené sushi"));
     }
 
+    #[cfg(feature = "messaging")]
     #[test]
     fn detect_food_intent_english() {
         assert!(detect_food_intent("I ate a burger"));
         assert!(detect_food_intent("had lunch at noon"));
     }
 
+    #[cfg(feature = "messaging")]
     #[test]
     fn detect_food_intent_unrelated() {
         assert!(!detect_food_intent("recordame mañana la junta"));

--- a/daemon/src/nutrition/extractor.rs
+++ b/daemon/src/nutrition/extractor.rs
@@ -1,0 +1,591 @@
+//! Structured nutrition extraction from photos and voice transcripts.
+//!
+//! The extractor produces a [`NutritionExtraction`] containing one or
+//! more [`NutritionEntry`] items plus an overall confidence score. The
+//! shape is intentionally compact so the local 4B default model can
+//! produce it reliably; richer macro breakdown lives downstream in
+//! `nutrition_log` (description + macros_kcal) and in the existing
+//! `food_db` lookups.
+
+use anyhow::{anyhow, bail, Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::ai::AiManager;
+use crate::memory_plane::{MemoryPlaneManager, NutritionLogEntry};
+
+/// Maximum kcal value we accept for a single item before rejecting as
+/// implausible. A whole large pizza tops out around 2400 kcal; we leave
+/// generous headroom but still cut off LLM hallucinations like
+/// "5,000,000 kcal".
+pub const MAX_REASONABLE_KCAL: f64 = 5_000.0;
+
+/// One structured food item extracted from an image or transcript.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct NutritionEntry {
+    /// Human-readable name of the food, e.g. "tacos al pastor".
+    pub name: String,
+    /// Quantity. Always positive. Units are described in `unit`.
+    pub qty: f64,
+    /// Unit string, free-form but normalized lowercase, e.g. "g",
+    /// "ml", "pieza", "porcion", "taza".
+    pub unit: String,
+    /// Best-effort kcal estimate produced by the LLM. May be `None`
+    /// when the model cannot estimate confidently; callers must not
+    /// invent a value.
+    pub kcal_estimate: Option<f64>,
+}
+
+/// Aggregated extraction result.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NutritionExtraction {
+    /// One or more items detected in the photo / transcript.
+    pub entries: Vec<NutritionEntry>,
+    /// Overall confidence in `[0.0, 1.0]`. Anything below 0.3 typically
+    /// means the model could not see / understand a meal.
+    pub confidence: f64,
+    /// Compact natural-language summary that ends up in
+    /// `nutrition_log.description`.
+    pub raw_description: String,
+    /// Meal classification: `breakfast`, `lunch`, `dinner`, `snack`,
+    /// `drink`, or `craving`. Defaults to `snack` when the model is
+    /// unsure — that is the most conservative bucket.
+    pub meal_type: String,
+}
+
+/// Keyword set used by [`detect_food_intent`]. Extra keywords (e.g.
+/// regional dishes) can be appended by callers without touching the
+/// extractor itself.
+const FOOD_KEYWORDS: &[&str] = &[
+    // Spanish — verbs
+    "comi",
+    "comí",
+    "almorce",
+    "almorcé",
+    "cene",
+    "cené",
+    "desayune",
+    "desayuné",
+    "merende",
+    "merendé",
+    "tome",
+    "tomé",
+    "bebí",
+    "bebi",
+    // Spanish — nouns
+    "comida",
+    "almuerzo",
+    "desayuno",
+    "cena",
+    "merienda",
+    "snack",
+    "antojo",
+    "bebida",
+    // English
+    "i ate",
+    "i had",
+    "i drank",
+    "breakfast",
+    "lunch",
+    "dinner",
+    "meal",
+    "craving",
+];
+
+/// Returns `true` when the transcript looks like the user is describing
+/// something they ate or drank. Cheap heuristic — meant to gate the
+/// optional auto-trigger path so we don't spend an LLM call on every
+/// utterance.
+pub fn detect_food_intent(text: &str) -> bool {
+    let lower = text.to_lowercase();
+    FOOD_KEYWORDS.iter().any(|kw| lower.contains(kw))
+}
+
+/// Validate a slice of entries. Returns the first failure (`anyhow`
+/// error) so the caller can surface a precise message to the LLM /
+/// user. Performs ALL of:
+///
+/// * `entries` is non-empty
+/// * each `name` is non-empty after trim
+/// * each `qty` is finite and `> 0`
+/// * each `unit` is non-empty after trim
+/// * each `kcal_estimate`, when present, is finite, `>= 0`, and
+///   `<= MAX_REASONABLE_KCAL`
+pub fn validate_entries(entries: &[NutritionEntry]) -> Result<()> {
+    if entries.is_empty() {
+        bail!("nutrition extraction must contain at least one entry");
+    }
+    for (idx, entry) in entries.iter().enumerate() {
+        if entry.name.trim().is_empty() {
+            bail!("entry #{idx} has empty name");
+        }
+        if !entry.qty.is_finite() || entry.qty <= 0.0 {
+            bail!(
+                "entry #{idx} ({}) has non-positive qty {}",
+                entry.name,
+                entry.qty
+            );
+        }
+        if entry.unit.trim().is_empty() {
+            bail!("entry #{idx} ({}) has empty unit", entry.name);
+        }
+        if let Some(kcal) = entry.kcal_estimate {
+            if !kcal.is_finite() || kcal < 0.0 {
+                bail!(
+                    "entry #{idx} ({}) has invalid kcal_estimate {}",
+                    entry.name,
+                    kcal
+                );
+            }
+            if kcal > MAX_REASONABLE_KCAL {
+                bail!(
+                    "entry #{idx} ({}) has implausible kcal_estimate {} (> {})",
+                    entry.name,
+                    kcal,
+                    MAX_REASONABLE_KCAL
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Normalize a meal-type string into the discrete buckets accepted by
+/// `nutrition_log`. Anything unrecognized falls back to `"snack"`.
+fn normalize_meal_type(raw: &str) -> String {
+    let l = raw.trim().to_lowercase();
+    match l.as_str() {
+        "breakfast" | "desayuno" => "breakfast".into(),
+        "lunch" | "almuerzo" | "comida" => "lunch".into(),
+        "dinner" | "cena" => "dinner".into(),
+        "drink" | "bebida" | "trago" => "drink".into(),
+        "craving" | "antojo" => "craving".into(),
+        _ => "snack".into(),
+    }
+}
+
+/// Prompt sent to the LLM. The model is instructed to return a JSON
+/// object ONLY (no prose, no fences) so the parser can be strict.
+const EXTRACTION_PROMPT: &str = r#"You analyze food described in either a photo or a voice transcript.
+
+Return ONLY a single JSON object, no prose, no markdown, no code fences. Schema:
+
+{
+  "entries": [
+    {
+      "name": "string (food name, lowercase, in the same language as the input)",
+      "qty": number (positive),
+      "unit": "string (g | ml | pieza | porcion | taza | rebanada | etc, lowercase)",
+      "kcal_estimate": number | null (best-effort kcal, null if unsure)
+    }
+  ],
+  "confidence": number in [0.0, 1.0],
+  "raw_description": "string (one short sentence describing the meal)",
+  "meal_type": "breakfast | lunch | dinner | snack | drink | craving"
+}
+
+Rules:
+- If the input does not describe food, return {"entries": [], "confidence": 0.0, "raw_description": "", "meal_type": "snack"}.
+- Never fabricate exact macros — leave kcal_estimate null when unsure.
+- Keep entries compact: one item per dish, not per ingredient.
+"#;
+
+fn parse_extraction_json(text: &str) -> Result<NutritionExtraction> {
+    // Some models still emit ```json fences; strip them defensively.
+    let trimmed = text.trim();
+    let trimmed = trimmed
+        .strip_prefix("```json")
+        .or_else(|| trimmed.strip_prefix("```"))
+        .unwrap_or(trimmed);
+    let trimmed = trimmed.strip_suffix("```").unwrap_or(trimmed).trim();
+
+    // Some models prepend prose. Find the first '{' and last '}' to
+    // recover the JSON envelope.
+    let start = trimmed
+        .find('{')
+        .ok_or_else(|| anyhow!("LLM response contains no JSON object: {trimmed}"))?;
+    let end = trimmed
+        .rfind('}')
+        .ok_or_else(|| anyhow!("LLM response has no closing '}}': {trimmed}"))?;
+    if end < start {
+        bail!("LLM response has malformed braces");
+    }
+    let json_slice = &trimmed[start..=end];
+
+    let mut value: NutritionExtraction = serde_json::from_str(json_slice)
+        .with_context(|| format!("LLM response is not valid extraction JSON: {json_slice}"))?;
+
+    value.meal_type = normalize_meal_type(&value.meal_type);
+    // Clamp confidence to a sane range.
+    if !value.confidence.is_finite() {
+        value.confidence = 0.0;
+    }
+    value.confidence = value.confidence.clamp(0.0, 1.0);
+    Ok(value)
+}
+
+/// Extract structured nutrition from an image on disk.
+///
+/// Uses the multimodal endpoint of the local `AiManager`. The image
+/// is sent base64-encoded inline (no upload to a remote service unless
+/// the user has explicitly configured a remote vision provider in the
+/// router; this function uses the local llama-server multimodal slot).
+pub async fn extract_from_image(ai: &AiManager, image_path: &str) -> Result<NutritionExtraction> {
+    let response = ai
+        .chat_multimodal(
+            None,
+            Some("You are a precise nutrition extraction model. Output only JSON."),
+            EXTRACTION_PROMPT,
+            image_path,
+        )
+        .await
+        .context("multimodal extraction call failed")?;
+    let extraction = parse_extraction_json(&response.response)?;
+    if !extraction.entries.is_empty() {
+        validate_entries(&extraction.entries)?;
+    }
+    Ok(extraction)
+}
+
+/// Extract structured nutrition from a free-form voice transcript.
+///
+/// Caller is responsible for producing the transcript (Whisper STT
+/// already exists in `sensory_pipeline.rs::transcribe_audio`). This
+/// function only handles the parsing step.
+pub async fn extract_from_voice_transcript(
+    ai: &AiManager,
+    transcript: &str,
+) -> Result<NutritionExtraction> {
+    let transcript = transcript.trim();
+    if transcript.is_empty() {
+        bail!("transcript is empty");
+    }
+    let user_prompt =
+        format!("{EXTRACTION_PROMPT}\n\nVoice transcript:\n\"\"\"\n{transcript}\n\"\"\"");
+    let response = ai
+        .chat(
+            None,
+            vec![
+                (
+                    "system".to_string(),
+                    "You are a precise nutrition extraction model. Output only JSON.".to_string(),
+                ),
+                ("user".to_string(), user_prompt),
+            ],
+        )
+        .await
+        .context("voice transcript extraction call failed")?;
+    let extraction = parse_extraction_json(&response.response)?;
+    if !extraction.entries.is_empty() {
+        validate_entries(&extraction.entries)?;
+    }
+    Ok(extraction)
+}
+
+/// Persist a validated extraction into `nutrition_log`.
+///
+/// One row per entry is written. The whole extraction shares a single
+/// `description` (the model's `raw_description`) and the per-entry
+/// `name`/`qty`/`unit` is appended so that downstream consumers can
+/// still see the structured shape inside the description string —
+/// the `nutrition_log` table itself doesn't have one column per item,
+/// so this is the cleanest way to keep the data without changing the
+/// schema.
+///
+/// Returns the list of newly created `log_id`s in the same order as
+/// `extraction.entries`.
+pub async fn persist_extraction(
+    mem: &MemoryPlaneManager,
+    extraction: &NutritionExtraction,
+    photo_attachment_id: Option<&str>,
+    voice_attachment_id: Option<&str>,
+    notes: &str,
+) -> Result<Vec<NutritionLogEntry>> {
+    validate_entries(&extraction.entries)?;
+    let mut out = Vec::with_capacity(extraction.entries.len());
+    for entry in &extraction.entries {
+        let description = format!(
+            "{} ({} {} de {})",
+            extraction.raw_description.trim(),
+            entry.qty,
+            entry.unit,
+            entry.name
+        );
+        let logged = mem
+            .log_nutrition_meal(
+                &extraction.meal_type,
+                description.trim(),
+                entry.kcal_estimate,
+                None, // protein
+                None, // carbs
+                None, // fat
+                photo_attachment_id,
+                voice_attachment_id,
+                None, // consumed_at -> now
+                notes,
+                None, // source_entry_id
+            )
+            .await
+            .with_context(|| format!("log_nutrition_meal failed for {}", entry.name))?;
+        out.push(logged);
+    }
+    Ok(out)
+}
+
+// -------------------------------------------------------------------------
+// Tests — pure logic. The `extract_from_*` functions hit llama-server, so
+// they cannot run in CI; we cover the JSON parser, validator, intent
+// detector, and meal-type normalizer instead.
+// -------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_entry() -> NutritionEntry {
+        NutritionEntry {
+            name: "tacos al pastor".to_string(),
+            qty: 3.0,
+            unit: "pieza".to_string(),
+            kcal_estimate: Some(450.0),
+        }
+    }
+
+    #[test]
+    fn validate_accepts_well_formed_entry() {
+        validate_entries(&[sample_entry()]).expect("valid entry should pass");
+    }
+
+    #[test]
+    fn validate_rejects_empty_list() {
+        let err = validate_entries(&[]).unwrap_err();
+        assert!(err.to_string().contains("at least one"));
+    }
+
+    #[test]
+    fn validate_rejects_empty_name() {
+        let mut e = sample_entry();
+        e.name = "   ".into();
+        let err = validate_entries(&[e]).unwrap_err();
+        assert!(err.to_string().contains("empty name"));
+    }
+
+    #[test]
+    fn validate_rejects_zero_qty() {
+        let mut e = sample_entry();
+        e.qty = 0.0;
+        let err = validate_entries(&[e]).unwrap_err();
+        assert!(err.to_string().contains("non-positive qty"));
+    }
+
+    #[test]
+    fn validate_rejects_negative_qty() {
+        let mut e = sample_entry();
+        e.qty = -1.5;
+        let err = validate_entries(&[e]).unwrap_err();
+        assert!(err.to_string().contains("non-positive qty"));
+    }
+
+    #[test]
+    fn validate_rejects_nan_qty() {
+        let mut e = sample_entry();
+        e.qty = f64::NAN;
+        let err = validate_entries(&[e]).unwrap_err();
+        assert!(err.to_string().contains("non-positive qty"));
+    }
+
+    #[test]
+    fn validate_rejects_empty_unit() {
+        let mut e = sample_entry();
+        e.unit = "".into();
+        let err = validate_entries(&[e]).unwrap_err();
+        assert!(err.to_string().contains("empty unit"));
+    }
+
+    #[test]
+    fn validate_rejects_negative_kcal() {
+        let mut e = sample_entry();
+        e.kcal_estimate = Some(-10.0);
+        let err = validate_entries(&[e]).unwrap_err();
+        assert!(err.to_string().contains("invalid kcal_estimate"));
+    }
+
+    #[test]
+    fn validate_rejects_implausible_kcal() {
+        let mut e = sample_entry();
+        e.kcal_estimate = Some(MAX_REASONABLE_KCAL + 1.0);
+        let err = validate_entries(&[e]).unwrap_err();
+        assert!(err.to_string().contains("implausible"));
+    }
+
+    #[test]
+    fn validate_accepts_none_kcal() {
+        let mut e = sample_entry();
+        e.kcal_estimate = None;
+        validate_entries(&[e]).expect("None kcal is allowed");
+    }
+
+    #[test]
+    fn detect_food_intent_spanish_verbs() {
+        assert!(detect_food_intent("hace rato comi unos tacos"));
+        assert!(detect_food_intent("Comí pizza ayer"));
+        assert!(detect_food_intent("almorcé pollo con arroz"));
+        assert!(detect_food_intent("cené sushi"));
+    }
+
+    #[test]
+    fn detect_food_intent_english() {
+        assert!(detect_food_intent("I ate a burger"));
+        assert!(detect_food_intent("had lunch at noon"));
+    }
+
+    #[test]
+    fn detect_food_intent_unrelated() {
+        assert!(!detect_food_intent("recordame mañana la junta"));
+        assert!(!detect_food_intent("turn off the lights"));
+    }
+
+    #[test]
+    fn parse_clean_json() {
+        let raw = r#"{
+            "entries": [
+                {"name": "tacos al pastor", "qty": 3, "unit": "pieza", "kcal_estimate": 450}
+            ],
+            "confidence": 0.78,
+            "raw_description": "Tres tacos al pastor",
+            "meal_type": "lunch"
+        }"#;
+        let extraction = parse_extraction_json(raw).unwrap();
+        assert_eq!(extraction.entries.len(), 1);
+        assert_eq!(extraction.entries[0].name, "tacos al pastor");
+        assert_eq!(extraction.entries[0].qty, 3.0);
+        assert_eq!(extraction.meal_type, "lunch");
+        assert!((extraction.confidence - 0.78).abs() < 1e-6);
+    }
+
+    #[test]
+    fn parse_strips_markdown_fences() {
+        let raw = "```json\n{\"entries\":[],\"confidence\":0.0,\"raw_description\":\"\",\"meal_type\":\"snack\"}\n```";
+        let extraction = parse_extraction_json(raw).unwrap();
+        assert!(extraction.entries.is_empty());
+        assert_eq!(extraction.meal_type, "snack");
+    }
+
+    #[test]
+    fn parse_recovers_from_prose_prefix() {
+        let raw = "Sure! Here is the JSON:\n{\"entries\":[{\"name\":\"agua\",\"qty\":500,\"unit\":\"ml\",\"kcal_estimate\":0}],\"confidence\":0.9,\"raw_description\":\"Agua\",\"meal_type\":\"drink\"}";
+        let extraction = parse_extraction_json(raw).unwrap();
+        assert_eq!(extraction.entries[0].name, "agua");
+        assert_eq!(extraction.meal_type, "drink");
+    }
+
+    #[test]
+    fn parse_normalizes_unknown_meal_type() {
+        let raw = r#"{"entries":[{"name":"x","qty":1,"unit":"g","kcal_estimate":null}],"confidence":0.5,"raw_description":"x","meal_type":"midnight"}"#;
+        let extraction = parse_extraction_json(raw).unwrap();
+        assert_eq!(extraction.meal_type, "snack");
+    }
+
+    #[test]
+    fn parse_clamps_confidence() {
+        let raw = r#"{"entries":[],"confidence":42.0,"raw_description":"","meal_type":"snack"}"#;
+        let extraction = parse_extraction_json(raw).unwrap();
+        assert_eq!(extraction.confidence, 1.0);
+    }
+
+    #[test]
+    fn parse_rejects_garbage() {
+        let err = parse_extraction_json("not json at all").unwrap_err();
+        assert!(err.to_string().contains("no JSON object"));
+    }
+
+    use std::path::PathBuf;
+
+    fn temp_dir_for(prefix: &str) -> PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!("lifeos-{prefix}-{}", uuid::Uuid::new_v4().simple()));
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    #[tokio::test]
+    async fn persist_writes_one_row_per_entry_and_round_trips() {
+        let dir = temp_dir_for("nutrition-persist");
+        let mgr = MemoryPlaneManager::new(dir.clone()).unwrap();
+        mgr.initialize().await.unwrap();
+
+        let extraction = NutritionExtraction {
+            entries: vec![
+                NutritionEntry {
+                    name: "tacos al pastor".into(),
+                    qty: 3.0,
+                    unit: "pieza".into(),
+                    kcal_estimate: Some(450.0),
+                },
+                NutritionEntry {
+                    name: "agua mineral".into(),
+                    qty: 500.0,
+                    unit: "ml".into(),
+                    kcal_estimate: Some(0.0),
+                },
+            ],
+            confidence: 0.81,
+            raw_description: "Tres tacos al pastor con agua mineral".into(),
+            meal_type: "lunch".into(),
+        };
+
+        let logged = persist_extraction(&mgr, &extraction, None, None, "")
+            .await
+            .expect("persist should succeed");
+        assert_eq!(logged.len(), 2);
+        assert_eq!(logged[0].meal_type, "lunch");
+        assert!(logged[0].description.contains("tacos al pastor"));
+        assert_eq!(logged[0].macros_kcal, Some(450.0));
+        assert_eq!(logged[1].macros_kcal, Some(0.0));
+        assert!(logged[1].description.contains("agua mineral"));
+
+        // Round-trip via list_nutrition_log.
+        let back = mgr.list_nutrition_log(Some("lunch"), 50).await.unwrap();
+        assert!(back.len() >= 2);
+        let names: Vec<&str> = back.iter().map(|e| e.description.as_str()).collect();
+        assert!(names.iter().any(|d| d.contains("tacos al pastor")));
+        assert!(names.iter().any(|d| d.contains("agua mineral")));
+
+        std::fs::remove_dir_all(dir).ok();
+    }
+
+    #[tokio::test]
+    async fn persist_rejects_invalid_extraction() {
+        let dir = temp_dir_for("nutrition-persist-invalid");
+        let mgr = MemoryPlaneManager::new(dir.clone()).unwrap();
+        mgr.initialize().await.unwrap();
+
+        let bad = NutritionExtraction {
+            entries: vec![NutritionEntry {
+                name: "x".into(),
+                qty: -1.0,
+                unit: "g".into(),
+                kcal_estimate: None,
+            }],
+            confidence: 0.5,
+            raw_description: "bad".into(),
+            meal_type: "snack".into(),
+        };
+        let err = persist_extraction(&mgr, &bad, None, None, "")
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("non-positive qty"));
+
+        std::fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn normalize_meal_type_buckets() {
+        assert_eq!(normalize_meal_type("Desayuno"), "breakfast");
+        assert_eq!(normalize_meal_type("ALMUERZO"), "lunch");
+        assert_eq!(normalize_meal_type("comida"), "lunch");
+        assert_eq!(normalize_meal_type("cena"), "dinner");
+        assert_eq!(normalize_meal_type("antojo"), "craving");
+        assert_eq!(normalize_meal_type("trago"), "drink");
+        assert_eq!(normalize_meal_type("nope"), "snack");
+    }
+}

--- a/daemon/src/nutrition/mod.rs
+++ b/daemon/src/nutrition/mod.rs
@@ -24,6 +24,11 @@
 pub mod extractor;
 
 pub use extractor::{
-    detect_food_intent, extract_from_image, extract_from_voice_transcript, persist_extraction,
-    NutritionExtraction,
+    extract_from_image, extract_from_voice_transcript, persist_extraction, NutritionExtraction,
 };
+
+// `detect_food_intent` is only callable from the messaging-gated auto-trigger
+// in axi_tools. Re-export it under the same gate so non-messaging builds do
+// not flag the import as unused.
+#[cfg(feature = "messaging")]
+pub use extractor::detect_food_intent;

--- a/daemon/src/nutrition/mod.rs
+++ b/daemon/src/nutrition/mod.rs
@@ -1,0 +1,29 @@
+//! Nutrition extraction pipeline (BI.3 — photo/voice → nutrition_log).
+//!
+//! This module turns raw user signals (a food photo from a capture, or
+//! a voice transcript describing what was eaten) into structured
+//! `NutritionEntry` records and persists them in the existing
+//! `nutrition_log` table via `MemoryPlaneManager::log_nutrition_meal`.
+//!
+//! Design principles:
+//!
+//! * **Local-first.** The extractor calls the in-house `AiManager`
+//!   wrapper around `llama-server` (vision-capable Qwen 4B by default).
+//!   No external API is contacted unless the user opted into a remote
+//!   provider through the standard router; this module never sends raw
+//!   images or transcripts off-device on its own.
+//! * **Strict schema.** LLM output is parsed into a strict JSON shape;
+//!   anything that fails validation (empty name, non-positive qty,
+//!   nonsensical kcal) is rejected before it touches storage.
+//! * **No new gates.** This module only EXPOSES extraction + persistence
+//!   helpers. Trigger surfaces (axi tool, HTTP endpoint, or the optional
+//!   sensory-pipeline auto path) live in their own files and reuse the
+//!   gates already enforced there (autoexec, audio_enabled, kill switch,
+//!   bootstrap-token middleware).
+
+pub mod extractor;
+
+pub use extractor::{
+    detect_food_intent, extract_from_image, extract_from_voice_transcript, persist_extraction,
+    NutritionExtraction,
+};

--- a/docs/user/user-guide.md
+++ b/docs/user/user-guide.md
@@ -401,3 +401,18 @@ The *Vida Plena* section of the dashboard now exposes three interactive surfaces
   - *Reset* (with confirmation) calls `POST .../vault/reset` to clear the configured passphrase.
 
 All Vida Plena endpoints require the same `x-bootstrap-token` header. Vault errors map to `403` (locked / wrong passphrase) and `400` (missing/invalid input) so the UI surfaces the actual reason on failure.
+
+## Nutrition pipeline (photo / voice → `nutrition_log`)
+
+Item BI.3 turns food photos and voice notes into structured entries in the existing `nutrition_log` table without a manual form.
+
+Two HTTP entry points (both behind the standard `x-bootstrap-token`):
+
+- `POST /api/v1/vida-plena/nutrition/log/from-image` — body `{ "image_path": "/abs/path.jpg", "photo_attachment_id": "<opt>", "notes": "<opt>" }`. The daemon reads the file from disk, hands it to the local multimodal model (Qwen 4B by default), parses the strict JSON schema, validates each entry, and writes one row per detected item. Returns `{ extraction, logged_ids, count }`.
+- `POST /api/v1/vida-plena/nutrition/log/from-voice` — body `{ "transcript": "comi tres tacos al pastor", "voice_attachment_id": "<opt>", "notes": "<opt>" }`. Caller is responsible for producing the transcript (Whisper STT in `sensory_pipeline.rs` already does this for the wake-word flow).
+
+Same pipeline is also exposed to Axi as the `nutrition_log_from_capture` tool with `kind: "image" | "voice"` so the assistant can log meals during a normal conversation.
+
+Validation is strict: empty names, non-positive quantities, negative kcal, or implausible kcal estimates (> 5,000 per item) are rejected before they touch storage. When the model cannot detect a meal in the input, the endpoint returns an empty `entries` list and writes nothing.
+
+Privacy: extraction stays local — the image is sent inline to `127.0.0.1:8082` (llama-server). Routing the request to a remote vision provider only happens if the user has explicitly configured one in the LLM router; this endpoint never opts in on its own.


### PR DESCRIPTION
## Summary

Implements **Item BI.3** — when the user snaps a photo of food or dictates a voice note describing what they ate, LifeOS extracts structured entries and persists them in the existing `nutrition_log` table.

### Design

- **New module** `daemon/src/nutrition/{mod.rs,extractor.rs}` with three public entry points:
  - `extract_from_image(ai, path)` — sends the photo inline to llama-server's multimodal slot (Qwen 4B by default).
  - `extract_from_voice_transcript(ai, transcript)` — runs the same strict-JSON prompt over a Whisper transcript.
  - `persist_extraction(mem, extraction, …)` — writes one row per detected item via `MemoryPlaneManager::log_nutrition_meal`.
- **Strict JSON schema:** `{ entries: [{name, qty, unit, kcal_estimate}], confidence, raw_description, meal_type }`. Parser tolerates markdown fences and prose prefixes; validator rejects empty names, non-positive qty, negative kcal, and implausible kcal (> 5,000 per item).
- **HTTP endpoints** in `daemon/src/api/vida_plena.rs`:
  - `POST /api/v1/vida-plena/nutrition/log/from-image`
  - `POST /api/v1/vida-plena/nutrition/log/from-voice`
- **Axi tool** `nutrition_log_from_capture` with `kind: "image" | "voice"` so the agent can log meals during a conversation. Voice path uses `detect_food_intent` as a cheap pre-gate to skip the LLM call when the transcript shows no food mention.

### Constraints honored

- No changes to `supervisor.rs`, `agent_loop.rs`, `agent_roles.rs`, `screen_capture.rs`, `storage_housekeeping.rs`, `session_store.rs`, `screenshot_crypt.rs`, `workers.rs`, `conversations.rs`, `providers.rs`, `skill_generator.rs`, `mcp_server.rs`, `self_improving.rs`, `index.html`, `style.css`.
- No new sensor gates opened — extraction only runs when explicitly invoked via endpoint or tool.
- Local-first by default (decision_default_model_4b respected — works on Qwen 4B).
- No new dead code: every public symbol re-exported in `nutrition/mod.rs` is wired to either the HTTP API, the axi tool, or unit tests.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --features "dbus,http-api,ui-overlay,wake-word,messaging" -- -D warnings` clean
- [x] `cargo test … nutrition` — 27/27 green (validator branches, JSON parser edge cases, intent detection, meal-type normalization, end-to-end persistence with round-trip)
- [ ] Manual smoke once deployed: POST a meal photo to `/nutrition/log/from-image`, verify an entry appears in `nutrition_log_recent`