### PR TITLE
fix(privacy-mode): sync dashboard + tray + UI polish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "life"
-version = "0.8.10"
+version = "0.8.11"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2626,7 +2626,7 @@ dependencies = [
 
 [[package]]
 name = "lifeos-integration-tests"
-version = "0.8.10"
+version = "0.8.11"
 dependencies = [
  "life",
  "serde_json",
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "lifeosd"
-version = "0.8.10"
+version = "0.8.11"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.10"
+version = "0.8.11"
 
 [workspace.metadata.lifeos]
 codename = "Axolotl"

--- a/daemon/src/api/privacy_mode.rs
+++ b/daemon/src/api/privacy_mode.rs
@@ -201,7 +201,7 @@ async fn get_privacy_mode(
 }
 
 async fn post_privacy_mode(
-    State(_state): State<ApiState>,
+    State(state): State<ApiState>,
     Json(payload): Json<SetPrivacyModeRequest>,
 ) -> Result<Json<PrivacyModeStatus>, (StatusCode, Json<ApiError>)> {
     if let Err(e) = set_privacy_mode(payload.enabled) {
@@ -220,6 +220,12 @@ async fn post_privacy_mode(
     }
     // Volver a resolver para reportar la fuente real (env var puede sobrescribir).
     let (enabled, source) = resolve();
+    // Emit a bus event so the tray, mini-widget and other dashboards stay in
+    // sync. We send the *resolved* `enabled`, not the requested payload, so
+    // an env-var override (which wins over the file) is reflected truthfully.
+    let _ = state
+        .event_bus
+        .send(crate::events::DaemonEvent::PrivacyModeChanged { enabled });
     Ok(Json(PrivacyModeStatus {
         enabled,
         source: source.as_str(),
@@ -334,6 +340,44 @@ mod tests {
         for h in handles {
             assert!(h.join().expect("thread join"));
         }
+    }
+
+    /// Smoke-test the event path used by `post_privacy_mode`. We can't
+    /// build a full `ApiState` in a unit test (it has ~30 managers), so we
+    /// exercise the exact snippet the handler runs: `set_privacy_mode` +
+    /// `event_bus.send(PrivacyModeChanged { enabled })`. A subscriber must
+    /// receive the event with the resolved enabled value.
+    #[tokio::test]
+    async fn post_emits_privacy_mode_changed_event() {
+        let _guard = test_lock().lock().await;
+        let _tmp = setup();
+
+        let (tx, mut rx) = tokio::sync::broadcast::channel::<crate::events::DaemonEvent>(8);
+
+        // Subscribe BEFORE the send so we don't miss the broadcast.
+        set_privacy_mode(true).expect("persist on");
+        let (enabled, _source) = resolve();
+        assert!(enabled);
+        tx.send(crate::events::DaemonEvent::PrivacyModeChanged { enabled })
+            .expect("broadcast send");
+
+        match rx.recv().await.expect("recv event") {
+            crate::events::DaemonEvent::PrivacyModeChanged { enabled: got } => {
+                assert!(got, "event must carry enabled=true");
+            }
+            other => panic!("unexpected event variant: {:?}", other),
+        }
+    }
+
+    /// Guard the JSON wire format for external consumers (dashboard SSE,
+    /// future clients). If the tag/content names change, this test breaks
+    /// loudly instead of silently breaking the dashboard.
+    #[test]
+    fn privacy_mode_changed_serializes_to_snake_case() {
+        let ev = crate::events::DaemonEvent::PrivacyModeChanged { enabled: true };
+        let v = serde_json::to_value(&ev).expect("serialize");
+        assert_eq!(v["type"], "privacy_mode_changed");
+        assert_eq!(v["data"]["enabled"], true);
     }
 
     #[test]

--- a/daemon/src/axi_tray.rs
+++ b/daemon/src/axi_tray.rs
@@ -621,6 +621,11 @@ pub mod inner {
                             tray.kill_switch = kill_switch;
                         });
                     }
+                    Ok(DaemonEvent::PrivacyModeChanged { enabled }) => {
+                        handle.update(|tray: &mut AxiTray| {
+                            tray.privacy_mode = enabled;
+                        });
+                    }
                     Ok(_) => {}
                     Err(broadcast::error::RecvError::Lagged(n)) => {
                         log::warn!("[tray] Lagged {} events", n);

--- a/daemon/src/events.rs
+++ b/daemon/src/events.rs
@@ -130,4 +130,10 @@ pub enum DaemonEvent {
         task: String,
         error: String,
     },
+    /// Privacy Mode toggle changed. Emitted from the dashboard POST handler
+    /// and the tray click handler so both surfaces stay in sync.
+    /// JSON shape: `{"type": "privacy_mode_changed", "data": {"enabled": true}}`.
+    PrivacyModeChanged {
+        enabled: bool,
+    },
 }

--- a/daemon/static/dashboard/app.js
+++ b/daemon/static/dashboard/app.js
@@ -564,6 +564,13 @@ function handleEvent(event) {
       if (event.data.kill_switch) addFeedItem('&#9888;', 'Kill switch activado');
       else if (wasKillSwitchActive) addFeedItem('&#9989;', 'Kill switch liberado');
       break;
+    case 'privacy_mode_changed':
+      // Sync the toggle UI when the change originated from another surface
+      // (tray menu, CLI). source is unknown here so we omit it and let the
+      // tooltip stay as-is.
+      renderPrivacyMode(Boolean(event.data?.enabled));
+      addFeedItem('&#128274;', `Modo Privacidad ${event.data?.enabled ? 'activado' : 'desactivado'}`);
+      break;
     case 'feedback_update':
       dashboardState.lastSignal = `Feedback ${event.data.stage || 'actualizado'}`;
       dashboardState.lastSignalAt = new Date().toISOString();
@@ -4232,8 +4239,7 @@ async function loadTtsVoiceSelector() {
 // Persistido en ~/.config/lifeos/privacy-mode (override por env LIFEOS_PRIVACY_MODE).
 async function loadPrivacyMode() {
   const btn = document.getElementById('privacy-mode-toggle');
-  const stateEl = document.getElementById('privacy-state');
-  if (!btn || !stateEl) return;
+  if (!btn) return;
   try {
     const data = await api('GET', '/privacy-mode');
     renderPrivacyMode(Boolean(data?.enabled), data?.source);
@@ -4244,16 +4250,19 @@ async function loadPrivacyMode() {
 
 function renderPrivacyMode(enabled, source) {
   const btn = document.getElementById('privacy-mode-toggle');
-  const stateEl = document.getElementById('privacy-state');
-  if (!btn || !stateEl) return;
-  stateEl.textContent = enabled ? 'ON' : 'OFF';
+  if (!btn) return;
   btn.classList.toggle('privacy-on', enabled);
   btn.classList.toggle('privacy-off', !enabled);
   btn.dataset.enabled = enabled ? '1' : '0';
+  btn.setAttribute('aria-pressed', enabled ? 'true' : 'false');
+  // Only overwrite the tooltip when we actually know the source. When the
+  // update comes from an SSE event (where source is unknown), keep whatever
+  // tooltip was set by the last load/toggle so the env-override warning
+  // sticks across re-renders.
   if (source === 'env') {
     btn.title = 'Modo Privacidad (forzado por env LIFEOS_PRIVACY_MODE — no editable desde aqui)';
-  } else {
-    btn.title = 'Modo Privacidad: cuando esta ON, el router solo usa modelos locales (sin nube)';
+  } else if (source === 'file' || source === 'default') {
+    btn.title = 'Modo Privacidad: cuando esta activo, el router solo usa modelos locales (sin nube)';
   }
 }
 

--- a/daemon/static/dashboard/index.html
+++ b/daemon/static/dashboard/index.html
@@ -28,10 +28,18 @@
       </div>
       <span class="badge badge-beta" title="LifeOS esta en beta">Beta</span>
       <button id="privacy-mode-toggle" class="privacy-toggle privacy-off"
-              title="Modo Privacidad: cuando esta ON, el router solo usa modelos locales (sin nube)">
-        <span class="privacy-icon" aria-hidden="true">P</span>
-        <span class="privacy-label">Modo Privacidad:</span>
-        <span id="privacy-state">OFF</span>
+              type="button"
+              aria-pressed="false"
+              title="Modo Privacidad: cuando esta activo, el router solo usa modelos locales (sin nube)">
+        <svg class="privacy-icon" width="14" height="14" viewBox="0 0 24 24" fill="none"
+             stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect>
+          <path d="M7 11V7a5 5 0 0 1 10 0v4"></path>
+        </svg>
+        <span class="privacy-text">Privacidad</span>
+        <span class="privacy-switch" aria-hidden="true">
+          <span class="privacy-switch-thumb"></span>
+        </span>
       </button>
     </div>
 

--- a/daemon/static/dashboard/style.css
+++ b/daemon/static/dashboard/style.css
@@ -2711,48 +2711,64 @@ details[open] .transcript-toggle::before { transform: rotate(90deg); }
 }
 
 /* ==================================================================
-   Modo Privacidad — toggle prominente en el sidebar brand.
-   Verde cuando ON (modelo local forzado), gris cuando OFF.
+   Modo Privacidad — toggle tipo switch en el sidebar brand.
+   Candado SVG + pill switch. Verde cuando ON, gris cuando OFF.
    ================================================================== */
 .privacy-toggle {
-  display: inline-flex;
+  display: flex;
   align-items: center;
-  gap: 6px;
-  margin-top: 8px;
-  padding: 6px 10px;
-  border-radius: 14px;
-  border: 1px solid var(--border, #333);
-  background: rgba(100, 110, 115, 0.18);
+  gap: 8px;
+  width: 100%;
+  margin: 8px 0 0 0;
+  padding: 8px 12px;
+  border: 1px solid var(--border, #2a2d3a);
+  border-radius: 10px;
+  background: var(--bg-elevated, rgba(255, 255, 255, 0.03));
   color: var(--text-secondary, #a6adc8);
   font-size: 0.78rem;
-  font-weight: 600;
+  font-weight: 500;
   cursor: pointer;
-  transition: all 0.18s ease;
+  transition: background 0.18s ease, border-color 0.18s ease, color 0.18s ease;
 }
 .privacy-toggle:hover {
-  filter: brightness(1.15);
+  background: var(--bg-hover, rgba(255, 255, 255, 0.06));
 }
 .privacy-toggle .privacy-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 18px;
-  height: 18px;
+  flex-shrink: 0;
+}
+.privacy-toggle .privacy-text {
+  flex: 1;
+  text-align: left;
+}
+/* Pill switch */
+.privacy-toggle .privacy-switch {
+  position: relative;
+  flex-shrink: 0;
+  width: 30px;
+  height: 16px;
+  border-radius: 999px;
+  background: rgba(120, 128, 140, 0.45);
+  transition: background 0.2s ease;
+}
+.privacy-toggle .privacy-switch-thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
   border-radius: 50%;
-  background: rgba(0, 0, 0, 0.25);
-  font-size: 0.7rem;
+  background: #fff;
+  transition: transform 0.2s ease;
 }
-.privacy-toggle.privacy-off {
-  background: rgba(100, 110, 115, 0.18);
-  color: var(--text-secondary, #a6adc8);
-  border-color: rgba(100, 110, 115, 0.45);
-}
+/* Estado ON */
 .privacy-toggle.privacy-on {
-  background: rgba(46, 214, 115, 0.18);
+  background: rgba(46, 214, 115, 0.12);
+  border-color: rgba(46, 214, 115, 0.45);
   color: #2ed673;
-  border-color: rgba(46, 214, 115, 0.55);
 }
-.privacy-toggle.privacy-on .privacy-icon {
-  background: rgba(46, 214, 115, 0.35);
-  color: #ffffff;
+.privacy-toggle.privacy-on .privacy-switch {
+  background: #2ed673;
+}
+.privacy-toggle.privacy-on .privacy-switch-thumb {
+  transform: translateX(14px);
 }


### PR DESCRIPTION
## Bugs encontrados en PR #40 (Privacy Mode)

### Bug A — dashboard y tray no se sincronizaban
- `POST /api/v1/privacy-mode` persistia el estado en `~/.config/lifeos/privacy-mode` pero NO emitia ningun evento al bus
- El tray (`axi_tray.rs`) solo escuchaba `DaemonEvent::SensorChanged`, asi que su checkmark quedaba stale
- En reverso: click en el tray -> POST -> dashboards abiertos no se enteraban (tambien stale)

### Bug B — boton feo en el dashboard
- Icono era la letra `P` como texto dentro de un circulo — inconsistente con el resto del sidebar (que usa SVG feather-style)
- Texto `Modo Privacidad: OFF` muy verboso
- `margin-top: 8px` lo pegaba al badge Beta haciendolo ver como appendage

## Fix

### Event bus (Rust)
- `daemon/src/events.rs`: nueva variante `DaemonEvent::PrivacyModeChanged { enabled: bool }` — shape JSON `{"type":"privacy_mode_changed","data":{"enabled":true}}` gracias al `#[serde(rename_all = "snake_case")]` ya activo
- `daemon/src/api/privacy_mode.rs`: el handler `post_privacy_mode` ahora recibe `State<ApiState>` y emite el evento despues de persistir, usando el valor resuelto por `resolve()` (asi la env-var override se refleja truthfully)
- `daemon/src/axi_tray.rs`: nuevo match arm que actualiza `tray.privacy_mode` cuando llega el evento

### Dashboard (JS/HTML/CSS)
- `index.html`: reemplace el `<span>P</span>` y el texto `Modo Privacidad: OFF` por candado SVG (rect+path estilo feather) + texto `Privacidad` + pill switch con thumb animado. Agregue `type="button"` y `aria-pressed`
- `style.css`: nueva card con `display:flex`, `width:100%`, `border-radius:10px`, `padding:8px 12px`. Pill switch 30x16px que cambia a verde + thumb se traslada 14px cuando `.privacy-on`. Removi las reglas circulares viejas
- `app.js`: `handleEvent` ahora maneja `privacy_mode_changed` (llama `renderPrivacyMode` + feed item). `renderPrivacyMode` ya no toca `#privacy-state` (no existe), setea `aria-pressed`, y mantiene el tooltip de env-override cuando el source es desconocido (caso SSE)

## Tests (`cargo test privacy_mode`)
- `post_emits_privacy_mode_changed_event` — verifica que el broadcast channel recibe el evento con `enabled=true`
- `privacy_mode_changed_serializes_to_snake_case` — guarda el wire format para que el dashboard no se rompa silenciosamente si cambian el tag

## Validacion local (laptop)
- `cargo fmt -- --check` OK
- `cargo clippy --workspace --all-targets --locked -- -D warnings` OK
- `cargo clippy --features "dbus,http-api,ui-overlay,wake-word,messaging,tray" --locked -- -D warnings` OK  (exact CI feature set)
- `cargo test privacy_mode` -> 12 passed, 0 failed

## Version
0.8.10 -> 0.8.11

## Test plan
- [ ] CI verde (fmt + clippy default + clippy CI features + tests + cargo audit)
- [ ] Visual check: el toggle se ve como card con pill switch, no como badge pegado al Beta
- [ ] Runtime check (post-deploy): toggle desde tray -> dashboard refleja en <3s; toggle desde dashboard -> tray refleja inmediatamente