### PR TITLE
fix(image): enforce /etc/os-release symlink on every boot (stale version bug)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "life"
-version = "0.8.8"
+version = "0.8.9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2626,7 +2626,7 @@ dependencies = [
 
 [[package]]
 name = "lifeos-integration-tests"
-version = "0.8.8"
+version = "0.8.9"
 dependencies = [
  "life",
  "serde_json",
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "lifeosd"
-version = "0.8.8"
+version = "0.8.9"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.8"
+version = "0.8.9"
 
 [workspace.metadata.lifeos]
 codename = "Axolotl"

--- a/image/Containerfile
+++ b/image/Containerfile
@@ -983,6 +983,15 @@ COPY image/files/etc/systemd/system/lifeos-thermal.service /usr/lib/systemd/syst
 COPY image/files/etc/tmpfiles.d/lifeos-thermal.conf /usr/lib/tmpfiles.d/lifeos-thermal.conf
 # Force 0600 on actions-runner/.env and llm-providers.env (token-bearing).
 COPY image/files/usr/lib/tmpfiles.d/lifeos-secrets.conf /usr/lib/tmpfiles.d/lifeos-secrets.conf
+# Enforce /etc/os-release as a symlink to /usr/lib/os-release on every boot.
+# Anaconda (and some OEM installers) copy /usr/lib/os-release into
+# /etc/os-release as a regular file at install time. bootc's 3-way merge
+# preserves /etc across upgrades → the authoritative VERSION updates in
+# /usr/lib/ but the frozen /etc/ copy silently stays at install-time values.
+# GNOME/KDE "About" dialogs and the boot-entry title generator read
+# /etc/os-release, so the user sees a stale version long after the image
+# has moved on. tmpfiles-setup.service re-enforces the symlink on every boot.
+COPY image/files/usr/lib/tmpfiles.d/lifeos-os-release.conf /usr/lib/tmpfiles.d/lifeos-os-release.conf
 COPY image/files/etc/udev/rules.d/90-lifeos-thermal.rules /usr/lib/udev/rules.d/90-lifeos-thermal.rules
 
 # --- I/O scheduler: NVMe=none, SSD=mq-deadline, HDD=bfq ---

--- a/image/files/usr/lib/tmpfiles.d/lifeos-os-release.conf
+++ b/image/files/usr/lib/tmpfiles.d/lifeos-os-release.conf
@@ -1,0 +1,24 @@
+# Enforce /etc/os-release as a symlink to /usr/lib/os-release on every boot.
+#
+# Background: LifeOS ships a Containerfile-generated /usr/lib/os-release with
+# the authoritative VERSION and PRETTY_NAME (sourced from Cargo.toml's
+# workspace.package.version + workspace.metadata.lifeos.codename). The
+# Containerfile also creates the `/etc/os-release -> ../usr/lib/os-release`
+# symlink at build time.
+#
+# Why we need this tmpfiles rule anyway:
+#   - Anaconda (and some OEM installers) copy /usr/lib/os-release into
+#     /etc/os-release as a regular file during initial install.
+#   - bootc's 3-way merge treats /etc changes as "user-modified" and
+#     preserves them across upgrades.
+#   - Net: the authoritative /usr/lib/os-release updates correctly on every
+#     deploy, but /etc/os-release silently freezes at install-time values.
+#     GNOME "Acerca de", KDE "About", cosmic-settings, and the boot entry
+#     title generator all read /etc/os-release — so the user sees a stale
+#     "LifeOS 0.2 Aegis" long after the image has moved on.
+#
+# `L+` (force-create symlink, replacing existing file if any) runs on every
+# boot via systemd-tmpfiles-setup.service. Re-applied after bootc upgrade
+# reboots, guaranteeing /etc/os-release always points at the deployment's
+# current /usr/lib/os-release.
+L+ /etc/os-release - - - - ../usr/lib/os-release


### PR DESCRIPTION
## Symptom

User on 0.8.8 sees:
- GNOME/cosmic "Acerca de" shows **"LifeOS 0.2 Aegis"** (a string from months ago)
- Boot loader entries title shows **"LifeOS 0.8.4 Axolotl"** (2 deploys behind)

`lifeosd --version` and `/usr/lib/os-release` correctly report `0.8.8 Axolotl`. The software is fine; the strings users SEE are stale.

## Root cause

`/etc/os-release` is a regular file dated `mar 27` — months before 0.8.8 was built:
```
$ ls -la /etc/os-release
-rw-r--r--. 1 root root 586 mar 27 10:02 /etc/os-release
$ sudo cat /etc/os-release | head -2
NAME="LifeOS"
VERSION="0.2 Aegis"
```

The Containerfile correctly creates `/etc/os-release -> ../usr/lib/os-release` at build time, but:

1. Anaconda (Fedora installer) copies `/usr/lib/os-release` into `/etc/` as a regular file during initial install, breaking the symlink.
2. bootc's 3-way merge treats `/etc` changes as "user-modified" and preserves them across every upgrade.
3. Result: `/usr/lib/os-release` updates on every deploy, but the frozen `/etc` copy stays at install-time forever.

Boot entry titles come from `/etc/os-release` via the ostree/BLS generator at deploy time, so they inherit the same stale value.

## Fix

New `tmpfiles.d` rule that re-enforces the symlink on every boot:

```
# image/files/usr/lib/tmpfiles.d/lifeos-os-release.conf
L+ /etc/os-release - - - - ../usr/lib/os-release
```

`L+` forces symlink creation even if a regular file exists at the target. `systemd-tmpfiles-setup.service` runs this early in boot, guaranteeing `/etc/os-release` always points at the deployment's current `/usr/lib/os-release`.

Wired into `image/Containerfile` next to the existing `lifeos-secrets.conf` COPY, with an explanatory comment.

## Immediate workaround for users on broken deployments

Before this PR lands in an image, users can repair with:
```
sudo rm /etc/os-release && sudo ln -sf ../usr/lib/os-release /etc/os-release
```

After the next upgrade that includes this patch, the tmpfiles rule keeps things honest automatically.

## Test plan

- [ ] CI green
- [ ] After merge + bootc upgrade on laptop:
  - [ ] `ls -la /etc/os-release` shows symlink to `../usr/lib/os-release`
  - [ ] `cat /etc/os-release | rg VERSION` shows `0.8.9 Axolotl` (or current)
  - [ ] GNOME/cosmic "Acerca de" shows the correct version
  - [ ] Boot entry title on NEXT upgrade reflects the new version