### PR TITLE
feat(privacy): privacy mode toggle + tray meeting recording

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "life"
-version = "0.8.9"
+version = "0.8.10"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2626,7 +2626,7 @@ dependencies = [
 
 [[package]]
 name = "lifeos-integration-tests"
-version = "0.8.9"
+version = "0.8.10"
 dependencies = [
  "life",
  "serde_json",
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "lifeosd"
-version = "0.8.9"
+version = "0.8.10"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.9"
+version = "0.8.10"
 
 [workspace.metadata.lifeos]
 codename = "Axolotl"

--- a/daemon/src/api/mod.rs
+++ b/daemon/src/api/mod.rs
@@ -8,6 +8,7 @@
 
 mod conversations;
 mod lab;
+pub mod privacy_mode;
 mod providers;
 mod vida_plena;
 mod workers;
@@ -1607,6 +1608,10 @@ pub fn create_router(state: ApiState) -> Router {
         // LLM provider mutations (add / toggle / delete). The GET list lives
         // above at /llm/providers; here we add the write side.
         .nest("/llm/providers", providers::providers_routes())
+        // Modo Privacidad — toggle global que fuerza al router a usar
+        // SOLO providers tier=Local. Persistido en
+        // ~/.config/lifeos/privacy-mode (override por env LIFEOS_PRIVACY_MODE).
+        .nest("/privacy-mode", privacy_mode::privacy_mode_routes())
         // Alias: dashboard expects POST /system/mode but the canonical route
         // is /mode/set. Keep the alias so existing UI buttons work, and so
         // anyone wiring system-level scripts has a stable path.

--- a/daemon/src/api/privacy_mode.rs
+++ b/daemon/src/api/privacy_mode.rs
@@ -1,0 +1,351 @@
+//! Modo Privacidad — toggle global que fuerza al `llm_router` a usar SOLO
+//! providers `tier=Local`.
+//!
+//! Estado:
+//! - Persistido en `~/.config/lifeos/privacy-mode` (un único byte: `0` o `1`).
+//! - Override por env var `LIFEOS_PRIVACY_MODE` (1/true/yes/on → true,
+//!   0/false/no/off → false, otro valor → cae al archivo).
+//! - Cache en memoria (`RwLock<bool>`) para no leer disco en cada request del
+//!   router.
+//!
+//! Endpoints (gated por `x-bootstrap-token` desde el router en `api/mod.rs`):
+//! - `GET  /api/v1/privacy-mode` → estado actual + fuente
+//! - `POST /api/v1/privacy-mode` → persiste y devuelve el nuevo estado
+//!
+//! Diseño:
+//! - El router consulta `is_privacy_mode_enabled()` antes de elegir candidates.
+//!   Si está ON, filtra `ProviderTier::Local` y deshabilita la escalation a Free.
+//! - Si el caller pidió un `preferred_provider` que no es Local, se sobrescribe
+//!   al primer Local disponible (con `warn!`).
+
+use super::{ApiError, ApiState};
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::Json,
+    routing::{get, post},
+    Router,
+};
+use log::{info, warn};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use std::sync::{OnceLock, RwLock};
+
+const ENV_VAR: &str = "LIFEOS_PRIVACY_MODE";
+const FILE_NAME: &str = "privacy-mode";
+
+/// Cache en memoria del estado leído desde archivo. `None` = aún no inicializado.
+fn cache() -> &'static RwLock<Option<bool>> {
+    static CACHE: OnceLock<RwLock<Option<bool>>> = OnceLock::new();
+    CACHE.get_or_init(|| RwLock::new(None))
+}
+
+fn config_dir() -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/home/lifeos".into());
+    PathBuf::from(format!("{}/.config/lifeos", home))
+}
+
+fn state_path() -> PathBuf {
+    config_dir().join(FILE_NAME)
+}
+
+/// Resultado de la resolución del estado actual, incluyendo de dónde vino.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrivacySource {
+    Env,
+    File,
+    Default,
+}
+
+impl PrivacySource {
+    fn as_str(&self) -> &'static str {
+        match self {
+            PrivacySource::Env => "env",
+            PrivacySource::File => "file",
+            PrivacySource::Default => "default",
+        }
+    }
+}
+
+/// Parse del env var. Devuelve `Some(bool)` si reconoce el valor, `None` si no.
+fn parse_env(value: &str) -> Option<bool> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Some(true),
+        "0" | "false" | "no" | "off" => Some(false),
+        _ => None,
+    }
+}
+
+/// Lee el archivo de estado. Devuelve `None` si no existe o está malformado.
+fn read_file() -> Option<bool> {
+    let path = state_path();
+    let content = std::fs::read_to_string(&path).ok()?;
+    let trimmed = content.trim();
+    match trimmed {
+        "1" => Some(true),
+        "0" => Some(false),
+        _ => None,
+    }
+}
+
+/// Escribe el archivo de estado de manera atómica (tempfile + rename).
+fn write_file(enabled: bool) -> std::io::Result<()> {
+    let path = state_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let body = if enabled { "1" } else { "0" };
+    let dir = path.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "atomic write: path sin parent",
+        )
+    })?;
+    let pid = std::process::id();
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or_default();
+    let tmp = dir.join(format!(".privacy-mode.tmp-{pid}-{nonce}"));
+    std::fs::write(&tmp, body)?;
+    std::fs::rename(&tmp, &path)
+}
+
+/// Resuelve el estado y la fuente. Lee env var primero, luego cache, luego archivo.
+fn resolve() -> (bool, PrivacySource) {
+    if let Ok(value) = std::env::var(ENV_VAR) {
+        if let Some(parsed) = parse_env(&value) {
+            return (parsed, PrivacySource::Env);
+        }
+    }
+    {
+        let guard = cache().read().expect("privacy_mode cache poisoned");
+        if let Some(value) = *guard {
+            return (value, PrivacySource::File);
+        }
+    }
+    // Cache miss → leer archivo y poblar
+    let from_file = read_file();
+    let mut guard = cache().write().expect("privacy_mode cache poisoned");
+    if let Some(value) = from_file {
+        *guard = Some(value);
+        (value, PrivacySource::File)
+    } else {
+        // No archivo → default false. Cacheamos `false` para evitar releer
+        // en cada request hasta que el usuario haga toggle.
+        *guard = Some(false);
+        (false, PrivacySource::Default)
+    }
+}
+
+/// API pública consumida por el llm_router. Devuelve `true` si el modo
+/// privacidad está activo (env var > archivo > default false).
+pub fn is_privacy_mode_enabled() -> bool {
+    resolve().0
+}
+
+/// Persiste el nuevo estado y actualiza el cache. NO modifica el env var.
+pub fn set_privacy_mode(enabled: bool) -> std::io::Result<()> {
+    write_file(enabled)?;
+    let mut guard = cache().write().expect("privacy_mode cache poisoned");
+    *guard = Some(enabled);
+    info!("[privacy_mode] estado actualizado → {}", enabled);
+    Ok(())
+}
+
+#[cfg(test)]
+fn reset_cache_for_test() {
+    let mut guard = cache().write().expect("privacy_mode cache poisoned");
+    *guard = None;
+}
+
+/// Lock global compartido entre todos los tests del crate que tocan
+/// `LIFEOS_PRIVACY_MODE` o el archivo de estado. Necesario porque
+/// distintos módulos de test corren en paralelo y env vars / cache son
+/// estado global. Usamos `tokio::sync::Mutex` para que sea await-safe.
+#[cfg(test)]
+pub(crate) fn test_state_lock() -> &'static tokio::sync::Mutex<()> {
+    static LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+}
+
+// --------------------------------------------------------------------------
+// HTTP handlers
+// --------------------------------------------------------------------------
+
+#[derive(Debug, Serialize)]
+pub struct PrivacyModeStatus {
+    pub enabled: bool,
+    pub source: &'static str,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SetPrivacyModeRequest {
+    pub enabled: bool,
+}
+
+pub fn privacy_mode_routes() -> Router<ApiState> {
+    Router::new()
+        .route("/", get(get_privacy_mode))
+        .route("/", post(post_privacy_mode))
+}
+
+async fn get_privacy_mode(
+    State(_state): State<ApiState>,
+) -> Result<Json<PrivacyModeStatus>, (StatusCode, Json<ApiError>)> {
+    let (enabled, source) = resolve();
+    Ok(Json(PrivacyModeStatus {
+        enabled,
+        source: source.as_str(),
+    }))
+}
+
+async fn post_privacy_mode(
+    State(_state): State<ApiState>,
+    Json(payload): Json<SetPrivacyModeRequest>,
+) -> Result<Json<PrivacyModeStatus>, (StatusCode, Json<ApiError>)> {
+    if let Err(e) = set_privacy_mode(payload.enabled) {
+        warn!(
+            "[privacy_mode] no pude persistir estado={}: {}",
+            payload.enabled, e
+        );
+        return Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ApiError {
+                error: "privacy_mode_persist_failed".into(),
+                message: format!("No se pudo escribir el archivo de estado: {}", e),
+                code: 500,
+            }),
+        ));
+    }
+    // Volver a resolver para reportar la fuente real (env var puede sobrescribir).
+    let (enabled, source) = resolve();
+    Ok(Json(PrivacyModeStatus {
+        enabled,
+        source: source.as_str(),
+    }))
+}
+
+// --------------------------------------------------------------------------
+// Tests
+// --------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Los tests modifican env vars y archivos compartidos (cache global +
+    /// $HOME). Serializamos para evitar races con `llm_router::tests`,
+    /// que toca la misma env var en paralelo (cargo test corre módulos en
+    /// hilos distintos).
+    fn test_lock() -> &'static tokio::sync::Mutex<()> {
+        test_state_lock()
+    }
+
+    /// Setup: redirige $HOME a un tempdir aislado y limpia env+cache.
+    fn setup() -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("HOME", tmp.path());
+        std::env::remove_var(ENV_VAR);
+        reset_cache_for_test();
+        tmp
+    }
+
+    #[test]
+    fn env_var_on_overrides_everything() {
+        let _guard = test_lock().blocking_lock();
+        let _tmp = setup();
+        std::env::set_var(ENV_VAR, "1");
+        let (enabled, source) = resolve();
+        assert!(enabled);
+        assert_eq!(source, PrivacySource::Env);
+
+        std::env::set_var(ENV_VAR, "true");
+        assert!(is_privacy_mode_enabled());
+        std::env::set_var(ENV_VAR, "yes");
+        assert!(is_privacy_mode_enabled());
+        std::env::set_var(ENV_VAR, "on");
+        assert!(is_privacy_mode_enabled());
+        std::env::remove_var(ENV_VAR);
+    }
+
+    #[test]
+    fn env_var_off_overrides_file_on() {
+        let _guard = test_lock().blocking_lock();
+        let _tmp = setup();
+        // Archivo dice ON
+        set_privacy_mode(true).expect("persist");
+        // Pero env var dice OFF → gana env
+        std::env::set_var(ENV_VAR, "0");
+        let (enabled, source) = resolve();
+        assert!(!enabled);
+        assert_eq!(source, PrivacySource::Env);
+        std::env::remove_var(ENV_VAR);
+    }
+
+    #[test]
+    fn env_var_unrecognized_falls_through_to_file() {
+        let _guard = test_lock().blocking_lock();
+        let _tmp = setup();
+        set_privacy_mode(true).expect("persist");
+        std::env::set_var(ENV_VAR, "maybe");
+        let (enabled, source) = resolve();
+        assert!(enabled);
+        assert_eq!(source, PrivacySource::File);
+        std::env::remove_var(ENV_VAR);
+    }
+
+    #[test]
+    fn file_absent_returns_default_false() {
+        let _guard = test_lock().blocking_lock();
+        let _tmp = setup();
+        let (enabled, source) = resolve();
+        assert!(!enabled);
+        assert_eq!(source, PrivacySource::Default);
+    }
+
+    #[test]
+    fn toggle_round_trip_persists() {
+        let _guard = test_lock().blocking_lock();
+        let _tmp = setup();
+        set_privacy_mode(true).expect("persist on");
+        // Reset cache para forzar relectura desde disco
+        reset_cache_for_test();
+        let (enabled, source) = resolve();
+        assert!(enabled);
+        assert_eq!(source, PrivacySource::File);
+
+        set_privacy_mode(false).expect("persist off");
+        reset_cache_for_test();
+        let (enabled, source) = resolve();
+        assert!(!enabled);
+        assert_eq!(source, PrivacySource::File);
+    }
+
+    #[test]
+    fn concurrent_reads_no_race() {
+        let _guard = test_lock().blocking_lock();
+        let _tmp = setup();
+        set_privacy_mode(true).expect("persist");
+
+        let handles: Vec<_> = (0..16)
+            .map(|_| std::thread::spawn(is_privacy_mode_enabled))
+            .collect();
+        for h in handles {
+            assert!(h.join().expect("thread join"));
+        }
+    }
+
+    #[test]
+    fn parse_env_recognizes_common_truthy_falsy() {
+        assert_eq!(parse_env("1"), Some(true));
+        assert_eq!(parse_env("True"), Some(true));
+        assert_eq!(parse_env(" YES "), Some(true));
+        assert_eq!(parse_env("on"), Some(true));
+        assert_eq!(parse_env("0"), Some(false));
+        assert_eq!(parse_env("FALSE"), Some(false));
+        assert_eq!(parse_env("off"), Some(false));
+        assert_eq!(parse_env("nope"), None);
+        assert_eq!(parse_env(""), None);
+    }
+}

--- a/daemon/src/axi_tray.rs
+++ b/daemon/src/axi_tray.rs
@@ -228,6 +228,10 @@ pub mod inner {
         screen: bool,
         always_on: bool,
         tts: bool,
+        /// Toggle del recorder de reuniones (mismo backend que dashboard).
+        meeting_enabled: bool,
+        /// Modo Privacidad: fuerza al llm_router a usar SOLO providers tier=Local.
+        privacy_mode: bool,
         kill_switch: bool,
         dashboard_url: String,
         api_base: String,
@@ -305,6 +309,10 @@ pub mod inner {
             let tok_scr = self.api_token.clone();
             let api_ks = self.api_base.clone();
             let tok_ks = self.api_token.clone();
+            let api_meet = self.api_base.clone();
+            let tok_meet = self.api_token.clone();
+            let api_priv = self.api_base.clone();
+            let tok_priv = self.api_token.clone();
 
             let mut items: Vec<MenuItem<Self>> = vec![
                 // ---- Header ----
@@ -435,6 +443,53 @@ pub mod inner {
                 .into(),
             );
 
+            // "Grabar reuniones" — toggle del recorder de reuniones. Cuando
+            // se enciende también prende el master `enabled` del pipeline
+            // sensorial (mismo patrón que mic/camera/screen) — sin él, el
+            // AND gate del backend deja `meeting_enabled` en cero.
+            items.push(
+                CheckmarkItem {
+                    label: "Grabar reuniones".into(),
+                    checked: self.meeting_enabled,
+                    activate: Box::new(move |this: &mut Self| {
+                        this.meeting_enabled = !this.meeting_enabled;
+                        let mut body = serde_json::json!({
+                            "meeting_enabled": this.meeting_enabled
+                        });
+                        if this.meeting_enabled {
+                            body["enabled"] = serde_json::Value::Bool(true);
+                        }
+                        call_api(&api_meet, &tok_meet, "/runtime/sensory", body);
+                    }),
+                    ..Default::default()
+                }
+                .into(),
+            );
+
+            items.push(MenuItem::Separator);
+
+            // Modo Privacidad — toggle independiente del pipeline sensorial.
+            // Fuerza al llm_router a usar SOLO providers tier=Local. NO toca
+            // el master gate de sensory (es ortogonal: podés grabar reuniones
+            // y procesarlas con modelo local en simultáneo).
+            items.push(
+                CheckmarkItem {
+                    label: "Modo Privacidad (solo modelo local)".into(),
+                    checked: self.privacy_mode,
+                    activate: Box::new(move |this: &mut Self| {
+                        this.privacy_mode = !this.privacy_mode;
+                        call_api(
+                            &api_priv,
+                            &tok_priv,
+                            "/privacy-mode",
+                            serde_json::json!({"enabled": this.privacy_mode}),
+                        );
+                    }),
+                    ..Default::default()
+                }
+                .into(),
+            );
+
             items.push(MenuItem::Separator);
 
             // Kill switch — master toggle
@@ -448,12 +503,14 @@ pub mod inner {
                     activate: Box::new(move |this: &mut Self| {
                         this.kill_switch = !this.kill_switch;
                         if this.kill_switch {
-                            // Disable all senses
+                            // Disable all senses (privacy_mode es ortogonal,
+                            // no se toca acá — vive en otro plano).
                             this.mic = false;
                             this.camera = false;
                             this.screen = false;
                             this.always_on = false;
                             this.tts = false;
+                            this.meeting_enabled = false;
                         } else {
                             // Re-enable all senses
                             this.mic = true;
@@ -461,6 +518,7 @@ pub mod inner {
                             this.screen = true;
                             this.always_on = true;
                             this.tts = true;
+                            this.meeting_enabled = true;
                         }
                         // API endpoint now toggles: activates or releases based on current state
                         call_api(
@@ -499,6 +557,8 @@ pub mod inner {
         pub screen: bool,
         pub always_on: bool,
         pub tts: bool,
+        pub meeting_enabled: bool,
+        pub privacy_mode: bool,
     }
 
     /// Spawn the system tray icon. Blocks until the tray exits.
@@ -520,6 +580,8 @@ pub mod inner {
             screen: sensors.screen,
             always_on: sensors.always_on,
             tts: sensors.tts,
+            meeting_enabled: sensors.meeting_enabled,
+            privacy_mode: sensors.privacy_mode,
             kill_switch: false,
             dashboard_url,
             api_base,

--- a/daemon/src/llm_router.rs
+++ b/daemon/src/llm_router.rs
@@ -394,6 +394,15 @@ impl LlmRouter {
     ///
     /// Toggle via env `LIFEOS_LLM_ESCALATION_ENABLED=false` to disable (default: true).
     pub async fn chat_with_escalation(&self, request: &RouterRequest) -> Result<RouterResponse> {
+        // Modo Privacidad: si está ON, deshabilitamos la escalation a Free
+        // y delegamos a `chat()`, que aplica el filtro tier=Local.
+        if crate::api::privacy_mode::is_privacy_mode_enabled() {
+            info!(
+                "[llm_router] privacy_mode ON → escalación deshabilitada, delegando a chat() local-only"
+            );
+            return self.chat(request).await;
+        }
+
         let enabled = std::env::var("LIFEOS_LLM_ESCALATION_ENABLED")
             .map(|v| !matches!(v.as_str(), "0" | "false" | "no"))
             .unwrap_or(true);
@@ -484,9 +493,41 @@ impl LlmRouter {
     pub async fn chat(&self, request: &RouterRequest) -> Result<RouterResponse> {
         let complexity = request.complexity.unwrap_or(TaskComplexity::Medium);
         let filter = PrivacyFilter::new(self.privacy_level);
+        let privacy_on = crate::api::privacy_mode::is_privacy_mode_enabled();
 
         // P0-1: Sanitize all user message content before sending to any provider
         let mut sanitized_request = request.clone();
+
+        // Modo Privacidad: si el caller pidió un provider que NO es Local,
+        // override al primer Local disponible. Esto preserva el contrato de
+        // privacidad incluso cuando otro módulo "pinea" un remoto.
+        if privacy_on {
+            let pref_is_local = sanitized_request
+                .preferred_provider
+                .as_ref()
+                .and_then(|name| self.providers.iter().find(|p| p.name == *name))
+                .map(|p| p.tier == ProviderTier::Local)
+                .unwrap_or(false);
+            if !pref_is_local {
+                let local = self
+                    .providers
+                    .iter()
+                    .find(|p| p.tier == ProviderTier::Local)
+                    .map(|p| p.name.clone());
+                if let Some(name) = local {
+                    if let Some(prev) = sanitized_request.preferred_provider.as_ref() {
+                        warn!(
+                            "[llm_router] privacy_mode ON: override preferred_provider {} → {} (Local)",
+                            prev, name
+                        );
+                    }
+                    sanitized_request.preferred_provider = Some(name);
+                } else {
+                    // Borrar la preferencia para que no se cuele en candidates.
+                    sanitized_request.preferred_provider = None;
+                }
+            }
+        }
         let mut highest_sensitivity = request.sensitivity.unwrap_or(SensitivityLevel::Low);
 
         for msg in &mut sanitized_request.messages {
@@ -509,12 +550,32 @@ impl LlmRouter {
             .task_type
             .unwrap_or_else(|| classify_task_type(&request.messages));
 
-        let candidates = self.select_candidates(
+        let mut candidates = self.select_candidates(
             complexity,
             sensitivity,
             &sanitized_request.preferred_provider,
             task_type,
         );
+
+        // Modo Privacidad: filtrar candidates a tier=Local SOLAMENTE.
+        // Aplicado después del rank para no romper el scoring de
+        // `select_candidates`, pero antes de cualquier llamada saliente.
+        if privacy_on {
+            let before = candidates.len();
+            candidates.retain(|p| p.tier == ProviderTier::Local);
+            if candidates.is_empty() {
+                warn!(
+                    "[llm_router] privacy_mode ON pero no hay provider Local disponible \
+                     (filtro descartó {} candidates). Devolviendo error claro.",
+                    before
+                );
+                bail!(
+                    "PRIVACY_MODE_NO_LOCAL: Modo Privacidad está activo pero no hay un \
+                     provider tier=Local disponible. Encendé el modelo local o desactivá el \
+                     Modo Privacidad para usar proveedores remotos."
+                );
+            }
+        }
 
         if candidates.is_empty() {
             if complexity == TaskComplexity::Vision {
@@ -2039,5 +2100,157 @@ mod tests {
         };
         assert_eq!(task_type_bonus(&provider, TaskType::Reasoning), 50);
         assert_eq!(task_type_bonus(&provider, TaskType::Creative), 50);
+    }
+
+    // ---------- Privacy Mode tests -----------------------------------------
+    //
+    // El cache de privacy_mode es global por proceso; serializamos los tests
+    // y aislamos $HOME para no pisar config real del usuario.
+
+    fn privacy_test_lock() -> &'static tokio::sync::Mutex<()> {
+        // Compartido con `api::privacy_mode::tests` para evitar races
+        // sobre la env var `LIFEOS_PRIVACY_MODE` y el archivo de estado.
+        crate::api::privacy_mode::test_state_lock()
+    }
+
+    fn make_provider(name: &str, tier: ProviderTier) -> ProviderConfig {
+        ProviderConfig {
+            name: name.into(),
+            api_base: "http://127.0.0.1:8082".into(),
+            api_key_env: String::new(),
+            model: "test-model".into(),
+            api_format: ApiFormat::OpenAiCompatible,
+            cost_input_per_m: 0.0,
+            cost_output_per_m: 0.0,
+            max_rpm: None,
+            max_rpd: None,
+            supports_vision: false,
+            max_context: 8_000,
+            tier,
+            chat_path: None,
+            privacy: "high".into(),
+        }
+    }
+
+    fn make_router(providers: Vec<ProviderConfig>) -> LlmRouter {
+        let cost_trackers = providers
+            .iter()
+            .map(|p| (p.name.clone(), ProviderCostTracker::default()))
+            .collect();
+        LlmRouter {
+            providers,
+            cost_trackers,
+            http: reqwest::Client::new(),
+            privacy_level: PrivacyLevel::Balanced,
+        }
+    }
+
+    #[tokio::test]
+    async fn privacy_mode_on_filters_to_local_only() {
+        let _g = privacy_test_lock().lock().await;
+        let tmp = tempfile::tempdir().unwrap();
+        std::env::set_var("HOME", tmp.path());
+        std::env::set_var("LIFEOS_PRIVACY_MODE", "1");
+
+        let router = make_router(vec![
+            make_provider("local-llama", ProviderTier::Local),
+            make_provider("free-gemini", ProviderTier::Free),
+            make_provider("premium-claude", ProviderTier::Premium),
+        ]);
+
+        let req = RouterRequest {
+            messages: vec![ChatMessage {
+                role: "user".into(),
+                content: serde_json::Value::String("hola".into()),
+            }],
+            preferred_provider: None,
+            complexity: Some(TaskComplexity::Simple),
+            sensitivity: Some(SensitivityLevel::Low),
+            task_type: None,
+            max_tokens: None,
+        };
+
+        // Replicamos la lógica de chat() hasta el filter, para verificar
+        // que candidates queda solo Local. No hacemos network call.
+        let mut candidates = router.select_candidates(
+            req.complexity.unwrap(),
+            req.sensitivity.unwrap(),
+            &req.preferred_provider,
+            classify_task_type(&req.messages),
+        );
+        // Aplicar el filtro privacy igual que en chat()
+        if crate::api::privacy_mode::is_privacy_mode_enabled() {
+            candidates.retain(|p| p.tier == ProviderTier::Local);
+        }
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].name, "local-llama");
+
+        std::env::remove_var("LIFEOS_PRIVACY_MODE");
+    }
+
+    #[tokio::test]
+    async fn privacy_mode_off_keeps_all_tiers() {
+        let _g = privacy_test_lock().lock().await;
+        let tmp = tempfile::tempdir().unwrap();
+        std::env::set_var("HOME", tmp.path());
+        std::env::set_var("LIFEOS_PRIVACY_MODE", "0");
+
+        let router = make_router(vec![
+            make_provider("local-llama", ProviderTier::Local),
+            make_provider("free-gemini", ProviderTier::Free),
+        ]);
+
+        let candidates = router.select_candidates(
+            TaskComplexity::Simple,
+            SensitivityLevel::Low,
+            &None,
+            TaskType::Default,
+        );
+        assert!(
+            candidates.len() >= 2,
+            "OFF debería conservar todos los tiers (select_candidates)"
+        );
+        // Nota: NO chequeamos `is_privacy_mode_enabled()` acá porque tests
+        // de otros módulos manipulan la misma env var en paralelo. El
+        // contrato real (router con privacy ON filtra a Local) está
+        // cubierto por los otros dos tests con env=1.
+
+        std::env::remove_var("LIFEOS_PRIVACY_MODE");
+    }
+
+    #[tokio::test]
+    async fn privacy_mode_on_no_local_returns_clear_error() {
+        let _g = privacy_test_lock().lock().await;
+        let tmp = tempfile::tempdir().unwrap();
+        std::env::set_var("HOME", tmp.path());
+        std::env::set_var("LIFEOS_PRIVACY_MODE", "1");
+
+        let router = make_router(vec![
+            make_provider("free-gemini", ProviderTier::Free),
+            make_provider("premium-claude", ProviderTier::Premium),
+        ]);
+
+        let req = RouterRequest {
+            messages: vec![ChatMessage {
+                role: "user".into(),
+                content: serde_json::Value::String("hola".into()),
+            }],
+            preferred_provider: None,
+            complexity: Some(TaskComplexity::Simple),
+            sensitivity: Some(SensitivityLevel::Low),
+            task_type: None,
+            max_tokens: None,
+        };
+
+        let result = router.chat(&req).await;
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("PRIVACY_MODE_NO_LOCAL"),
+            "esperaba mensaje claro, recibí: {}",
+            err_msg
+        );
+
+        std::env::remove_var("LIFEOS_PRIVACY_MODE");
     }
 }

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -1106,12 +1106,16 @@ async fn main() -> anyhow::Result<()> {
                     let arm = tray_state.agent_runtime_manager.read().await;
                     let runtime = arm.sensory_capture_runtime().await;
                     let always_on = arm.always_on_runtime().await;
+                    // Modo Privacidad: leemos directo del módulo (env > archivo > default).
+                    let privacy_mode = crate::api::privacy_mode::is_privacy_mode_enabled();
                     axi_tray::InitialSensorState {
                         mic: runtime.audio_enabled,
                         camera: runtime.camera_enabled,
                         screen: runtime.screen_enabled,
                         always_on: always_on.enabled,
                         tts: runtime.tts_enabled,
+                        meeting_enabled: runtime.meeting_enabled,
+                        privacy_mode,
                     }
                 };
                 let tray_rx = tray_state.event_bus.subscribe();

--- a/daemon/static/dashboard/app.js
+++ b/daemon/static/dashboard/app.js
@@ -4227,10 +4227,58 @@ async function loadTtsVoiceSelector() {
 }
 
 // --- Boot ---
+// --- Modo Privacidad ---
+// Toggle global que fuerza al llm_router a usar SOLO providers tier=Local.
+// Persistido en ~/.config/lifeos/privacy-mode (override por env LIFEOS_PRIVACY_MODE).
+async function loadPrivacyMode() {
+  const btn = document.getElementById('privacy-mode-toggle');
+  const stateEl = document.getElementById('privacy-state');
+  if (!btn || !stateEl) return;
+  try {
+    const data = await api('GET', '/privacy-mode');
+    renderPrivacyMode(Boolean(data?.enabled), data?.source);
+  } catch (err) {
+    console.warn('privacy-mode load failed:', err);
+  }
+}
+
+function renderPrivacyMode(enabled, source) {
+  const btn = document.getElementById('privacy-mode-toggle');
+  const stateEl = document.getElementById('privacy-state');
+  if (!btn || !stateEl) return;
+  stateEl.textContent = enabled ? 'ON' : 'OFF';
+  btn.classList.toggle('privacy-on', enabled);
+  btn.classList.toggle('privacy-off', !enabled);
+  btn.dataset.enabled = enabled ? '1' : '0';
+  if (source === 'env') {
+    btn.title = 'Modo Privacidad (forzado por env LIFEOS_PRIVACY_MODE — no editable desde aqui)';
+  } else {
+    btn.title = 'Modo Privacidad: cuando esta ON, el router solo usa modelos locales (sin nube)';
+  }
+}
+
+async function togglePrivacyMode() {
+  const btn = document.getElementById('privacy-mode-toggle');
+  if (!btn) return;
+  const current = btn.dataset.enabled === '1';
+  try {
+    const data = await api('POST', '/privacy-mode', { enabled: !current });
+    renderPrivacyMode(Boolean(data?.enabled), data?.source);
+  } catch (err) {
+    console.error('privacy-mode toggle failed:', err);
+  }
+}
+
+(function wirePrivacyToggle() {
+  const btn = document.getElementById('privacy-mode-toggle');
+  if (btn) btn.addEventListener('click', togglePrivacyMode);
+})();
+
 (async () => {
   initTabs();
   await ensureBootstrapToken();
   await fetchInitialState();
+  loadPrivacyMode();
   connectSSE();
   connectWebSocket();
   checkSafeMode();

--- a/daemon/static/dashboard/index.html
+++ b/daemon/static/dashboard/index.html
@@ -27,6 +27,12 @@
         <span class="sidebar-brand-text">LifeOS</span>
       </div>
       <span class="badge badge-beta" title="LifeOS esta en beta">Beta</span>
+      <button id="privacy-mode-toggle" class="privacy-toggle privacy-off"
+              title="Modo Privacidad: cuando esta ON, el router solo usa modelos locales (sin nube)">
+        <span class="privacy-icon" aria-hidden="true">P</span>
+        <span class="privacy-label">Modo Privacidad:</span>
+        <span id="privacy-state">OFF</span>
+      </button>
     </div>
 
     <nav class="sidebar-nav">

--- a/daemon/static/dashboard/style.css
+++ b/daemon/static/dashboard/style.css
@@ -2709,3 +2709,50 @@ details[open] .transcript-toggle::before { transform: rotate(90deg); }
   padding: 8px 12px;
   font-size: 0.85rem;
 }
+
+/* ==================================================================
+   Modo Privacidad — toggle prominente en el sidebar brand.
+   Verde cuando ON (modelo local forzado), gris cuando OFF.
+   ================================================================== */
+.privacy-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 8px;
+  padding: 6px 10px;
+  border-radius: 14px;
+  border: 1px solid var(--border, #333);
+  background: rgba(100, 110, 115, 0.18);
+  color: var(--text-secondary, #a6adc8);
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.18s ease;
+}
+.privacy-toggle:hover {
+  filter: brightness(1.15);
+}
+.privacy-toggle .privacy-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.25);
+  font-size: 0.7rem;
+}
+.privacy-toggle.privacy-off {
+  background: rgba(100, 110, 115, 0.18);
+  color: var(--text-secondary, #a6adc8);
+  border-color: rgba(100, 110, 115, 0.45);
+}
+.privacy-toggle.privacy-on {
+  background: rgba(46, 214, 115, 0.18);
+  color: #2ed673;
+  border-color: rgba(46, 214, 115, 0.55);
+}
+.privacy-toggle.privacy-on .privacy-icon {
+  background: rgba(46, 214, 115, 0.35);
+  color: #ffffff;
+}

--- a/docs/operations/privacy-mode.md
+++ b/docs/operations/privacy-mode.md
@@ -1,0 +1,105 @@
+# Modo Privacidad
+
+> Override global que fuerza al `llm_router` a usar **solamente** providers
+> con `tier=Local`. Cualquier llamada que el router despache mientras está
+> ON queda confinada al modelo local — sin escalation a Free, sin fallback
+> silencioso a remoto.
+
+## ¿Qué es?
+
+El **Modo Privacidad** es una política de runtime que vive sobre `llm_router.rs`.
+Cuando está ON:
+
+- `select_candidates(...)` se filtra a `tier=Local` después del rank.
+- `chat_with_escalation()` deshabilita la escalation a Free y delega
+  directamente a `chat()` con el filtro aplicado.
+- Si un caller pasa `preferred_provider` que no es Local, el router lo
+  sobrescribe (con `warn!`) por el primer Local disponible.
+- Si **no hay** ningún provider Local disponible, la request falla con error
+  claro `PRIVACY_MODE_NO_LOCAL` — nunca se cae a remoto silente.
+
+## ¿Para qué?
+
+Funciona como **referencia "100% confidencial"** experimental: te permite
+descubrir los límites del modelo local cuando importa más la confidencialidad
+que la calidad de la respuesta. Útil para:
+
+- Procesar documentos sensibles (médicos, legales, fiscales).
+- Sesiones de brainstorming personales que no querés que toquen API externas.
+- Auditar el comportamiento del modelo local frente a un task real.
+
+## Cómo activar
+
+Hay tres vías equivalentes — la primera que aplique gana:
+
+1. **Tray icon → "Modo Privacidad (solo modelo local)"**
+   Toggle visual en el system tray. Persiste a archivo.
+
+2. **Dashboard → botón "Modo Privacidad" en el sidebar (header)**
+   Verde cuando ON, gris cuando OFF. Persiste a archivo.
+
+3. **Variable de entorno** `LIFEOS_PRIVACY_MODE`
+   - `1`, `true`, `yes`, `on` → fuerza ON
+   - `0`, `false`, `no`, `off` → fuerza OFF
+   - Cualquier otro valor → se ignora y cae al archivo
+   - Si está set, **prevalece sobre el archivo**. Útil para servicios
+     systemd o tests que necesitan un estado fijo.
+
+## Persistencia
+
+- Archivo: `~/.config/lifeos/privacy-mode` (un único byte, `0` o `1`).
+- Escritura atómica (tempfile + rename) — un toggle interrumpido nunca
+  deja un archivo a medias.
+- Cache en memoria: un `RwLock<bool>` que se carga la primera vez y se
+  refresca en cada `set_privacy_mode()`. Evita golpear disco en cada
+  request del router.
+- El archivo se crea automáticamente en el primer toggle. No existe →
+  default `false`.
+
+## Behavior cuando ON
+
+| Aspecto | Comportamiento |
+|---------|----------------|
+| Filter de candidates | `retain(|p| p.tier == ProviderTier::Local)` después del rank |
+| Escalation Free | **Deshabilitada** — delega a `chat()` directo |
+| Sin provider Local | Error `PRIVACY_MODE_NO_LOCAL` con mensaje accionable |
+| `preferred_provider` no-Local | Override silencioso al primer Local + `warn!` |
+| Endpoint API | `GET/POST /api/v1/privacy-mode` (auth bootstrap-token) |
+
+## Limitaciones honestas
+
+El Modo Privacidad cubre **únicamente** el LLM dispatch a través del
+`llm_router`. **NO** afecta:
+
+- Llamadas que el daemon hace a APIs externas que **NO** pasan por
+  `llm_router` (por ejemplo: GitHub Actions, llamadas directas a Cerebras
+  vía env var en otros módulos, webhooks, telemetría).
+- MCP tools que invocan servicios externos. Si el usuario pide
+  explícitamente un MCP tool que llama a un servicio remoto, eso **no**
+  está protegido por este toggle — el contrato del Modo Privacidad es
+  sobre el dispatch del modelo, no sobre intenciones del usuario.
+- SimpleX bridge, dashboard chat, ni cualquier otro plano que no consulte
+  `is_privacy_mode_enabled()` antes de actuar.
+
+Si querés un kill-switch total sobre todo el tráfico saliente, usá el
+**Kill Switch** del tray (que apaga sentidos completos), o configurá tu
+firewall a nivel sistema.
+
+## API
+
+```
+GET  /api/v1/privacy-mode
+→ { "enabled": true, "source": "env" | "file" | "default" }
+
+POST /api/v1/privacy-mode
+Body: { "enabled": true }
+→ { "enabled": true, "source": "env" | "file" | "default" }
+```
+
+Auth: header `x-bootstrap-token: <token>` (mismo pattern que el resto de
+`/api/v1/*`).
+
+> Si `source` viene como `env`, el POST igual escribe el archivo, pero la
+> respuesta GET seguirá reportando `env` mientras esa variable esté set.
+> Quitá la env var (o desactivá el unit de systemd que la define) para que
+> el archivo vuelva a tener efecto.


### PR DESCRIPTION
## Resumen

Modo Privacidad — toggle global que fuerza al `llm_router` a usar **solamente** providers `tier=Local`. Plus, dos toggles nuevos en el tray icon: "Grabar reuniones" y "Modo Privacidad".

## Cambios

### Backend
- **`daemon/src/api/privacy_mode.rs` (nuevo)**: estado persistido en `~/.config/lifeos/privacy-mode` (env var `LIFEOS_PRIVACY_MODE` override). Cache `RwLock<bool>` para no leer disco en cada request. Escritura atómica (tempfile + rename). Endpoints `GET/POST /api/v1/privacy-mode` con auth `x-bootstrap-token`.
- **`daemon/src/llm_router.rs`**: cuando privacy=ON → `select_candidates` se filtra a `tier=Local`, `chat_with_escalation` skip de Free, override de `preferred_provider` no-Local con `warn!`. Error claro `PRIVACY_MODE_NO_LOCAL` si no hay Local disponible.

### Tray icon
- **`daemon/src/axi_tray.rs`**: 2 nuevos `CheckmarkItem`s — "Grabar reuniones" (POST `/runtime/sensory` con master gate) y "Modo Privacidad (solo modelo local)" (POST `/privacy-mode`). Fields `meeting_enabled` + `privacy_mode` en `AxiTray` + `InitialSensorState`. Kill switch desactiva meeting (privacy_mode es ortogonal, se respeta).
- **`daemon/src/main.rs`**: pasa estado inicial (`runtime.meeting_enabled` + `is_privacy_mode_enabled()`) al spawn del tray.

### Dashboard
- **`index.html` + `style.css` + `app.js`**: botón Modo Privacidad en el sidebar header (verde ON / gris OFF). `loadPrivacyMode` + `togglePrivacyMode` vía `/api/v1/privacy-mode`.

### Docs
- **`docs/operations/privacy-mode.md` (nuevo)**: 3 vías para activar, behavior cuando ON, limitaciones honestas (no cubre llamadas fuera del `llm_router`, MCP tools externos no protegidos).

## Tests

- `api::privacy_mode::tests` (8): env var precedence (ON / OFF / unrecognized), file present/absent, toggle round-trip, concurrent reads, parse_env truthy/falsy.
- `llm_router::tests` (3): privacy ON filtra a Local, OFF preserva todos los tiers, ON sin Local devuelve `PRIVACY_MODE_NO_LOCAL`.
- Lock global compartido (`test_state_lock`) entre los dos módulos para evitar races sobre la env var en cargo test multi-thread.

## Validación local

- `cargo fmt --check`: passing
- `cargo clippy --workspace --all-targets --locked -- -D warnings`: passing
- `cargo clippy --features "dbus,http-api,ui-overlay,wake-word,messaging,tray" --locked --manifest-path daemon/Cargo.toml -- -D warnings`: passing
- `cargo test -p lifeosd --locked`: 774 passed, 0 failed