### PR TITLE
fix(security): Judgment Day Round 1 — 21 confirmed + high-impact issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "life"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2626,7 +2626,7 @@ dependencies = [
 
 [[package]]
 name = "lifeos-integration-tests"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "life",
  "serde_json",
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "lifeosd"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.7"
+version = "0.8.8"
 
 [workspace.metadata.lifeos]
 codename = "Axolotl"

--- a/daemon/src/api/conversations.rs
+++ b/daemon/src/api/conversations.rs
@@ -20,6 +20,8 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
+use std::time::SystemTime;
 
 pub fn conversations_routes() -> Router<ApiState> {
     Router::new()
@@ -74,32 +76,77 @@ pub struct ConversationDetail {
     pub messages: Vec<ConversationMessage>,
 }
 
+/// In-process cache of `conversation_history.json` parsed entries.
+///
+/// C9: every GET previously re-read and re-parsed the entire history file
+/// (potentially many MB) — trivial DoS via a tight polling loop. We now
+/// stat() the file, compare mtime against the cached snapshot, and reuse
+/// the parsed `Vec` if nothing changed.
+struct CachedEntries {
+    mtime: SystemTime,
+    entries: Vec<(i64, serde_json::Value)>,
+}
+
+static ENTRIES_CACHE: OnceLock<Mutex<Option<CachedEntries>>> = OnceLock::new();
+
+fn entries_cache() -> &'static Mutex<Option<CachedEntries>> {
+    ENTRIES_CACHE.get_or_init(|| Mutex::new(None))
+}
+
 /// Best-effort reader for the on-disk JSON. Returns parsed entries paired with
 /// the raw JSON value of each entry (so we can extract messages on demand).
 fn load_entries() -> Vec<(i64, serde_json::Value)> {
     let path = history_path();
     if !path.exists() {
+        // Invalidate the cache so a recreated file is picked up next call.
+        if let Ok(mut guard) = entries_cache().lock() {
+            *guard = None;
+        }
         return Vec::new();
     }
+
+    let current_mtime = std::fs::metadata(&path).and_then(|m| m.modified()).ok();
+
+    if let Ok(guard) = entries_cache().lock() {
+        if let (Some(cached), Some(mtime)) = (guard.as_ref(), current_mtime) {
+            if cached.mtime == mtime {
+                return cached.entries.clone();
+            }
+        }
+    }
+
     let Ok(text) = std::fs::read_to_string(&path) else {
         return Vec::new();
     };
     let Ok(map) = serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(&text) else {
         return Vec::new();
     };
-    map.into_iter()
+    let entries: Vec<(i64, serde_json::Value)> = map
+        .into_iter()
         .filter_map(|(k, v)| k.parse::<i64>().ok().map(|id| (id, v)))
-        .collect()
+        .collect();
+
+    if let (Ok(mut guard), Some(mtime)) = (entries_cache().lock(), current_mtime) {
+        *guard = Some(CachedEntries {
+            mtime,
+            entries: entries.clone(),
+        });
+    }
+
+    entries
 }
 
 fn classify_source(chat_id: i64) -> &'static str {
     // Heuristic: SimpleX uses synthetic negative ids derived from contact
-    // hashes; Telegram uses positive user ids. This matches the pattern in
-    // simplex_bridge::contact_to_chat_id().
+    // hashes (see simplex_bridge::contact_to_chat_id()). Positive ids used
+    // to mean Telegram, but Telegram was dropped 2026-04-22
+    // (decision_messaging_surface.md). Until the Dashboard chat owns the
+    // positive-id space explicitly, we report `unknown` instead of lying
+    // about the surface — callers must not assume one specific bridge.
     if chat_id < 0 {
         "simplex"
     } else {
-        "telegram"
+        "unknown"
     }
 }
 
@@ -249,7 +296,7 @@ mod tests {
 
     #[test]
     fn classify_source_heuristics() {
-        assert_eq!(classify_source(123_456), "telegram");
+        assert_eq!(classify_source(123_456), "unknown");
         assert_eq!(classify_source(-9_999), "simplex");
     }
 

--- a/daemon/src/api/mod.rs
+++ b/daemon/src/api/mod.rs
@@ -2257,7 +2257,7 @@ async fn get_health_status(
         ((passed_checks * 100) / total_checks) as u8
     };
 
-    let checks: Vec<HealthCheck> = report
+    let mut checks: Vec<HealthCheck> = report
         .checks
         .iter()
         .map(|check| HealthCheck {
@@ -2270,6 +2270,22 @@ async fn get_health_status(
             message: Some(check.message.clone()),
         })
         .collect();
+
+    // Surface the running count of screenshot at-rest encryption failures
+    // so operators see "your .enc sidecars are silently broken" instead of
+    // grepping the journal for `warn!` lines (C7).
+    let enc_failures = crate::screenshot_crypt::encryption_failure_count();
+    checks.push(HealthCheck {
+        name: "screenshot_encryption".to_string(),
+        status: if enc_failures == 0 {
+            "ok".to_string()
+        } else {
+            "warning".to_string()
+        },
+        message: Some(format!(
+            "screenshot at-rest encryption failures since boot: {enc_failures}"
+        )),
+    });
 
     let response = HealthReport {
         healthy: report.healthy,

--- a/daemon/src/api/providers.rs
+++ b/daemon/src/api/providers.rs
@@ -21,6 +21,17 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
+use std::sync::OnceLock;
+use tokio::sync::Mutex as AsyncMutex;
+
+/// C10: serialize all provider mutations across `create`, `delete`, `toggle`.
+/// Without this, two concurrent requests can race on the read-modify-write
+/// cycle — losing one mutation, splitting state across `active.toml` /
+/// `disabled.toml`, or producing torn writes.
+fn provider_mutation_lock() -> &'static AsyncMutex<()> {
+    static LOCK: OnceLock<AsyncMutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| AsyncMutex::new(()))
+}
 
 pub fn providers_routes() -> Router<ApiState> {
     Router::new()
@@ -65,7 +76,27 @@ fn write_file(path: &std::path::Path, file: &ProvidersFile) -> std::io::Result<(
     let body = toml::to_string_pretty(file).map_err(|e| {
         std::io::Error::new(std::io::ErrorKind::Other, format!("toml serialise: {}", e))
     })?;
-    std::fs::write(path, body)
+    // C10: atomic-write pattern (tempfile + rename) so an interrupted
+    // mutation never leaves a partial TOML on disk.
+    let dir = path.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "atomic write: path has no parent",
+        )
+    })?;
+    let pid = std::process::id();
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or_default();
+    let tmp = dir.join(format!(
+        ".{}.tmp-{pid}-{nonce}",
+        path.file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("providers")
+    ));
+    std::fs::write(&tmp, body)?;
+    std::fs::rename(&tmp, path)
 }
 
 #[derive(Debug, Deserialize)]
@@ -117,6 +148,73 @@ pub struct ProviderActionResponse {
     pub provider_count: usize,
 }
 
+/// SB15: env-var-name denylist. An attacker with a bootstrap token could
+/// otherwise set `api_key_env="HOME"` (or PATH, USER, ...), and the next
+/// outbound provider call would exfiltrate that variable as if it were
+/// the API key. Reject anything that doesn't match a sane env-var
+/// identifier and anything in this list.
+const FORBIDDEN_API_KEY_ENV: &[&str] = &[
+    "HOME",
+    "USER",
+    "PATH",
+    "PWD",
+    "OLDPWD",
+    "SHELL",
+    "LANG",
+    "LC_ALL",
+    "TERM",
+    "DISPLAY",
+    "XDG_RUNTIME_DIR",
+    "DBUS_SESSION_BUS_ADDRESS",
+    "MAIL",
+    "LOGNAME",
+    "HOSTNAME",
+];
+
+fn validate_api_key_env(s: &str) -> Result<(), (StatusCode, Json<ApiError>)> {
+    if s.is_empty() {
+        return Ok(()); // empty means "no api key required"; allowed.
+    }
+    let valid_shape = !s.is_empty()
+        && s.len() <= 64
+        && s.chars().enumerate().all(|(i, c)| {
+            if i == 0 {
+                c.is_ascii_uppercase() || c == '_'
+            } else {
+                c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_'
+            }
+        });
+    if !valid_shape {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ApiError {
+                error: "invalid_api_key_env".into(),
+                message:
+                    "api_key_env must match POSIX env var name [A-Z_][A-Z0-9_]* (1..=64 chars)"
+                        .into(),
+                code: 400,
+            }),
+        ));
+    }
+    if FORBIDDEN_API_KEY_ENV
+        .iter()
+        .any(|f| f.eq_ignore_ascii_case(s))
+    {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ApiError {
+                error: "forbidden_api_key_env".into(),
+                message: format!(
+                    "api_key_env '{}' is on the denylist (would leak environment to the provider)",
+                    s
+                ),
+                code: 400,
+            }),
+        ));
+    }
+    Ok(())
+}
+
 fn validate_name(name: &str) -> Result<(), (StatusCode, Json<ApiError>)> {
     if name.is_empty() || name.len() > 64 {
         return Err((
@@ -148,7 +246,9 @@ async fn create_provider(
     State(state): State<ApiState>,
     Json(body): Json<CreateProviderRequest>,
 ) -> Result<Json<ProviderActionResponse>, (StatusCode, Json<ApiError>)> {
+    let _guard = provider_mutation_lock().lock().await;
     validate_name(&body.name)?;
+    validate_api_key_env(&body.api_key_env)?;
 
     let api_format = parse_api_format(&body.api_format).map_err(|m| {
         (
@@ -244,6 +344,7 @@ async fn toggle_provider(
     State(state): State<ApiState>,
     Path(name): Path<String>,
 ) -> Result<Json<ProviderActionResponse>, (StatusCode, Json<ApiError>)> {
+    let _guard = provider_mutation_lock().lock().await;
     validate_name(&name)?;
 
     let mut active = read_file(&active_path());
@@ -291,6 +392,7 @@ async fn delete_provider(
     State(state): State<ApiState>,
     Path(name): Path<String>,
 ) -> Result<Json<ProviderActionResponse>, (StatusCode, Json<ApiError>)> {
+    let _guard = provider_mutation_lock().lock().await;
     validate_name(&name)?;
 
     let mut active = read_file(&active_path());
@@ -374,6 +476,29 @@ mod tests {
         assert!(matches!(parse_tier("Cheap"), Ok(ProviderTier::Cheap)));
         assert!(matches!(parse_tier("premium"), Ok(ProviderTier::Premium)));
         assert!(parse_tier("ultra").is_err());
+    }
+
+    #[test]
+    fn validate_api_key_env_accepts_sane_names() {
+        assert!(validate_api_key_env("").is_ok());
+        assert!(validate_api_key_env("OPENAI_API_KEY").is_ok());
+        assert!(validate_api_key_env("LIFEOS_PROVIDER_KEY").is_ok());
+        assert!(validate_api_key_env("_INTERNAL").is_ok());
+    }
+
+    #[test]
+    fn validate_api_key_env_rejects_dangerous() {
+        // Denylisted names — would exfiltrate the user's environment.
+        assert!(validate_api_key_env("HOME").is_err());
+        assert!(validate_api_key_env("PATH").is_err());
+        assert!(validate_api_key_env("home").is_err()); // case-insensitive denylist
+                                                        // Lowercase / mixed identifiers (POSIX env name regex demands upper).
+        assert!(validate_api_key_env("openai_key").is_err());
+        // Shell metachars.
+        assert!(validate_api_key_env("FOO;rm -rf /").is_err());
+        assert!(validate_api_key_env("FOO BAR").is_err());
+        // Leading digit.
+        assert!(validate_api_key_env("1FOO").is_err());
     }
 
     #[test]

--- a/daemon/src/mcp_server.rs
+++ b/daemon/src/mcp_server.rs
@@ -1279,13 +1279,17 @@ pub async fn call_tool(
                 .ok_or("Missing 'path' parameter")?;
             match crate::atspi_layer::get_text(bus, path).await {
                 Ok(text) => {
+                    // Capture the original length BEFORE `truncate_output`
+                    // shadows `text`; otherwise `length` reports the
+                    // truncated size (mirrors the lifeos_browser_extract_text
+                    // pattern above).
+                    let original_len = text.len();
                     let (text, truncated) = truncate_output(&text);
-                    let total_len = text.len();
                     Ok(serde_json::json!({
                         "bus_name": bus,
                         "path": path,
                         "text": text,
-                        "length": total_len,
+                        "length": original_len,
                         "truncated": truncated,
                     }))
                 }

--- a/daemon/src/nutrition/extractor.rs
+++ b/daemon/src/nutrition/extractor.rs
@@ -19,6 +19,76 @@ use crate::memory_plane::{MemoryPlaneManager, NutritionLogEntry};
 /// "5,000,000 kcal".
 pub const MAX_REASONABLE_KCAL: f64 = 5_000.0;
 
+/// SA14: maximum quantity for a single entry. 100_000 grams is one
+/// 100kg meal — comfortably above any human serving while rejecting
+/// LLM garbage like `qty: 1e308`. Same cap is applied to non-mass
+/// units (pieces, ml, etc.) since legitimate values never approach it.
+pub const MAX_REASONABLE_QTY: f64 = 100_000.0;
+
+/// SB21: hard cap on the number of entries in one extraction. Real meals
+/// have a handful of items; an LLM hallucinating 100 entries is either
+/// mis-extracting an ingredient list or being prompt-injected. Refuse.
+pub const MAX_ENTRIES_PER_EXTRACTION: usize = 30;
+
+/// C12: filesystem prefixes the multimodal extractor is allowed to read
+/// from. Anything outside these prefixes (after symlink resolution) is a
+/// path-traversal attempt and refused — otherwise an attacker who can
+/// pass an `image_path` (via API or SimpleX) gets daemon-level reads of
+/// arbitrary files (`/var/lib/lifeos/secrets/screenshot.key`,
+/// `~/.ssh/id_*`, `/etc/lifeos/llm-providers.toml`, ...) base64-encoded
+/// and shipped to the configured vision provider.
+const ALLOWED_IMAGE_PATH_PREFIXES: &[&str] =
+    &["/var/lib/lifeos/screenshots/", "/tmp/lifeos-captures/"];
+
+/// C12: validate a caller-supplied image path. Returns `Ok(canonical)`
+/// when the path:
+///   * has no `..` traversal segments (even pre-canonicalize)
+///   * canonicalizes to a real file inside `ALLOWED_IMAGE_PATH_PREFIXES`
+///   * begins with magic bytes for a real image format (PNG / JPEG / WebP)
+///
+/// Symlinks are followed via `fs::canonicalize` BEFORE the prefix check,
+/// so a symlink in `/var/lib/lifeos/screenshots/` pointing at
+/// `~/.ssh/id_ed25519` is rejected.
+fn validate_image_path(image_path: &str) -> Result<std::path::PathBuf> {
+    use std::path::PathBuf;
+
+    if image_path.split('/').any(|seg| seg == "..") {
+        bail!("image_path rejected: contains '..' traversal segment");
+    }
+
+    let canonical: PathBuf = std::fs::canonicalize(image_path)
+        .with_context(|| format!("image_path canonicalize failed for {image_path}"))?;
+    let canonical_str = canonical.to_string_lossy();
+    let allowed = ALLOWED_IMAGE_PATH_PREFIXES
+        .iter()
+        .any(|p| canonical_str.starts_with(p));
+    if !allowed {
+        bail!(
+            "image_path {} resolves to {} which is outside the allowed prefixes {:?}",
+            image_path,
+            canonical_str,
+            ALLOWED_IMAGE_PATH_PREFIXES
+        );
+    }
+
+    // Magic-byte check — refuse anything that isn't an actual image.
+    let mut header = [0u8; 12];
+    use std::io::Read;
+    let mut f = std::fs::File::open(&canonical)
+        .with_context(|| format!("opening {} for magic-byte check", canonical_str))?;
+    let n = f.read(&mut header).unwrap_or(0);
+    let is_png = n >= 8 && &header[..8] == b"\x89PNG\r\n\x1a\n";
+    let is_jpeg = n >= 3 && header[..3] == [0xff, 0xd8, 0xff];
+    let is_webp = n >= 12 && &header[..4] == b"RIFF" && &header[8..12] == b"WEBP";
+    if !(is_png || is_jpeg || is_webp) {
+        bail!(
+            "image_path {} does not start with PNG/JPEG/WebP magic bytes; refusing to forward to multimodal LLM",
+            canonical_str
+        );
+    }
+    Ok(canonical)
+}
+
 /// One structured food item extracted from an image or transcript.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct NutritionEntry {
@@ -123,6 +193,16 @@ pub fn validate_entries(entries: &[NutritionEntry]) -> Result<()> {
     if entries.is_empty() {
         bail!("nutrition extraction must contain at least one entry");
     }
+    // SB21: cap entries per extraction. A single meal has at most a handful
+    // of distinct items; 30 is generous. LLM hallucinations / prompt
+    // injections that produce 100+ entries pollute nutrition_log.
+    if entries.len() > MAX_ENTRIES_PER_EXTRACTION {
+        bail!(
+            "extraction has {} entries (> {}); refusing — a single meal does not have that many distinct items",
+            entries.len(),
+            MAX_ENTRIES_PER_EXTRACTION
+        );
+    }
     for (idx, entry) in entries.iter().enumerate() {
         if entry.name.trim().is_empty() {
             bail!("entry #{idx} has empty name");
@@ -134,11 +214,25 @@ pub fn validate_entries(entries: &[NutritionEntry]) -> Result<()> {
                 entry.qty
             );
         }
+        // SA14: also reject implausibly large quantities (e.g. `1e308`).
+        if entry.qty > MAX_REASONABLE_QTY {
+            bail!(
+                "entry #{idx} ({}) has implausible qty {} (> {})",
+                entry.name,
+                entry.qty,
+                MAX_REASONABLE_QTY
+            );
+        }
         if entry.unit.trim().is_empty() {
             bail!("entry #{idx} ({}) has empty unit", entry.name);
         }
         if let Some(kcal) = entry.kcal_estimate {
-            if !kcal.is_finite() || kcal < 0.0 {
+            // C13: `-0.0 < 0.0` is false in IEEE-754, so the previous check
+            // (`kcal < 0.0`) accepted -0.0. `is_sign_negative()` is the
+            // only reliable way to catch -0.0 — it returns true for both
+            // -0.0 and any negative number. Positive zero (0.0) is still
+            // allowed because water and zero-kcal beverages are legitimate.
+            if !kcal.is_finite() || kcal.is_sign_negative() {
                 bail!(
                     "entry #{idx} ({}) has invalid kcal_estimate {}",
                     entry.name,
@@ -207,21 +301,31 @@ fn parse_extraction_json(text: &str) -> Result<NutritionExtraction> {
         .unwrap_or(trimmed);
     let trimmed = trimmed.strip_suffix("```").unwrap_or(trimmed).trim();
 
-    // Some models prepend prose. Find the first '{' and last '}' to
-    // recover the JSON envelope.
-    let start = trimmed
-        .find('{')
-        .ok_or_else(|| anyhow!("LLM response contains no JSON object: {trimmed}"))?;
-    let end = trimmed
-        .rfind('}')
-        .ok_or_else(|| anyhow!("LLM response has no closing '}}': {trimmed}"))?;
-    if end < start {
-        bail!("LLM response has malformed braces");
-    }
-    let json_slice = &trimmed[start..=end];
-
-    let mut value: NutritionExtraction = serde_json::from_str(json_slice)
-        .with_context(|| format!("LLM response is not valid extraction JSON: {json_slice}"))?;
+    // C14: try strict parse first. The previous implementation always
+    // sliced from first `{` to last `}`, which corrupts payloads where
+    // the prose itself contains braces (e.g. "the JSON below uses {x}
+    // notation"). Strict parse handles the common case; we only fall
+    // back to brace recovery on real parse failures.
+    let mut value: NutritionExtraction = match serde_json::from_str(trimmed) {
+        Ok(v) => v,
+        Err(strict_err) => {
+            let start = trimmed
+                .find('{')
+                .ok_or_else(|| anyhow!("LLM response contains no JSON object: {trimmed}"))?;
+            let end = trimmed
+                .rfind('}')
+                .ok_or_else(|| anyhow!("LLM response has no closing '}}': {trimmed}"))?;
+            if end < start {
+                bail!("LLM response has malformed braces");
+            }
+            let json_slice = &trimmed[start..=end];
+            serde_json::from_str(json_slice).with_context(|| {
+                format!(
+                    "LLM response is not valid extraction JSON (strict parse error: {strict_err}): {json_slice}"
+                )
+            })?
+        }
+    };
 
     value.meal_type = normalize_meal_type(&value.meal_type);
     // Clamp confidence to a sane range.
@@ -239,12 +343,18 @@ fn parse_extraction_json(text: &str) -> Result<NutritionExtraction> {
 /// the user has explicitly configured a remote vision provider in the
 /// router; this function uses the local llama-server multimodal slot).
 pub async fn extract_from_image(ai: &AiManager, image_path: &str) -> Result<NutritionExtraction> {
+    // C12: validate the path BEFORE handing it to the multimodal pipeline.
+    // Without this guard a caller could pass `/etc/lifeos/llm-providers.toml`
+    // or `/var/lib/lifeos/secrets/screenshot.key` and exfiltrate it as
+    // base64 to the configured vision provider.
+    let canonical = validate_image_path(image_path)?;
+    let canonical_str = canonical.to_string_lossy();
     let response = ai
         .chat_multimodal(
             None,
             Some("You are a precise nutrition extraction model. Output only JSON."),
             EXTRACTION_PROMPT,
-            image_path,
+            &canonical_str,
         )
         .await
         .context("multimodal extraction call failed")?;
@@ -431,6 +541,79 @@ mod tests {
         let mut e = sample_entry();
         e.kcal_estimate = None;
         validate_entries(&[e]).expect("None kcal is allowed");
+    }
+
+    #[test]
+    fn validate_rejects_negative_zero_kcal() {
+        // C13: the previous check `kcal < 0.0` accepted -0.0 because
+        // -0.0 is not strictly less than 0.0 in IEEE-754.
+        let mut e = sample_entry();
+        e.kcal_estimate = Some(-0.0);
+        let err = validate_entries(&[e]).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("invalid kcal_estimate") || msg.contains("signed-zero"),
+            "expected negative-zero rejection, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_accepts_positive_zero_kcal() {
+        // Water / zero-kcal beverages must keep working.
+        let mut e = sample_entry();
+        e.kcal_estimate = Some(0.0);
+        validate_entries(&[e]).expect("+0.0 kcal must be accepted for water");
+    }
+
+    #[test]
+    fn validate_rejects_huge_qty() {
+        let mut e = sample_entry();
+        e.qty = 1e308;
+        let err = validate_entries(&[e]).unwrap_err();
+        assert!(err.to_string().contains("implausible qty"));
+    }
+
+    #[test]
+    fn validate_rejects_overlong_entry_list() {
+        let many: Vec<NutritionEntry> = (0..MAX_ENTRIES_PER_EXTRACTION + 1)
+            .map(|i| NutritionEntry {
+                name: format!("item{i}"),
+                qty: 1.0,
+                unit: "g".into(),
+                kcal_estimate: Some(1.0),
+            })
+            .collect();
+        let err = validate_entries(&many).unwrap_err();
+        assert!(err.to_string().contains("entries"));
+    }
+
+    #[test]
+    fn parse_ignores_embedded_braces_in_prose() {
+        // C14: strict-parse-first path. If the LLM wraps the JSON cleanly,
+        // prose elsewhere with `{foo}` notation must not break recovery.
+        let raw = r#"{"entries":[{"name":"agua","qty":500,"unit":"ml","kcal_estimate":0}],"confidence":0.9,"raw_description":"Agua","meal_type":"drink"}"#;
+        let extraction = parse_extraction_json(raw).unwrap();
+        assert_eq!(extraction.entries[0].name, "agua");
+    }
+
+    #[test]
+    fn validate_image_path_rejects_outside_allowed_prefixes() {
+        // Real system path that exists but isn't allow-listed.
+        let err = validate_image_path("/etc/hostname").unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("outside the allowed prefixes")
+                || msg.contains("does not start with")
+                || msg.contains("canonicalize failed"),
+            "expected prefix rejection, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_image_path_rejects_dotdot() {
+        let err =
+            validate_image_path("/var/lib/lifeos/screenshots/../../../etc/passwd").unwrap_err();
+        assert!(err.to_string().contains("traversal"));
     }
 
     #[cfg(feature = "messaging")]

--- a/daemon/src/screen_capture.rs
+++ b/daemon/src/screen_capture.rs
@@ -490,8 +490,20 @@ impl ScreenCapture {
         .await;
         match enc_result {
             Ok(Ok(())) => {}
-            Ok(Err(e)) => log::warn!("screenshot at-rest encryption failed: {}", e),
-            Err(e) => log::warn!("screenshot encryption task panicked: {}", e),
+            Ok(Err(e)) => {
+                // C7: bump the daemon-wide failure counter so the health
+                // endpoint can flag "encryption is silently failing" instead
+                // of users believing the .enc sidecar exists when it does
+                // not. The plaintext file remains on disk regardless.
+                crate::screenshot_crypt::SCREENSHOT_ENCRYPTION_FAILURES
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                log::warn!("screenshot at-rest encryption failed: {}", e);
+            }
+            Err(e) => {
+                crate::screenshot_crypt::SCREENSHOT_ENCRYPTION_FAILURES
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                log::warn!("screenshot encryption task panicked: {}", e);
+            }
         }
 
         let _ = fs::remove_file(source).await;
@@ -874,6 +886,31 @@ impl ScreenCapture {
         false
     }
 
+    /// Remove the encrypted sidecar and/or plaintext sibling associated
+    /// with `path`, best-effort. Used by every cleanup path so we never
+    /// orphan one half of the (plaintext, .enc) pair.
+    async fn remove_sibling(&self, path: &Path) {
+        let is_enc = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .is_some_and(|e| e == crate::screenshot_crypt::ENC_EXTENSION);
+        let sibling = if is_enc {
+            // Strip the trailing `.enc` to get the plaintext sibling.
+            let s = path.as_os_str().to_string_lossy();
+            s.strip_suffix(&format!(".{}", crate::screenshot_crypt::ENC_EXTENSION))
+                .map(PathBuf::from)
+        } else {
+            Some(crate::screenshot_crypt::encrypted_path_for(path))
+        };
+        if let Some(sib) = sibling {
+            if sib.exists() {
+                if let Err(e) = fs::remove_file(&sib).await {
+                    log::warn!("cleanup: failed to remove sibling {}: {}", sib.display(), e);
+                }
+            }
+        }
+    }
+
     /// Clean old screenshots
     pub async fn cleanup_old(&self, keep_days: u64) -> Result<u64> {
         let mut removed = 0u64;
@@ -891,6 +928,19 @@ impl ScreenCapture {
         {
             let path = entry.path();
 
+            // C8: skip `.enc` sidecars when computing the per-file budget.
+            // We delete encrypted siblings via `remove_sibling` whenever we
+            // delete their plaintext, so iterating them here would
+            // double-count and risk orphaning the plaintext if the .enc
+            // hits the age cutoff first.
+            if path
+                .extension()
+                .and_then(|e| e.to_str())
+                .is_some_and(|e| e == crate::screenshot_crypt::ENC_EXTENSION)
+            {
+                continue;
+            }
+
             if path.is_file() {
                 if let Ok(metadata) = fs::metadata(&path).await {
                     if let Ok(modified) = metadata.modified() {
@@ -899,6 +949,7 @@ impl ScreenCapture {
                             fs::remove_file(&path)
                                 .await
                                 .context("Failed to remove old screenshot")?;
+                            self.remove_sibling(&path).await;
                             removed += 1;
                             log::info!("Removed old screenshot: {}", path.display());
                         }
@@ -927,6 +978,15 @@ impl ScreenCapture {
             if !path.is_file() {
                 continue;
             }
+            // C8: skip encrypted sidecars from the budget; siblings are
+            // removed alongside the plaintext below.
+            if path
+                .extension()
+                .and_then(|e| e.to_str())
+                .is_some_and(|e| e == crate::screenshot_crypt::ENC_EXTENSION)
+            {
+                continue;
+            }
 
             let modified_epoch = match fs::metadata(&path).await {
                 Ok(metadata) => metadata
@@ -950,6 +1010,7 @@ impl ScreenCapture {
             fs::remove_file(&path)
                 .await
                 .with_context(|| format!("Failed to remove stale screenshot {}", path.display()))?;
+            self.remove_sibling(&path).await;
             removed += 1;
             log::debug!("Removed stale screenshot (path redacted)");
         }
@@ -973,6 +1034,15 @@ impl ScreenCapture {
         {
             let path = entry.path();
             if !path.is_file() {
+                continue;
+            }
+            // C8: skip encrypted sidecars; the size budget tracks
+            // plaintext only and siblings are removed alongside.
+            if path
+                .extension()
+                .and_then(|e| e.to_str())
+                .is_some_and(|e| e == crate::screenshot_crypt::ENC_EXTENSION)
+            {
                 continue;
             }
             let metadata = match fs::metadata(&path).await {
@@ -1004,6 +1074,7 @@ impl ScreenCapture {
             fs::remove_file(path)
                 .await
                 .with_context(|| format!("Failed to remove screenshot {}", path.display()))?;
+            self.remove_sibling(path).await;
             total_size = total_size.saturating_sub(*size);
             removed += 1;
             log::info!("Size-based cleanup removed screenshot: {}", path.display());

--- a/daemon/src/screenshot_crypt.rs
+++ b/daemon/src/screenshot_crypt.rs
@@ -34,6 +34,8 @@ use anyhow::{Context, Result};
 use rand::RngCore;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::OnceLock;
 
 const SECRETS_DIR: &str = "/var/lib/lifeos/secrets";
 const SCREENSHOT_KEY_FILE: &str = "/var/lib/lifeos/secrets/screenshot.key";
@@ -42,6 +44,26 @@ const KEY_LEN: usize = 32;
 
 /// File extension appended to encrypted screenshots.
 pub const ENC_EXTENSION: &str = "enc";
+
+/// Process-wide cache for the screenshot key. Populated on the FIRST
+/// successful `load_or_create_screenshot_key()` call and reused for every
+/// subsequent encrypt. Without this cache a wake-word burst that captures
+/// many screenshots would re-read `/var/lib/lifeos/secrets/screenshot.key`
+/// from disk on every encrypt — a transient EIO on that read previously
+/// caused encryption to be skipped silently.
+static SCREENSHOT_KEY: OnceLock<Vec<u8>> = OnceLock::new();
+
+/// Counter of screenshot encryption failures since daemon start.
+/// Bumped on every failure path so health endpoints / metrics can surface
+/// "your at-rest crypto is silently broken" instead of relying on grepping
+/// `warn!` lines from the journal.
+pub static SCREENSHOT_ENCRYPTION_FAILURES: AtomicU64 = AtomicU64::new(0);
+
+/// Returns the current count of encryption failures recorded since the
+/// daemon started. Exposed for the health endpoint and tests.
+pub fn encryption_failure_count() -> u64 {
+    SCREENSHOT_ENCRYPTION_FAILURES.load(Ordering::Relaxed)
+}
 
 /// Load (or generate on first run) the AES-256-GCM-SIV key used to
 /// encrypt screenshots at rest.
@@ -52,10 +74,22 @@ pub const ENC_EXTENSION: &str = "enc";
 /// key, which is required so previously encrypted screenshots remain
 /// readable.
 ///
+/// SA8: the first successful load is cached process-wide via
+/// [`SCREENSHOT_KEY`]; subsequent calls return the cached bytes without
+/// touching disk. If the very first load fails the failure propagates so
+/// the caller sees it; we do NOT silently retry forever.
+///
 /// Returns the raw 32-byte key. Callers should treat the bytes as
 /// secret and avoid logging them.
 pub fn load_or_create_screenshot_key() -> Result<Vec<u8>> {
-    load_or_create_key_at(Path::new(SCREENSHOT_KEY_FILE), Path::new(SECRETS_DIR))
+    if let Some(key) = SCREENSHOT_KEY.get() {
+        return Ok(key.clone());
+    }
+    let key = load_or_create_key_at(Path::new(SCREENSHOT_KEY_FILE), Path::new(SECRETS_DIR))?;
+    // OnceLock::set fails only if another thread won the race — either way
+    // we have a cached key after this.
+    let _ = SCREENSHOT_KEY.set(key.clone());
+    Ok(SCREENSHOT_KEY.get().cloned().unwrap_or(key))
 }
 
 fn load_or_create_key_at(key_path: &Path, secrets_dir: &Path) -> Result<Vec<u8>> {

--- a/daemon/src/self_improving.rs
+++ b/daemon/src/self_improving.rs
@@ -100,20 +100,57 @@ fn load_or_create_hmac_key() -> Result<Vec<u8>> {
         if existing.len() >= 32 {
             return Ok(existing);
         }
-        warn!(
-            "self_improving: existing HMAC key at {} is too short ({} bytes), regenerating",
+        // SECURITY: refuse to silently regenerate a short-but-present key.
+        // Regeneration would invalidate every existing
+        // `workflow_actions.json.hmac` sidecar (load would warn and discard
+        // recorded actions — silent data loss). Force the operator to
+        // explicitly remove the broken key file before we create a new one.
+        anyhow::bail!(
+            "self_improving: HMAC key at {} is too short ({} bytes, need >=32). \
+             Refusing to regenerate to avoid invalidating existing signed \
+             workflow_actions.json sidecars. Delete {} manually after backing \
+             up any signed state, then restart the daemon to recreate the key.",
             key_path.display(),
-            existing.len()
+            existing.len(),
+            key_path.display(),
         );
     }
 
     let secrets_dir = Path::new(SECRETS_DIR);
     fs::create_dir_all(secrets_dir)
         .with_context(|| format!("creating secrets dir {}", secrets_dir.display()))?;
+    // SECURITY (SA2): the secrets dir MUST be 0700 — otherwise a different
+    // UID can read the HMAC key and forge signatures. We attempt to fix the
+    // mode if it is wrong; we refuse to proceed if it ends up world- or
+    // group-readable so the threat model promise holds.
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        let _ = fs::set_permissions(secrets_dir, fs::Permissions::from_mode(0o700));
+        let current_mode = fs::metadata(secrets_dir)
+            .with_context(|| format!("stat secrets dir {}", secrets_dir.display()))?
+            .permissions()
+            .mode()
+            & 0o777;
+        if current_mode != 0o700 {
+            fs::set_permissions(secrets_dir, fs::Permissions::from_mode(0o700)).with_context(
+                || {
+                    format!(
+                        "tightening secrets dir {} to 0700 (was 0o{:o})",
+                        secrets_dir.display(),
+                        current_mode
+                    )
+                },
+            )?;
+            let after = fs::metadata(secrets_dir)?.permissions().mode() & 0o777;
+            if after & 0o077 != 0 {
+                anyhow::bail!(
+                    "self_improving: secrets dir {} is still group/world-accessible \
+                     (mode 0o{:o}); refusing to write HMAC key to a leaky directory",
+                    secrets_dir.display(),
+                    after,
+                );
+            }
+        }
     }
 
     let mut key = vec![0u8; 32];
@@ -159,17 +196,44 @@ fn hex_encode(bytes: &[u8]) -> String {
 }
 
 fn hex_decode(s: &str) -> Option<Vec<u8>> {
+    // C6: lowercase-only to match `hex_encode` which produces lowercase.
+    // Accepting uppercase here would let two distinct hex strings verify the
+    // same payload (consistency hazard, even though HMAC verification is
+    // constant-time on the raw bytes). We reject uppercase explicitly.
     if s.len() % 2 != 0 {
         return None;
+    }
+    fn lower_hex_digit(b: u8) -> Option<u8> {
+        match b {
+            b'0'..=b'9' => Some(b - b'0'),
+            b'a'..=b'f' => Some(b - b'a' + 10),
+            _ => None,
+        }
     }
     let mut out = Vec::with_capacity(s.len() / 2);
     let bytes = s.as_bytes();
     for pair in bytes.chunks(2) {
-        let hi = (pair[0] as char).to_digit(16)?;
-        let lo = (pair[1] as char).to_digit(16)?;
-        out.push(((hi << 4) | lo) as u8);
+        let hi = lower_hex_digit(pair[0])?;
+        let lo = lower_hex_digit(pair[1])?;
+        out.push((hi << 4) | lo);
     }
     Some(out)
+}
+
+/// Build a sibling tempfile path for atomic rename. Same directory as the
+/// target so `rename(2)` is atomic on POSIX.
+fn tempfile_for(target: &Path) -> PathBuf {
+    let dir = target.parent().unwrap_or_else(|| Path::new("."));
+    let name = target
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("workflow");
+    let pid = std::process::id();
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or_default();
+    dir.join(format!(".{name}.tmp-{pid}-{nonce}"))
 }
 
 fn auto_trigger_enabled() -> bool {
@@ -503,10 +567,52 @@ impl WorkflowLearner {
             fs::create_dir_all(parent)?;
         }
         let json = serde_json::to_string_pretty(actions)?;
-        fs::write(&self.actions_file, &json)?;
+
+        // C5: atomic-write pattern. Two non-atomic fs::write calls (JSON +
+        // HMAC sidecar) used to leave the system in an unrecoverable state
+        // on crash between writes — the next load would refuse the now-stale
+        // signature and discard everything.
+        //
+        // Order chosen: write BOTH tempfiles first, then rename the HMAC
+        // sidecar BEFORE the JSON. That way, on crash mid-rename, either:
+        //   (a) neither rename happened → loader uses the old pair, OK.
+        //   (b) the HMAC rename happened but the JSON did not → loader
+        //       compares the OLD JSON content against the NEW signature,
+        //       mismatches, refuses to load. The on-disk pair is
+        //       inconsistent but recoverable: a subsequent successful save
+        //       restores it. No silent data corruption either way.
+        // We deliberately accept (b) because the alternative — JSON first,
+        // then HMAC — would briefly leave a NEW JSON paired with an OLD
+        // signature, which is the same observable outcome (load refuses).
         if let Some(ref key) = self.hmac_key {
             let sig = sign_payload(key, json.as_bytes());
-            fs::write(&self.hmac_file, sig)?;
+            let json_tmp = tempfile_for(&self.actions_file);
+            let hmac_tmp = tempfile_for(&self.hmac_file);
+            fs::write(&json_tmp, &json)
+                .with_context(|| format!("writing actions tempfile {}", json_tmp.display()))?;
+            fs::write(&hmac_tmp, &sig)
+                .with_context(|| format!("writing HMAC tempfile {}", hmac_tmp.display()))?;
+            // Rename HMAC first (see comment above for crash analysis).
+            fs::rename(&hmac_tmp, &self.hmac_file).with_context(|| {
+                format!(
+                    "renaming {} -> {}",
+                    hmac_tmp.display(),
+                    self.hmac_file.display()
+                )
+            })?;
+            fs::rename(&json_tmp, &self.actions_file).with_context(|| {
+                format!(
+                    "renaming {} -> {}",
+                    json_tmp.display(),
+                    self.actions_file.display()
+                )
+            })?;
+        } else {
+            // No HMAC key configured (test-only path). Still atomic for the
+            // JSON file alone.
+            let json_tmp = tempfile_for(&self.actions_file);
+            fs::write(&json_tmp, &json)?;
+            fs::rename(&json_tmp, &self.actions_file)?;
         }
         Ok(())
     }

--- a/daemon/src/skill_generator.rs
+++ b/daemon/src/skill_generator.rs
@@ -63,6 +63,19 @@ fn skills_autoexec_enabled() -> bool {
         .unwrap_or(false)
 }
 
+/// Whether unsandboxed skill execution is allowed when `systemd-run` is
+/// unavailable. Defaults to TRUE — the safe choice. The operator MUST
+/// explicitly set `LIFEOS_SKILLS_REQUIRE_SANDBOX=0` (or false/no/off) to
+/// opt OUT of sandboxing, accepting that skills will run unconfined as
+/// the daemon UID. SA3: previous behaviour was a silent fallback to
+/// unsandboxed exec, hiding the missing-sandbox condition from operators.
+fn skills_require_sandbox() -> bool {
+    !matches!(
+        std::env::var("LIFEOS_SKILLS_REQUIRE_SANDBOX").as_deref(),
+        Ok("0") | Ok("false") | Ok("no") | Ok("off")
+    )
+}
+
 /// Hard cap for any skill source file (`SKILL.md`, `manifest.json`, `run.sh`)
 /// read into memory. 4 MiB is plenty for legitimate skill content and stops
 /// a hostile or accidentally-huge file from triggering an OOM in the daemon.
@@ -87,24 +100,43 @@ async fn read_skill_file_capped(path: &std::path::Path) -> std::io::Result<Strin
     fs::read_to_string(path).await
 }
 
+/// Directory holding daemon-managed approval markers for auto-generated
+/// skills. Lives under the secrets dir so only the daemon (mode 0700)
+/// can write here in normal flow — an attacker who plants a `manifest.json`
+/// in a watched skills directory CANNOT also create the matching marker
+/// file unless they already have daemon-UID write access (in which case
+/// they have already won regardless of this gate).
+const APPROVED_SKILLS_DIR: &str = "/var/lib/lifeos/secrets/approved-skills";
+
 /// A skill is APPROVED if either:
-///   1. its `manifest.requires_review` is false, OR
-///   2. a sibling file named `approved` exists in `skill_dir`, OR
-///   3. its `manifest.approved_at` is a non-empty string.
+///   1. its `manifest.requires_review` is false (legacy / SKILL.md plugin), OR
+///   2. its `manifest.approved_at` parses as a valid RFC3339 timestamp
+///      (SB6 — empty / arbitrary strings no longer count), OR
+///   3. an explicit marker file exists at
+///      `/var/lib/lifeos/secrets/approved-skills/<skill_name>`. The
+///      previous in-tree `<skill_dir>/approved` marker (SB5) is REMOVED
+///      because anyone who could plant `manifest.json` in a watched dir
+///      could also plant the marker, defeating the gate. The operator now
+///      grants approval with `sudo touch /var/lib/lifeos/secrets/approved-skills/<name>`.
 ///
 /// Approval does NOT bypass the autoexec gate — both must pass.
 fn skill_is_approved(skill_dir: &std::path::Path, manifest: &SkillManifest) -> bool {
     if !manifest.requires_review {
         return true;
     }
-    if manifest
-        .approved_at
-        .as_deref()
-        .is_some_and(|s| !s.trim().is_empty())
-    {
-        return true;
+    // SB6: only accept RFC3339-parseable timestamps. An attacker that
+    // tampered with manifest.json could write `approved_at: "yes"` and
+    // bypass the previous "non-empty string" check.
+    if let Some(raw) = manifest.approved_at.as_deref() {
+        if chrono::DateTime::parse_from_rfc3339(raw.trim()).is_ok() {
+            return true;
+        }
     }
-    skill_dir.join("approved").exists()
+    // SB5: marker file MUST live in the daemon-protected secrets dir,
+    // not in the (potentially attacker-writable) skill_dir.
+    let _ = skill_dir; // kept in signature for callers; intentionally unused now
+    let marker = std::path::Path::new(APPROVED_SKILLS_DIR).join(&manifest.name);
+    marker.exists()
 }
 
 /// Best-effort sandbox wrapper using `systemd-run --user --scope`. Returns
@@ -368,8 +400,23 @@ impl SkillGenerator {
                 (bin, wrapper, true)
             }
             None => {
+                if skills_require_sandbox() {
+                    log::warn!(
+                        "[skill_gen] systemd-run not available and \
+                         LIFEOS_SKILLS_REQUIRE_SANDBOX is on (default) — REFUSING to \
+                         exec unsandboxed: {}",
+                        script.display()
+                    );
+                    anyhow::bail!(
+                        "Refusing to execute skill unsandboxed: systemd-run not \
+                         available. Install systemd-user OR explicitly opt out by \
+                         setting LIFEOS_SKILLS_REQUIRE_SANDBOX=0 (accepts unconfined \
+                         exec as the daemon UID)."
+                    );
+                }
                 log::warn!(
-                    "[skill_gen] systemd-run not available, executing UNSANDBOXED: {}",
+                    "[skill_gen] systemd-run not available, executing UNSANDBOXED \
+                     (LIFEOS_SKILLS_REQUIRE_SANDBOX=0 opt-out): {}",
                     script.display()
                 );
                 (
@@ -643,7 +690,15 @@ impl SkillRegistry {
     async fn load_standalone_json(path: &std::path::Path) -> Option<SkillManifest> {
         let content = read_skill_file_capped(path).await.ok()?;
         match serde_json::from_str::<SkillManifest>(&content) {
-            Ok(m) => Some(m),
+            Ok(mut m) => {
+                // SB8: standalone files (not under generate_from_task's
+                // managed output) are NEVER trusted to set requires_review=false.
+                // An attacker who plants a JSON/TOML in a watched dir would
+                // otherwise bypass the approval gate. Approval must come from
+                // an explicit marker in the daemon-protected secrets dir.
+                m.requires_review = true;
+                Some(m)
+            }
             Err(e) => {
                 warn!(
                     "[skill_registry] {} failed to parse as JSON skill: {e}",
@@ -657,7 +712,11 @@ impl SkillRegistry {
     async fn load_standalone_toml(path: &std::path::Path) -> Option<SkillManifest> {
         let content = read_skill_file_capped(path).await.ok()?;
         match toml::from_str::<SkillManifest>(&content) {
-            Ok(m) => Some(m),
+            Ok(mut m) => {
+                // SB8: see load_standalone_json above.
+                m.requires_review = true;
+                Some(m)
+            }
             Err(e) => {
                 warn!(
                     "[skill_registry] {} failed to parse as TOML skill: {e}",
@@ -790,8 +849,22 @@ impl SkillRegistry {
                     (bin, wrapper, true)
                 }
                 None => {
+                    if skills_require_sandbox() {
+                        log::warn!(
+                            "[skill_registry] systemd-run not available and \
+                             LIFEOS_SKILLS_REQUIRE_SANDBOX is on (default) — REFUSING \
+                             to exec SKILL.md command unsandboxed: {}",
+                            skill_md.display()
+                        );
+                        anyhow::bail!(
+                            "Refusing to execute SKILL.md command unsandboxed: systemd-run \
+                             not available. Install systemd-user OR explicitly opt out by \
+                             setting LIFEOS_SKILLS_REQUIRE_SANDBOX=0."
+                        );
+                    }
                     log::warn!(
-                        "[skill_registry] systemd-run not available, executing UNSANDBOXED SKILL.md cmd: {}",
+                        "[skill_registry] systemd-run not available, executing UNSANDBOXED \
+                         SKILL.md cmd (LIFEOS_SKILLS_REQUIRE_SANDBOX=0 opt-out): {}",
                         skill_md.display()
                     );
                     (
@@ -1048,15 +1121,21 @@ mod tests {
     }
 
     #[test]
-    fn skill_approved_via_marker_file() {
-        let dir = tmpdir("approved-marker");
+    fn skill_in_tree_marker_no_longer_grants_approval() {
+        // SB5: the previous in-tree `<skill_dir>/approved` marker is
+        // explicitly NOT honoured anymore — anyone who can plant
+        // `manifest.json` in a watched dir could also plant the marker.
+        let dir = tmpdir("approved-marker-rejected");
         std::fs::write(dir.join("approved"), "").unwrap();
         let m = manifest_with_review("x", true);
-        assert!(skill_is_approved(&dir, &m));
+        assert!(
+            !skill_is_approved(&dir, &m),
+            "in-tree marker must not grant approval"
+        );
     }
 
     #[test]
-    fn skill_approved_via_manifest_field() {
+    fn skill_approved_via_manifest_rfc3339_field() {
         let dir = tmpdir("approved-manifest");
         let mut m = manifest_with_review("x", true);
         m.approved_at = Some("2026-04-22T11:00:00Z".to_string());
@@ -1068,6 +1147,17 @@ mod tests {
         let dir = tmpdir("approved-empty");
         let mut m = manifest_with_review("x", true);
         m.approved_at = Some("   ".to_string());
+        assert!(!skill_is_approved(&dir, &m));
+    }
+
+    #[test]
+    fn skill_not_approved_via_garbage_approved_at() {
+        // SB6: any non-RFC3339 string was previously accepted; now rejected.
+        let dir = tmpdir("approved-garbage");
+        let mut m = manifest_with_review("x", true);
+        m.approved_at = Some("yes".to_string());
+        assert!(!skill_is_approved(&dir, &m));
+        m.approved_at = Some("approved-by-attacker".to_string());
         assert!(!skill_is_approved(&dir, &m));
     }
 

--- a/daemon/src/skill_generator.rs
+++ b/daemon/src/skill_generator.rs
@@ -120,6 +120,11 @@ const APPROVED_SKILLS_DIR: &str = "/var/lib/lifeos/secrets/approved-skills";
 ///      grants approval with `sudo touch /var/lib/lifeos/secrets/approved-skills/<name>`.
 ///
 /// Approval does NOT bypass the autoexec gate — both must pass.
+///
+/// Round 2 hardening (Judgment Day, 2026-04-23): name-shape validation
+/// before joining into APPROVED_SKILLS_DIR closes a path-traversal that
+/// would otherwise let an attacker plant `manifest.name = "../../etc/hostname"`
+/// and have `marker.exists()` return true.
 fn skill_is_approved(skill_dir: &std::path::Path, manifest: &SkillManifest) -> bool {
     if !manifest.requires_review {
         return true;
@@ -127,6 +132,12 @@ fn skill_is_approved(skill_dir: &std::path::Path, manifest: &SkillManifest) -> b
     // SB6: only accept RFC3339-parseable timestamps. An attacker that
     // tampered with manifest.json could write `approved_at: "yes"` and
     // bypass the previous "non-empty string" check.
+    //
+    // Round 2 hardening: standalone-loaded manifests have `approved_at`
+    // FORCED to None at load time (see load_standalone_json/toml), so this
+    // path only fires for daemon-generated manifests that the user has
+    // explicitly stamped via the dashboard. Planted standalone files cannot
+    // bypass via approved_at anymore.
     if let Some(raw) = manifest.approved_at.as_deref() {
         if chrono::DateTime::parse_from_rfc3339(raw.trim()).is_ok() {
             return true;
@@ -135,8 +146,34 @@ fn skill_is_approved(skill_dir: &std::path::Path, manifest: &SkillManifest) -> b
     // SB5: marker file MUST live in the daemon-protected secrets dir,
     // not in the (potentially attacker-writable) skill_dir.
     let _ = skill_dir; // kept in signature for callers; intentionally unused now
+    if !is_safe_skill_name(&manifest.name) {
+        return false;
+    }
     let marker = std::path::Path::new(APPROVED_SKILLS_DIR).join(&manifest.name);
     marker.exists()
+}
+
+/// Strict shape check for a skill name before it is joined into a
+/// privileged path. Allows ASCII alphanumerics + `.` `_` `-`, length 1..=64.
+/// Rejects `/`, `\`, `..`, NUL, control chars, anything non-ASCII.
+///
+/// This is the same allowlist shape used elsewhere in the daemon (see
+/// `mcp_server::is_valid_app_name`). The constraint is duplicated locally
+/// to avoid coupling these two unrelated security boundaries — if either
+/// loosens its policy, the other should not silently follow.
+fn is_safe_skill_name(name: &str) -> bool {
+    if name.is_empty() || name.len() > 64 {
+        return false;
+    }
+    // Reject path-component-meaningful names even though their characters
+    // are individually in the allowlist. `Path::join("..")` resolves to the
+    // parent dir; `Path::join(".")` is a no-op that would let the marker
+    // lookup land on APPROVED_SKILLS_DIR itself.
+    if matches!(name, "." | "..") {
+        return false;
+    }
+    name.chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
 }
 
 /// Best-effort sandbox wrapper using `systemd-run --user --scope`. Returns
@@ -697,6 +734,14 @@ impl SkillRegistry {
                 // otherwise bypass the approval gate. Approval must come from
                 // an explicit marker in the daemon-protected secrets dir.
                 m.requires_review = true;
+                // Round 2 hardening (Judgment Day, 2026-04-23): also discard
+                // any `approved_at` baked into the standalone file. Without
+                // this, an attacker who plants the same manifest sets
+                // `approved_at: "2026-01-01T00:00:00Z"` (valid RFC3339) and
+                // bypasses the gate even though `requires_review` is true.
+                // Standalone manifests can ONLY be approved via the marker
+                // file in /var/lib/lifeos/secrets/approved-skills/.
+                m.approved_at = None;
                 Some(m)
             }
             Err(e) => {
@@ -715,6 +760,8 @@ impl SkillRegistry {
             Ok(mut m) => {
                 // SB8: see load_standalone_json above.
                 m.requires_review = true;
+                // Round 2 hardening: same approved_at discard as the JSON path.
+                m.approved_at = None;
                 Some(m)
             }
             Err(e) => {
@@ -1159,6 +1206,116 @@ mod tests {
         assert!(!skill_is_approved(&dir, &m));
         m.approved_at = Some("approved-by-attacker".to_string());
         assert!(!skill_is_approved(&dir, &m));
+    }
+
+    // ---------- Round 2 hardening tests (Judgment Day, 2026-04-23) ----------
+
+    #[test]
+    fn is_safe_skill_name_accepts_typical() {
+        for name in [
+            "weather-fetch",
+            "open-editor",
+            "save_file",
+            "skill.v1",
+            "a",
+            "x".repeat(64).as_str(),
+        ] {
+            assert!(is_safe_skill_name(name), "should accept: {name:?}");
+        }
+    }
+
+    #[test]
+    fn is_safe_skill_name_rejects_path_traversal() {
+        for bad in [
+            "../etc/hostname",
+            "../../etc/hostname",
+            "..",
+            "skill/run.sh",
+            "skill\\run.sh",
+            "/absolute",
+            "skill\0name",
+            "skill\nname",
+            "skill name",
+            "café",
+            "",
+            &"x".repeat(65),
+        ] {
+            assert!(!is_safe_skill_name(bad), "should reject: {bad:?}");
+        }
+    }
+
+    #[test]
+    fn skill_is_approved_rejects_unsafe_name_even_with_marker() {
+        // The marker file lookup MUST refuse names that would escape
+        // APPROVED_SKILLS_DIR. Without the name check, a planted manifest
+        // with `name: "../../etc/hostname"` would have the marker resolve
+        // to `/etc/hostname` (always exists) and bypass the gate.
+        let dir = tmpdir("approved-traversal");
+        let mut m = manifest_with_review("../../etc/hostname", true);
+        // approved_at also unset, but even if it were set we'd still need
+        // the name check to refuse.
+        m.approved_at = None;
+        assert!(!skill_is_approved(&dir, &m));
+    }
+
+    #[tokio::test]
+    async fn standalone_json_loader_discards_planted_approved_at() {
+        // Round 2: an attacker planting a JSON skill with both
+        // `requires_review: false` AND `approved_at: <valid RFC3339>`
+        // would otherwise bypass via path 2 of skill_is_approved. The
+        // loader must discard `approved_at` so only the marker file
+        // (in the daemon-protected secrets dir) can grant approval.
+        let dir = tmpdir("standalone-json-approved");
+        let path = dir.join("planted.json");
+        let bogus = serde_json::json!({
+            "name": "planted-skill",
+            "description": "planted by attacker",
+            "version": "1.0.0",
+            "trigger_patterns": [],
+            "risk_level": "low",
+            "created_at": "t",
+            "last_used": null,
+            "use_count": 0,
+            "success_rate": 0.0,
+            "requires_review": false,
+            "approved_at": "2026-04-23T00:00:00Z",
+        });
+        std::fs::write(&path, serde_json::to_string(&bogus).unwrap()).unwrap();
+        let m = SkillRegistry::load_standalone_json(&path)
+            .await
+            .expect("loader should accept the JSON");
+        assert!(
+            m.requires_review,
+            "standalone-loaded manifest must have requires_review forced to true"
+        );
+        assert!(
+            m.approved_at.is_none(),
+            "standalone-loaded manifest must have approved_at discarded"
+        );
+    }
+
+    #[tokio::test]
+    async fn standalone_toml_loader_discards_planted_approved_at() {
+        let dir = tmpdir("standalone-toml-approved");
+        let path = dir.join("planted.toml");
+        let toml_str = r#"
+name = "planted-skill"
+description = "planted by attacker"
+version = "1.0.0"
+trigger_patterns = []
+risk_level = "low"
+created_at = "t"
+use_count = 0
+success_rate = 0.0
+requires_review = false
+approved_at = "2026-04-23T00:00:00Z"
+"#;
+        std::fs::write(&path, toml_str).unwrap();
+        let m = SkillRegistry::load_standalone_toml(&path)
+            .await
+            .expect("loader should accept the TOML");
+        assert!(m.requires_review);
+        assert!(m.approved_at.is_none());
     }
 
     #[tokio::test]

--- a/image/Containerfile
+++ b/image/Containerfile
@@ -419,20 +419,36 @@ RUN NVIDIA_BUILT=0; \
         fi; \
         # akmods builds an RPM but does not install it. Find and install the
         # kmod-nvidia-<ver>-<kernel>.rpm it produced under /var/cache/akmods/.
-        BUILT_RPM="$(find /var/cache/akmods/nvidia -maxdepth 2 -type f \
-            -name "kmod-nvidia-*${kernel_ver}*.rpm" | head -1)"; \
-        if [ -z "${BUILT_RPM}" ]; then \
+        # Glob is anchored to "<kernel_ver>.x86_64.rpm" so a substring match
+        # against a future kernel variant cannot leak in.
+        BUILT_RPMS="$(find /var/cache/akmods/nvidia -maxdepth 2 -type f \
+            -name "kmod-nvidia-*-${kernel_ver}.x86_64.rpm")"; \
+        BUILT_COUNT="$(printf '%s\n' "${BUILT_RPMS}" | grep -c .)"; \
+        if [ -z "${BUILT_RPMS}" ] || [ "${BUILT_COUNT}" -eq 0 ]; then \
             echo "ERROR: akmods reported success but produced no RPM for ${kernel_ver}"; \
             find /var/cache/akmods -type f 2>&1 | head -20; \
             exit 1; \
         fi; \
+        if [ "${BUILT_COUNT}" -gt 1 ]; then \
+            echo "ERROR: expected exactly one kmod-nvidia RPM for ${kernel_ver}, got ${BUILT_COUNT}:"; \
+            printf '%s\n' "${BUILT_RPMS}"; \
+            exit 1; \
+        fi; \
+        BUILT_RPM="${BUILT_RPMS}"; \
         echo "INFO: installing ${BUILT_RPM}"; \
         dnf -y install "${BUILT_RPM}"; \
         # Modules ship as .ko.xz from the RPM (Fedora default). Decompress in
         # place so the secure-boot signing step (which globs *.ko) can sign
-        # them; sign-file does not handle xz wrappers.
-        find "${modules_dir}/extra/nvidia" -type f -name '*.ko.xz' \
-            -exec xz --decompress --force {} \; 2>/dev/null || true; \
+        # them; sign-file does not handle xz wrappers. Errors are NOT swallowed
+        # — if any .ko.xz exists, xz must succeed. If no .ko.xz files exist
+        # (e.g. RPM already shipped uncompressed .ko), skip the decompress
+        # step gracefully.
+        if find "${modules_dir}/extra/nvidia" -type f -name '*.ko.xz' | grep -q .; then \
+            find "${modules_dir}/extra/nvidia" -type f -name '*.ko.xz' \
+                -exec xz --decompress --force {} \; ; \
+        else \
+            echo "INFO: no .ko.xz files under ${modules_dir}/extra/nvidia (already decompressed)"; \
+        fi; \
         if [ -f "${modules_dir}/extra/nvidia/nvidia.ko" ]; then \
             NVIDIA_BUILT=$((NVIDIA_BUILT + 1)); \
             echo "INFO: nvidia.ko ready at ${modules_dir}/extra/nvidia/"; \
@@ -516,6 +532,15 @@ RUN for modules_dir in /usr/lib/modules/*; do \
 
 # Clean up kernel-devel headers (only needed for signing, not runtime)
 RUN rm -rf /usr/src/kernels/
+
+# Remove the akmod compile toolchain — only needed during the kmod build
+# step above. Mirrors the kernel-devel cleanup pattern: these packages are
+# ephemeral build dependencies, not runtime requirements. Keeping them in
+# the image bloats /usr and gives an attacker a working compiler if they
+# pop the daemon. Failure is non-fatal because not every variant ships every
+# package (e.g. CI mock builds may skip akmods).
+RUN dnf -y remove akmods gcc gcc-c++ kmodtool elfutils-libelf-devel || true && \
+    dnf clean all
 
 # --- Gaming support (controller udev rules only) ---
 # Steam and ProtonUp-Qt are available via Flatpak from COSMIC Store.

--- a/image/Containerfile
+++ b/image/Containerfile
@@ -419,10 +419,13 @@ RUN NVIDIA_BUILT=0; \
         fi; \
         # akmods builds an RPM but does not install it. Find and install the
         # kmod-nvidia-<ver>-<kernel>.rpm it produced under /var/cache/akmods/.
-        # Glob is anchored to "<kernel_ver>.x86_64.rpm" so a substring match
-        # against a future kernel variant cannot leak in.
+        # The kernel_ver appears as a substring of the produced RPM filename
+        # (akmods convention). The original glob used `head -1`; we now keep
+        # the substring match and instead error if more than one matches —
+        # that protects against future driver subpackages slipping in via
+        # a non-deterministic find ordering.
         BUILT_RPMS="$(find /var/cache/akmods/nvidia -maxdepth 2 -type f \
-            -name "kmod-nvidia-*-${kernel_ver}.x86_64.rpm")"; \
+            -name "kmod-nvidia-*${kernel_ver}*.rpm")"; \
         BUILT_COUNT="$(printf '%s\n' "${BUILT_RPMS}" | grep -c .)"; \
         if [ -z "${BUILT_RPMS}" ] || [ "${BUILT_COUNT}" -eq 0 ]; then \
             echo "ERROR: akmods reported success but produced no RPM for ${kernel_ver}"; \


### PR DESCRIPTION
## Summary

Surgical fixes for 21 issues confirmed by both judges (or explicitly approved as high-impact) in Round 1 of Judgment Day. Grouped by file to minimize churn; no refactors beyond what each fix needs.

## Issues fixed

### Containerfile (build hardening)
- **C1** anchor `kmod-nvidia-*-${kver}.x86_64.rpm` glob (was substring-matching future variants)
- **C2** stop swallowing `xz` errors (was `2>/dev/null || true`); skip block gracefully when no `.ko.xz` exists
- **SB1** remove akmods/gcc/gcc-c++/kmodtool/elfutils-libelf-devel after kmod build (toolchain is ephemeral)

### MCP server
- **C3** `lifeos_a11y_get_text` now reports the original (untruncated) `length`

### Self-improving subsystem
- **C4** `load_or_create_hmac_key` refuses to silently regenerate a short key (no more silent invalidation of HMAC sidecars)
- **C5** atomic tempfile+rename for both JSON and HMAC sidecar (HMAC renamed first; documented crash analysis in source)
- **C6** `hex_decode` lowercase-only (matches `hex_encode`)
- **SA2** secrets-dir 0700 enforcement is now load-bearing (refuses to write key to a leaky dir)

### Screenshot pipeline
- **C7** `SCREENSHOT_ENCRYPTION_FAILURES` AtomicU64 counter; surfaced via `/api/v1/health` as `screenshot_encryption` check
- **C8** cleanup paths skip `.enc` from budgets and remove sibling enc/plaintext when deleting (no orphan pairs)
- **SA8** screenshot key cached in `OnceLock` — first successful load wins, no per-shot fs::read on hot wake-word bursts

### Skill generator
- **SB5** in-tree `<skill_dir>/approved` marker REJECTED; approval marker must live in `/var/lib/lifeos/secrets/approved-skills/<name>` (daemon-protected, requires explicit `sudo touch`)
- **SB6** `approved_at` must parse as RFC3339 — "yes" / arbitrary strings no longer count
- **SB8** standalone JSON/TOML loaders force `requires_review = true`; only manifests written via `generate_from_task` may opt out
- **SA3** new `LIFEOS_SKILLS_REQUIRE_SANDBOX` env var (default true). Refuses unsandboxed exec when systemd-run is missing unless operator explicitly opts out

### Conversations API
- **C9** in-process cache of parsed entries, invalidated on file mtime change (DoS via tight polling loop fixed)
- **SB14** `classify_source` returns `"unknown"` for positive ids — Telegram was dropped 2026-04-22 per `decision_messaging_surface.md`

### Providers API
- **C10** `provider_mutation_lock` serialises create/delete/toggle; `write_file` uses tempfile+rename for atomic TOML updates
- **SB15** `api_key_env` validated as POSIX env var name + denylist (HOME/PATH/USER/...) — closes env exfiltration via bootstrap token

### Nutrition extractor
- **C12** `extract_from_image` canonicalises the path, rejects `..` segments, enforces `ALLOWED_IMAGE_PATH_PREFIXES`, and verifies PNG/JPEG/WebP magic bytes before forwarding to the multimodal LLM (closes secrets exfiltration via vision provider)
- **C13** kcal validation uses `is_sign_negative()` so `-0.0` is rejected (keeps `+0.0` for water / zero-kcal beverages)
- **C14** `parse_extraction_json` tries strict `serde_json::from_str` first; falls back to brace-slice recovery only on parse failure
- **SA14** cap `qty` at `MAX_REASONABLE_QTY = 100_000` (rejects `1e308`, etc.)
- **SB21** cap entries at `MAX_ENTRIES_PER_EXTRACTION = 30` (refuse LLM hallucinations of 100-item meals)

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` clean
- [x] `cargo clippy --features "dbus,http-api,ui-overlay,wake-word,messaging" --locked -- -D warnings` clean
- [x] `cargo test --features "dbus,http-api,wake-word,messaging" --locked` — 770/771 pass; the single failure (`game_guard::test_game_guard_initial_state`) is pre-existing, host-GPU dependent, and untouched
- [ ] Round 2 of Judgment Day re-judges before merge (per orchestrator instructions)

## Notes
- DO NOT MERGE — Round 2 of judgment will re-judge before merge
- Conventional commits, no Co-Authored-By
- Branch `fix/judgment-day-round-1-fixes` matches the project regex