### PR TITLE
feat(memory): Sprint 1 — Axi never forgets + safe LLM CRUD

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "life"
-version = "0.8.12"
+version = "0.8.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2626,7 +2626,7 @@ dependencies = [
 
 [[package]]
 name = "lifeos-integration-tests"
-version = "0.8.12"
+version = "0.8.13"
 dependencies = [
  "life",
  "serde_json",
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "lifeosd"
-version = "0.8.12"
+version = "0.8.13"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.12"
+version = "0.8.13"
 
 [workspace.metadata.lifeos]
 codename = "Axolotl"

--- a/daemon/src/api/mod.rs
+++ b/daemon/src/api/mod.rs
@@ -12604,7 +12604,11 @@ async fn delete_user_forget(
     let mut deleted_count = 0u64;
     for entry in &entries {
         // Right-to-be-forgotten requires PHYSICAL erasure, not soft archive.
-        if mgr.hard_delete_entry(&entry.entry_id).await.unwrap_or(false) {
+        if mgr
+            .hard_delete_entry(&entry.entry_id)
+            .await
+            .unwrap_or(false)
+        {
             deleted_count += 1;
         }
     }

--- a/daemon/src/api/mod.rs
+++ b/daemon/src/api/mod.rs
@@ -9934,9 +9934,22 @@ async fn search_memory_entries(
 async fn delete_memory_entry(
     State(state): State<ApiState>,
     Path(entry_id): Path<String>,
+    axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ApiError>)> {
+    // Default = soft (archive). `?hard=true` opts into the irreversible
+    // physical delete that also cleans up KG triples and memory_links.
+    let hard = params
+        .get("hard")
+        .map(|v| matches!(v.as_str(), "1" | "true" | "yes"))
+        .unwrap_or(false);
+
     let mgr = state.memory_plane_manager.read().await;
-    let deleted = mgr.delete_entry(&entry_id).await.map_err(|e| {
+    let result = if hard {
+        mgr.hard_delete_entry(&entry_id).await
+    } else {
+        mgr.delete_entry(&entry_id).await
+    };
+    let deleted = result.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ApiError {
@@ -9950,6 +9963,7 @@ async fn delete_memory_entry(
     Ok(Json(serde_json::json!({
         "status": "ok",
         "deleted": deleted,
+        "hard": hard,
         "entry_id": entry_id,
     })))
 }
@@ -12589,7 +12603,8 @@ async fn delete_user_forget(
     let entries = mgr.list_entries(500, None, None).await.unwrap_or_default();
     let mut deleted_count = 0u64;
     for entry in &entries {
-        if mgr.delete_entry(&entry.entry_id).await.unwrap_or(false) {
+        // Right-to-be-forgotten requires PHYSICAL erasure, not soft archive.
+        if mgr.hard_delete_entry(&entry.entry_id).await.unwrap_or(false) {
             deleted_count += 1;
         }
     }

--- a/daemon/src/axi_tools.rs
+++ b/daemon/src/axi_tools.rs
@@ -1025,6 +1025,21 @@ REGLAS FIRMES:
     args: {"question": "Es seguro hacer ayuno intermitente?", "topic": "health"}
     topic (opcional): health, mental_health, nutrition, exercise, finance, relationships, spiritual, general
 
+86. **memory_delete** — Borra una memoria por su entry_id. Por defecto archiva (recuperable con recall_archived o memory_unarchive). Para borrado permanente pasa hard=true junto con confirm=true; PRIMERO pregunta al usuario y solo entonces reenvia con confirm=true. Limite global: 10 ops destructivas/hora.
+    args: {"entry_id": "mem-...", "hard": false, "confirm": false}
+
+87. **memory_update** — Edita una memoria existente: cambia contenido, importancia (0-100) y/o tags. Si cambias contenido, el embedding se regenera automaticamente.
+    args: {"entry_id": "mem-...", "content": "texto nuevo", "importance": 80, "tags": ["tag1","tag2"]}
+
+88. **memory_relate** — Vincula dos memorias con una relacion semantica (ej: "causa", "supersedes", "refers_to"). Usalo cuando descubras que dos memorias estan conectadas.
+    args: {"from_entry_id": "mem-A", "to_entry_id": "mem-B", "relation": "causa"}
+
+89. **knowledge_delete** — Borra un triple del knowledge graph por (subject, predicate, object) exactos. Usalo cuando un hecho del KG sea incorrecto u obsoleto. Requiere confirm=true (operacion irreversible). Pregunta primero al usuario.
+    args: {"subject": "Hector", "predicate": "vive_en", "object": "CDMX", "confirm": false}
+
+90. **memory_unarchive** — Restaura una memoria archivada (deshace memory_delete soft). Sin confirm — es restaurativa, no destructiva.
+    args: {"entry_id": "mem-..."}
+
 ## Reglas
 
 - Puedes usar MULTIPLES herramientas en una respuesta.
@@ -1089,7 +1104,13 @@ REGLAS FIRMES:
     pub struct ConversationHistory {
         chats: RwLock<HashMap<i64, ConversationEntry>>,
         persist_path: std::path::PathBuf,
+        /// Throttle for `drain_stale_and_persist`: at most one scan per
+        /// `DRAIN_STALE_THROTTLE_SECS` to avoid a write-lock storm on
+        /// every Axi turn.
+        last_drain_at: tokio::sync::Mutex<Option<std::time::Instant>>,
     }
+
+    const DRAIN_STALE_THROTTLE_SECS: u64 = 60;
 
     impl ConversationHistory {
         pub fn new() -> Self {
@@ -1123,6 +1144,7 @@ REGLAS FIRMES:
             Self {
                 chats: RwLock::new(chats),
                 persist_path,
+                last_drain_at: tokio::sync::Mutex::new(None),
             }
         }
 
@@ -1315,6 +1337,85 @@ REGLAS FIRMES:
                 if let Some(entry) = chats.get_mut(&chat_id) {
                     entry.compacted_summary = Some(resp.text);
                     info!("[history] LLM-compacted summary for chat {}", chat_id);
+                }
+                self.persist_locked(&chats);
+            }
+        }
+
+        /// PERSIST-FIRST, REMOVE-SECOND drain of stale chats.
+        ///
+        /// For every chat older than `HISTORY_TTL_SECS` we first call
+        /// `save_session_summary` (which writes to memory_plane). ONLY
+        /// after that returns do we remove the entry from the in-memory
+        /// map and rewrite the on-disk JSON. If persistence fails for a
+        /// given chat we keep it in RAM and try again next tick — this
+        /// is the SIGTERM-safety contract: data never disappears unless
+        /// it has already been saved.
+        ///
+        /// Throttled to once per `DRAIN_STALE_THROTTLE_SECS` to avoid a
+        /// write-lock storm on hot chats.
+        pub async fn drain_stale_and_persist(&self, ctx: &ToolContext) {
+            // Throttle: skip if we ran recently.
+            {
+                let mut last = self.last_drain_at.lock().await;
+                let now_inst = std::time::Instant::now();
+                if let Some(prev) = *last {
+                    if now_inst.duration_since(prev).as_secs() < DRAIN_STALE_THROTTLE_SECS {
+                        return;
+                    }
+                }
+                *last = Some(now_inst);
+            }
+
+            // Phase 1 — READ-only scan to identify candidates.
+            let candidates: Vec<(i64, Vec<ChatMessage>)> = {
+                let chats = self.chats.read().await;
+                let now = chrono::Utc::now();
+                chats
+                    .iter()
+                    .filter(|(_, v)| {
+                        now.signed_duration_since(v.last_active).num_seconds()
+                            >= HISTORY_TTL_SECS
+                    })
+                    .map(|(k, v)| {
+                        let mut msgs = Vec::new();
+                        if let Some(first) = v.first_message.clone() {
+                            msgs.push(first);
+                        }
+                        msgs.extend(v.messages.iter().cloned());
+                        (*k, msgs)
+                    })
+                    .collect()
+            };
+
+            if candidates.is_empty() {
+                return;
+            }
+
+            // Phase 2 — persist each candidate SYNCHRONOUSLY, await result.
+            // ONLY entries whose persist returns true are queued for
+            // removal. If memory_plane is down or the write failed, the
+            // chat stays in RAM and we'll retry next tick — no data loss.
+            let mut persisted: Vec<i64> = Vec::with_capacity(candidates.len());
+            for (cid, msgs) in &candidates {
+                if save_session_summary(ctx, *cid, msgs).await {
+                    persisted.push(*cid);
+                } else {
+                    warn!(
+                        "[history] drain_stale: persist failed for chat {} — keeping in RAM for retry",
+                        cid
+                    );
+                }
+            }
+            if persisted.is_empty() {
+                return;
+            }
+
+            // Phase 3 — remove ONLY the entries we successfully persisted.
+            {
+                let mut chats = self.chats.write().await;
+                for id in &persisted {
+                    chats.remove(id);
                 }
                 self.persist_locked(&chats);
             }
@@ -2043,6 +2144,11 @@ REGLAS FIRMES:
             "remember" => execute_remember(&call.args, ctx).await,
             "recall" => execute_recall(&call.args, ctx).await,
             "recall_archived" => execute_recall_archived(&call.args, ctx).await,
+            "memory_delete" => execute_memory_delete(&call.args, ctx).await,
+            "memory_update" => execute_memory_update(&call.args, ctx).await,
+            "memory_relate" => execute_memory_relate(&call.args, ctx).await,
+            "memory_unarchive" => execute_memory_unarchive(&call.args, ctx).await,
+            "knowledge_delete" => execute_knowledge_delete(&call.args, ctx).await,
             // BI.2 — Salud médica estructurada
             "health_fact_add" => execute_health_fact_add(&call.args, ctx).await,
             "health_fact_list" => execute_health_fact_list(&call.args, ctx).await,
@@ -2333,6 +2439,12 @@ REGLAS FIRMES:
         force_sensitivity: Option<crate::privacy_filter::SensitivityLevel>,
         session_key_override: Option<SessionKey>,
     ) -> (String, Option<String>) {
+        // No-forget: persist-then-prune any chats that aged past the 48 h
+        // history TTL. PERSIST FIRST so a SIGTERM between drain and write
+        // never destroys user context. Throttled to once per minute inside
+        // `drain_stale_and_persist` so it doesn't write-lock on every turn.
+        ctx.history.drain_stale_and_persist(ctx).await;
+
         // AQ.3 — Detect implicit preference feedback and update user model
         if let Some(ref um_arc) = ctx.user_model {
             if let Some((key, value)) = crate::user_model::detect_preference_feedback(user_text) {
@@ -3490,6 +3602,357 @@ REGLAS FIRMES:
                 }
             }
             Err(e) => Ok(format!("Error buscando en el archivo: {}", e)),
+        }
+    }
+
+    // ========================================================================
+    // Memory CRUD tools — Axi can edit / delete / relate / forget on demand.
+    // Sprint 1 (feat/axi-memory-no-forget): user goal is "Axi never forgets,
+    // and can edit anything from chat". These four tools expose the
+    // memory_plane CRUD surface that previously only existed via REST.
+    //
+    // Destructive guard (FIX 3 of JD review):
+    //  - `LIFEOS_AXI_REQUIRE_CONFIRM_DESTRUCTIVE` (default true) requires
+    //    `confirm: true` on every destructive call.
+    //  - Every destructive call is logged to
+    //    `~/.local/share/lifeos/destructive_actions.log` (mode 0600,
+    //    append-only, best-effort).
+    //  - Rate-limited to 10 destructive ops per rolling hour across all
+    //    destructive tools, tracked in `DESTRUCTIVE_RATE_LIMITER`.
+    // ========================================================================
+
+    /// Returns true if confirm-mode is OFF via env (user opt-out).
+    fn destructive_confirm_disabled() -> bool {
+        match std::env::var("LIFEOS_AXI_REQUIRE_CONFIRM_DESTRUCTIVE") {
+            Ok(v) => matches!(v.as_str(), "0" | "false" | "no"),
+            Err(_) => false,
+        }
+    }
+
+    /// Rolling 1-hour window rate limiter for destructive tool calls.
+    /// Single global instance — every destructive tool consults it before
+    /// touching state. Limit applies ACROSS tools, not per tool.
+    struct DestructiveRateLimiter {
+        max_per_hour: usize,
+        events: std::sync::Mutex<std::collections::VecDeque<std::time::Instant>>,
+    }
+
+    impl DestructiveRateLimiter {
+        const fn new(max_per_hour: usize) -> Self {
+            Self {
+                max_per_hour,
+                events: std::sync::Mutex::new(std::collections::VecDeque::new()),
+            }
+        }
+
+        /// Try to record a new destructive event. Returns Ok on success,
+        /// Err with seconds-until-window-frees if exceeded.
+        fn try_record(&self) -> Result<(), u64> {
+            let now = std::time::Instant::now();
+            let one_hour = std::time::Duration::from_secs(3600);
+            let mut q = self.events.lock().expect("rate limiter mutex");
+            while let Some(front) = q.front() {
+                if now.duration_since(*front) > one_hour {
+                    q.pop_front();
+                } else {
+                    break;
+                }
+            }
+            if q.len() >= self.max_per_hour {
+                let oldest = *q.front().expect("non-empty");
+                let wait = one_hour
+                    .saturating_sub(now.duration_since(oldest))
+                    .as_secs();
+                return Err(wait.max(1));
+            }
+            q.push_back(now);
+            Ok(())
+        }
+    }
+
+    static DESTRUCTIVE_RATE_LIMITER: DestructiveRateLimiter =
+        DestructiveRateLimiter::new(10);
+
+    /// Append a JSON line describing a destructive action. Best-effort: any
+    /// I/O error is swallowed and a `warn!` emitted. Mode 0600 on first
+    /// create; subsequent appends inherit the existing permission.
+    fn audit_destructive(tool: &str, args: &serde_json::Value, result: &str) {
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/home/lifeos".into());
+        let dir = std::path::PathBuf::from(format!("{home}/.local/share/lifeos"));
+        if let Err(e) = std::fs::create_dir_all(&dir) {
+            warn!("[audit] cannot create audit dir: {}", e);
+            return;
+        }
+        let path = dir.join("destructive_actions.log");
+        let line = serde_json::json!({
+            "ts": chrono::Utc::now().to_rfc3339(),
+            "tool": tool,
+            "args": args,
+            "result": result,
+        });
+        let mut serialized = match serde_json::to_string(&line) {
+            Ok(s) => s,
+            Err(e) => {
+                warn!("[audit] serialize failed: {}", e);
+                return;
+            }
+        };
+        serialized.push('\n');
+
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut opts = std::fs::OpenOptions::new();
+        opts.create(true).append(true).mode(0o600);
+        match opts.open(&path) {
+            Ok(mut f) => {
+                if let Err(e) = f.write_all(serialized.as_bytes()) {
+                    warn!("[audit] write failed: {}", e);
+                }
+            }
+            Err(e) => warn!("[audit] open {}: {}", path.display(), e),
+        }
+    }
+
+    /// Pre-flight check used by every destructive tool. On error returns a
+    /// `Result::Ok(message)` because tool functions surface the message back
+    /// to the LLM rather than aborting the agent loop.
+    fn destructive_preflight(
+        tool: &str,
+        args: &serde_json::Value,
+    ) -> std::result::Result<(), String> {
+        // Confirmation gate.
+        if !destructive_confirm_disabled() {
+            let confirmed = args
+                .get("confirm")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            if !confirmed {
+                return Err(format!(
+                    "Operacion destructiva ({tool}) requiere confirmacion explicita del usuario. \
+                     Pregunta al usuario antes de continuar y luego reenviame la llamada con \"confirm\": true."
+                ));
+            }
+        }
+        // Rate-limit gate.
+        if let Err(wait_secs) = DESTRUCTIVE_RATE_LIMITER.try_record() {
+            return Err(format!(
+                "Limite de operaciones destructivas alcanzado (10/hora). \
+                 Espera {wait_secs} segundos o pide al usuario que reintente luego."
+            ));
+        }
+        Ok(())
+    }
+
+    async fn execute_memory_delete(
+        args: &serde_json::Value,
+        ctx: &ToolContext,
+    ) -> Result<String> {
+        let entry_id = args["entry_id"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("Falta parametro 'entry_id'"))?;
+        let hard = args["hard"].as_bool().unwrap_or(false);
+
+        // Hard delete is irreversible: confirm + rate-limit + audit.
+        // Soft delete is recoverable via recall_archived, so we let it
+        // through unguarded (it's basically an archive, not destruction).
+        if hard {
+            if let Err(msg) = destructive_preflight("memory_delete", args) {
+                return Ok(msg);
+            }
+        }
+
+        let memory = match &ctx.memory {
+            Some(m) => m,
+            None => return Ok("La memoria persistente no esta disponible.".into()),
+        };
+        let mem = memory.read().await;
+
+        let result = if hard {
+            mem.hard_delete_entry(entry_id).await
+        } else {
+            mem.delete_entry(entry_id).await
+        };
+
+        let response = match result {
+            Ok(true) if hard => format!(
+                "Borre permanentemente la memoria {} (y sus links / KG triples).",
+                entry_id
+            ),
+            Ok(true) => format!(
+                "Archive la memoria {} (sigue recuperable con recall_archived).",
+                entry_id
+            ),
+            Ok(false) => format!("No encontre la memoria {}.", entry_id),
+            Err(e) => format!("Error borrando memoria: {}", e),
+        };
+        if hard {
+            audit_destructive("memory_delete", args, &response);
+        }
+        Ok(response)
+    }
+
+    async fn execute_memory_update(
+        args: &serde_json::Value,
+        ctx: &ToolContext,
+    ) -> Result<String> {
+        let entry_id = args["entry_id"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("Falta parametro 'entry_id'"))?;
+        let new_content = args["content"].as_str();
+        let new_importance = args["importance"].as_i64().map(|v| v.clamp(0, 100) as u8);
+        let new_tags = args["tags"].as_array().map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .collect::<Vec<String>>()
+        });
+
+        if new_content.is_none() && new_importance.is_none() && new_tags.is_none() {
+            return Ok(
+                "Necesito al menos uno de: 'content', 'importance', o 'tags' para actualizar."
+                    .into(),
+            );
+        }
+
+        let memory = match &ctx.memory {
+            Some(m) => m,
+            None => return Ok("La memoria persistente no esta disponible.".into()),
+        };
+        let mem = memory.read().await;
+
+        match mem
+            .update_entry(
+                entry_id,
+                new_content,
+                new_importance,
+                new_tags.as_deref(),
+            )
+            .await
+        {
+            Ok(true) => Ok(format!("Actualice la memoria {}.", entry_id)),
+            Ok(false) => Ok(format!("No encontre la memoria {}.", entry_id)),
+            Err(e) => Ok(format!("Error actualizando memoria: {}", e)),
+        }
+    }
+
+    async fn execute_memory_relate(
+        args: &serde_json::Value,
+        ctx: &ToolContext,
+    ) -> Result<String> {
+        let from = args["from_entry_id"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("Falta parametro 'from_entry_id'"))?;
+        let to = args["to_entry_id"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("Falta parametro 'to_entry_id'"))?;
+        let relation = args["relation"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("Falta parametro 'relation'"))?;
+
+        // Reject self-links: useless and pollutes get_linked output.
+        if from == to {
+            return Ok(format!(
+                "No puedo vincular {} consigo mismo. Indica dos entry_ids distintos.",
+                from
+            ));
+        }
+
+        let memory = match &ctx.memory {
+            Some(m) => m,
+            None => return Ok("La memoria persistente no esta disponible.".into()),
+        };
+        let mem = memory.read().await;
+
+        // Verify BOTH entries exist before linking — link_entries uses
+        // INSERT OR IGNORE on memory_links, which has no FK back to
+        // memory_entries, so phantom IDs would silently succeed.
+        match mem.entry_exists(from).await {
+            Ok(false) => {
+                return Ok(format!("No encontre la memoria origen {}.", from));
+            }
+            Err(e) => return Ok(format!("Error verificando memoria origen: {}", e)),
+            Ok(true) => {}
+        }
+        match mem.entry_exists(to).await {
+            Ok(false) => {
+                return Ok(format!("No encontre la memoria destino {}.", to));
+            }
+            Err(e) => return Ok(format!("Error verificando memoria destino: {}", e)),
+            Ok(true) => {}
+        }
+
+        match mem.link_entries(from, to, relation).await {
+            Ok(()) => Ok(format!(
+                "Vincule {} -[{}]-> {}.",
+                from, relation, to
+            )),
+            Err(e) => Ok(format!("Error creando vinculo: {}", e)),
+        }
+    }
+
+    async fn execute_knowledge_delete(
+        args: &serde_json::Value,
+        ctx: &ToolContext,
+    ) -> Result<String> {
+        let subject = args["subject"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("Falta parametro 'subject'"))?;
+        let predicate = args["predicate"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("Falta parametro 'predicate'"))?;
+        let object = args["object"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("Falta parametro 'object'"))?;
+
+        if let Err(msg) = destructive_preflight("knowledge_delete", args) {
+            return Ok(msg);
+        }
+
+        let memory = match &ctx.memory {
+            Some(m) => m,
+            None => return Ok("La memoria persistente no esta disponible.".into()),
+        };
+        let mem = memory.read().await;
+
+        let response = match mem.delete_kg_triple(subject, predicate, object).await {
+            Ok(true) => format!(
+                "Borre el triple ({}, {}, {}) del knowledge graph.",
+                subject, predicate, object
+            ),
+            Ok(false) => format!(
+                "No encontre el triple ({}, {}, {}).",
+                subject, predicate, object
+            ),
+            Err(e) => format!("Error borrando triple: {}", e),
+        };
+        audit_destructive("knowledge_delete", args, &response);
+        Ok(response)
+    }
+
+    /// Restore a soft-deleted memory. Restorative (not destructive) so it
+    /// is intentionally NOT subject to the destructive confirm/audit/rate
+    /// limit gates — undoing a mistake should never require ceremony.
+    async fn execute_memory_unarchive(
+        args: &serde_json::Value,
+        ctx: &ToolContext,
+    ) -> Result<String> {
+        let entry_id = args["entry_id"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("Falta parametro 'entry_id'"))?;
+        let memory = match &ctx.memory {
+            Some(m) => m,
+            None => return Ok("La memoria persistente no esta disponible.".into()),
+        };
+        let mem = memory.read().await;
+        match mem.unarchive_entry(entry_id).await {
+            Ok(true) => Ok(format!(
+                "Restaure la memoria {} (vuelve a aparecer en busquedas activas).",
+                entry_id
+            )),
+            Ok(false) => Ok(format!(
+                "No habia nada que restaurar para {} (no existe o ya estaba activa).",
+                entry_id
+            )),
+            Err(e) => Ok(format!("Error restaurando memoria: {}", e)),
         }
     }
 
@@ -9691,11 +10154,22 @@ REGLAS FIRMES:
     // Session summary — saves conversation context to persistent memory
     // -----------------------------------------------------------------------
 
-    // Auto-save a session summary when conversation is cleared or expires
-    #[allow(dead_code)]
-    pub async fn save_session_summary(ctx: &ToolContext, chat_id: i64, messages: &[ChatMessage]) {
+    // Auto-save a session summary when conversation is cleared or expires.
+    // Called by the TTL-prune path (drain_stale_and_persist) and by `/clear`
+    // so the 48 h ConversationHistory window never silently drops user
+    // context — everything goes to memory_plane first.
+    //
+    // Returns `true` if the summary was successfully written to memory_plane
+    // (or if there was nothing to save), `false` if memory_plane is missing
+    // or the write failed. The drain path uses this to decide whether the
+    // chat is safe to remove from RAM.
+    pub async fn save_session_summary(
+        ctx: &ToolContext,
+        chat_id: i64,
+        messages: &[ChatMessage],
+    ) -> bool {
         if messages.is_empty() {
-            return;
+            return true;
         }
 
         // Build a summary prompt from conversation messages
@@ -9743,18 +10217,36 @@ REGLAS FIRMES:
         };
         drop(router);
 
-        // Save to persistent memory
-        if let Some(memory) = &ctx.memory {
-            let mem = memory.read().await;
-            let tags = vec!["session_summary".to_string()];
-            let content = format!(
-                "[decision] Session summary (chat {})\ntopic: session:chat-{}\n{}",
-                chat_id, chat_id, summary_text
+        // Save to persistent memory. Return whether the write succeeded so
+        // the drain-stale path can decide whether the chat is safe to drop.
+        let Some(memory) = &ctx.memory else {
+            warn!(
+                "[session_summary] memory_plane unavailable; chat {} NOT persisted",
+                chat_id
             );
-            mem.add_entry("decision", "user", &tags, Some("session"), 60, &content)
-                .await
-                .ok();
-            info!("[engram] Session summary saved for chat {}", chat_id);
+            return false;
+        };
+        let mem = memory.read().await;
+        let tags = vec!["session_summary".to_string()];
+        let content = format!(
+            "[decision] Session summary (chat {})\ntopic: session:chat-{}\n{}",
+            chat_id, chat_id, summary_text
+        );
+        match mem
+            .add_entry("decision", "user", &tags, Some("session"), 60, &content)
+            .await
+        {
+            Ok(_) => {
+                info!("[engram] Session summary saved for chat {}", chat_id);
+                true
+            }
+            Err(e) => {
+                warn!(
+                    "[engram] Failed to persist session summary for chat {}: {}",
+                    chat_id, e
+                );
+                false
+            }
         }
     }
 

--- a/daemon/src/axi_tools.rs
+++ b/daemon/src/axi_tools.rs
@@ -1374,8 +1374,7 @@ REGLAS FIRMES:
                 chats
                     .iter()
                     .filter(|(_, v)| {
-                        now.signed_duration_since(v.last_active).num_seconds()
-                            >= HISTORY_TTL_SECS
+                        now.signed_duration_since(v.last_active).num_seconds() >= HISTORY_TTL_SECS
                     })
                     .map(|(k, v)| {
                         let mut msgs = Vec::new();
@@ -3670,8 +3669,7 @@ REGLAS FIRMES:
         }
     }
 
-    static DESTRUCTIVE_RATE_LIMITER: DestructiveRateLimiter =
-        DestructiveRateLimiter::new(10);
+    static DESTRUCTIVE_RATE_LIMITER: DestructiveRateLimiter = DestructiveRateLimiter::new(10);
 
     /// Append a JSON line describing a destructive action. Best-effort: any
     /// I/O error is swallowed and a `warn!` emitted. Mode 0600 on first
@@ -3743,10 +3741,7 @@ REGLAS FIRMES:
         Ok(())
     }
 
-    async fn execute_memory_delete(
-        args: &serde_json::Value,
-        ctx: &ToolContext,
-    ) -> Result<String> {
+    async fn execute_memory_delete(args: &serde_json::Value, ctx: &ToolContext) -> Result<String> {
         let entry_id = args["entry_id"]
             .as_str()
             .ok_or_else(|| anyhow::anyhow!("Falta parametro 'entry_id'"))?;
@@ -3791,10 +3786,7 @@ REGLAS FIRMES:
         Ok(response)
     }
 
-    async fn execute_memory_update(
-        args: &serde_json::Value,
-        ctx: &ToolContext,
-    ) -> Result<String> {
+    async fn execute_memory_update(args: &serde_json::Value, ctx: &ToolContext) -> Result<String> {
         let entry_id = args["entry_id"]
             .as_str()
             .ok_or_else(|| anyhow::anyhow!("Falta parametro 'entry_id'"))?;
@@ -3820,12 +3812,7 @@ REGLAS FIRMES:
         let mem = memory.read().await;
 
         match mem
-            .update_entry(
-                entry_id,
-                new_content,
-                new_importance,
-                new_tags.as_deref(),
-            )
+            .update_entry(entry_id, new_content, new_importance, new_tags.as_deref())
             .await
         {
             Ok(true) => Ok(format!("Actualice la memoria {}.", entry_id)),
@@ -3834,10 +3821,7 @@ REGLAS FIRMES:
         }
     }
 
-    async fn execute_memory_relate(
-        args: &serde_json::Value,
-        ctx: &ToolContext,
-    ) -> Result<String> {
+    async fn execute_memory_relate(args: &serde_json::Value, ctx: &ToolContext) -> Result<String> {
         let from = args["from_entry_id"]
             .as_str()
             .ok_or_else(|| anyhow::anyhow!("Falta parametro 'from_entry_id'"))?;
@@ -3881,10 +3865,7 @@ REGLAS FIRMES:
         }
 
         match mem.link_entries(from, to, relation).await {
-            Ok(()) => Ok(format!(
-                "Vincule {} -[{}]-> {}.",
-                from, relation, to
-            )),
+            Ok(()) => Ok(format!("Vincule {} -[{}]-> {}.", from, relation, to)),
             Err(e) => Ok(format!("Error creando vinculo: {}", e)),
         }
     }

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -725,6 +725,11 @@ async fn main() -> anyhow::Result<()> {
     if let Err(e) = shared_session_store.init().await {
         warn!("Failed to initialize SessionStore: {}", e);
     }
+    // Wire memory_plane into the session store so compaction summaries and
+    // pruning persist into long-term memory (no-forget contract).
+    shared_session_store
+        .set_memory_plane(shared_memory.clone())
+        .await;
 
     // Screenshot at-rest crypto: validate the key + round-trip on
     // every boot so a corrupt key file or an unwritable secrets dir is
@@ -1733,6 +1738,32 @@ async fn main() -> anyhow::Result<()> {
         }
     });
     info!("Storage housekeeping started (every 6h, 120-file limit per dir, daily memory hygiene: garbage+decay+dedup, nightly LLM cluster summary 02-05h)");
+
+    // --- Session-store TTL prune (every 6h) ---
+    // Periodically calls `SessionStore::prune_stale_sessions`, which
+    // persists each session's compaction summary into memory_plane BEFORE
+    // dropping the in-memory metadata. Closes the loop opened by FIX 2 of
+    // the JD review: previously this method was dead code.
+    {
+        let prune_session_store = state.session_store.clone();
+        let _prune_handle = tokio::spawn(async move {
+            // Stagger after boot to avoid colliding with housekeeping.
+            tokio::time::sleep(Duration::from_secs(420)).await;
+            let mut interval = tokio::time::interval(Duration::from_secs(6 * 3600));
+            loop {
+                interval.tick().await;
+                match prune_session_store.prune_stale_sessions().await {
+                    Ok(0) => {}
+                    Ok(n) => info!(
+                        "[session_store] Periodic prune persisted+removed {} stale sessions",
+                        n
+                    ),
+                    Err(e) => warn!("[session_store] Periodic prune failed: {}", e),
+                }
+            }
+        });
+        info!("Session-store prune task started (every 6h, 72h TTL)");
+    }
 
     // --- Self-improvement loop (Fase U): tick every 6 hours ---
     {

--- a/daemon/src/memory_plane.rs
+++ b/daemon/src/memory_plane.rs
@@ -2060,15 +2060,21 @@ impl MemoryPlaneManager {
                 }
 
                 MemorySearchMode::Lexical => {
+                    // The ciphertext is AES-encrypted then base64'd, so a
+                    // plaintext keyword can never appear in `ciphertext_b64`
+                    // (the previous LIKE filter on it returned ~0 rows). We
+                    // narrow with cheap structured filters first (scope, tag,
+                    // archived), cap the candidate window, then decrypt+score
+                    // post-fetch.
+                    const LEXICAL_CANDIDATE_CAP: usize = 1000;
+
                     let mut sql = "SELECT entry_id, created_at, updated_at, kind, scope, tags, source,
                                           importance, nonce_b64, ciphertext_b64, plaintext_sha256
                                    FROM memory_entries"
                         .to_string();
                     let archived_clause = archived_filter.sql_clause("");
-                    let mut conditions: Vec<String> =
-                        vec!["ciphertext_b64 LIKE ?".into(), archived_clause];
-                    let mut params_vec: Vec<Box<dyn rusqlite::ToSql>> =
-                        vec![Box::new(format!("%{}%", query_lc))];
+                    let mut conditions: Vec<String> = vec![archived_clause];
+                    let mut params_vec: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
 
                     if let Some(ref s) = scope {
                         conditions.push("scope = ?".into());
@@ -2081,7 +2087,8 @@ impl MemoryPlaneManager {
 
                     sql.push_str(" WHERE ");
                     sql.push_str(&conditions.join(" AND "));
-                    sql.push_str(" ORDER BY created_at DESC");
+                    sql.push_str(" ORDER BY created_at DESC LIMIT ?");
+                    params_vec.push(Box::new(LEXICAL_CANDIDATE_CAP as i32));
 
                     let params: Vec<&dyn rusqlite::ToSql> =
                         params_vec.iter().map(|p| p.as_ref()).collect();
@@ -2240,7 +2247,35 @@ impl MemoryPlaneManager {
         Ok(results)
     }
 
+    /// Soft-delete an entry: mark `archived = 1`. The row, its embedding,
+    /// linked KG triples, and memory_links remain so the user can still
+    /// recover via `search_archived` or undo. Use [`hard_delete_entry`]
+    /// to physically remove the row plus all its dependents.
     pub async fn delete_entry(&self, entry_id: &str) -> Result<bool> {
+        let entry_id = normalize_non_empty(entry_id).context("entry_id is required")?;
+
+        let db_path = self.db_path.clone();
+        let now = Utc::now().to_rfc3339();
+
+        let archived = tokio::task::spawn_blocking(move || {
+            let db = Self::open_db(&db_path)?;
+            let updated = db.execute(
+                "UPDATE memory_entries SET archived = 1, updated_at = ?2 WHERE entry_id = ?1",
+                params![entry_id, now],
+            )?;
+            Ok::<_, anyhow::Error>(updated > 0)
+        })
+        .await??;
+
+        Ok(archived)
+    }
+
+    /// Physically remove an entry and ALL its dependents (embedding, KG
+    /// triples sourced from it, and memory_links pointing at it). There
+    /// is no FK chain in the schema so this method is the cleanup
+    /// boundary: callers (axi tool / API ?hard=true) are expected to
+    /// confirm with the user first.
+    pub async fn hard_delete_entry(&self, entry_id: &str) -> Result<bool> {
         let entry_id = normalize_non_empty(entry_id).context("entry_id is required")?;
 
         let db_path = self.db_path.clone();
@@ -2259,8 +2294,176 @@ impl MemoryPlaneManager {
                 params![entry_id],
             )?;
 
+            tx.execute(
+                "DELETE FROM knowledge_graph WHERE source_entry_id = ?",
+                params![entry_id],
+            )?;
+
+            tx.execute(
+                "DELETE FROM memory_links WHERE from_entry = ?1 OR to_entry = ?1",
+                params![entry_id],
+            )?;
+
+            // sqlite-vec virtual tables have no FK chain — we MUST delete
+            // the embedding row explicitly or it lingers and pollutes
+            // semantic search hits.
+            tx.execute(
+                "DELETE FROM memory_embeddings WHERE entry_id = ?",
+                params![entry_id],
+            )?;
+
             tx.commit()?;
             Ok::<_, anyhow::Error>(deleted > 0)
+        })
+        .await??;
+
+        Ok(deleted)
+    }
+
+    /// Update an existing entry's content, importance, and/or tags.
+    /// If `new_content` is provided the embedding is regenerated so semantic
+    /// search stays consistent with the visible text.
+    pub async fn update_entry(
+        &self,
+        entry_id: &str,
+        new_content: Option<&str>,
+        new_importance: Option<u8>,
+        new_tags: Option<&[String]>,
+    ) -> Result<bool> {
+        let entry_id = normalize_non_empty(entry_id).context("entry_id is required")?;
+        if new_content.is_none() && new_importance.is_none() && new_tags.is_none() {
+            anyhow::bail!("update_entry requires at least one field to change");
+        }
+
+        if let Some(imp) = new_importance {
+            if imp > 100 {
+                anyhow::bail!("importance must be in range 0..=100");
+            }
+        }
+
+        let new_encrypted = if let Some(content) = new_content {
+            let content = content.trim();
+            if content.is_empty() {
+                anyhow::bail!("content is required");
+            }
+            if content.len() > MAX_CONTENT_BYTES {
+                anyhow::bail!("content too large (max {} bytes)", MAX_CONTENT_BYTES);
+            }
+            let (nonce_b64, ciphertext_b64, plaintext_sha256) = encrypt_content(content)?;
+            let (embedding, embedding_source) = self.generate_embedding(content).await;
+            let embedding_bytes: Vec<u8> =
+                embedding.iter().flat_map(|f| f.to_le_bytes()).collect();
+            Some((
+                nonce_b64,
+                ciphertext_b64,
+                plaintext_sha256,
+                embedding_source,
+                embedding_bytes,
+            ))
+        } else {
+            None
+        };
+
+        let normalized_tags = new_tags.map(normalize_tags);
+        let tags_json = match &normalized_tags {
+            Some(t) => Some(serde_json::to_string(t)?),
+            None => None,
+        };
+
+        let db_path = self.db_path.clone();
+        let now = Utc::now().to_rfc3339();
+
+        let updated = tokio::task::spawn_blocking(move || {
+            let db = Self::open_db(&db_path)?;
+            let tx = db.unchecked_transaction()?;
+
+            // Build the UPDATE dynamically with positional `?` placeholders to
+            // stay consistent with the rest of the file (no named-param helper
+            // is used elsewhere). `updated_at` is always touched; `entry_id`
+            // is always the WHERE clause; everything else is conditional.
+            let mut sets: Vec<String> = vec!["updated_at = ?".to_string()];
+            let mut params_vec: Vec<Box<dyn rusqlite::ToSql>> =
+                vec![Box::new(now.clone())];
+
+            if let Some((ref n, ref c, ref h, ref es, _)) = new_encrypted {
+                sets.push("nonce_b64 = ?".to_string());
+                sets.push("ciphertext_b64 = ?".to_string());
+                sets.push("plaintext_sha256 = ?".to_string());
+                sets.push("embedding_source = ?".to_string());
+                params_vec.push(Box::new(n.clone()));
+                params_vec.push(Box::new(c.clone()));
+                params_vec.push(Box::new(h.clone()));
+                params_vec.push(Box::new(es.clone()));
+            }
+            if let Some(imp) = new_importance {
+                sets.push("importance = ?".to_string());
+                params_vec.push(Box::new(imp as i32));
+            }
+            if let Some(ref t) = tags_json {
+                sets.push("tags = ?".to_string());
+                params_vec.push(Box::new(t.clone()));
+            }
+
+            // Trailing WHERE param.
+            params_vec.push(Box::new(entry_id.clone()));
+
+            let sql = format!(
+                "UPDATE memory_entries SET {} WHERE entry_id = ?",
+                sets.join(", ")
+            );
+
+            let bound: Vec<&dyn rusqlite::ToSql> =
+                params_vec.iter().map(|p| p.as_ref()).collect();
+            let rows = tx.execute(&sql, bound.as_slice())?;
+
+            if let Some((_, _, _, _, embedding_bytes)) = new_encrypted {
+                tx.execute(
+                    "DELETE FROM memory_embeddings WHERE entry_id = ?",
+                    params![entry_id],
+                )?;
+                tx.execute(
+                    "INSERT INTO memory_embeddings (entry_id, embedding) VALUES (?1, vec_f32(?2))",
+                    params![entry_id, embedding_bytes],
+                )?;
+            }
+
+            tx.commit()?;
+            Ok::<_, anyhow::Error>(rows > 0)
+        })
+        .await??;
+
+        Ok(updated)
+    }
+
+    /// Delete a single knowledge-graph triple by exact `(subject, predicate, object)` match.
+    pub async fn delete_kg_triple(
+        &self,
+        subject: &str,
+        predicate: &str,
+        object: &str,
+    ) -> Result<bool> {
+        // KG triples are stored lowercase by `add_triple`, so we match
+        // the same normalization here or the DELETE silently misses.
+        let subject = normalize_non_empty(subject)
+            .context("subject is required")?
+            .to_lowercase();
+        let predicate = normalize_non_empty(predicate)
+            .context("predicate is required")?
+            .to_lowercase();
+        let object = normalize_non_empty(object)
+            .context("object is required")?
+            .to_lowercase();
+
+        let db_path = self.db_path.clone();
+
+        let deleted = tokio::task::spawn_blocking(move || {
+            let db = Self::open_db(&db_path)?;
+            let rows = db.execute(
+                "DELETE FROM knowledge_graph
+                 WHERE subject = ?1 AND predicate = ?2 AND object = ?3",
+                params![subject, predicate, object],
+            )?;
+            Ok::<_, anyhow::Error>(rows > 0)
         })
         .await??;
 
@@ -2929,6 +3132,45 @@ impl MemoryPlaneManager {
     // -----------------------------------------------------------------------
 
     /// Link two memory entries with a relationship.
+    /// Returns true if an entry with `entry_id` exists in `memory_entries`,
+    /// regardless of archived state. Used by `memory_relate` to fail fast
+    /// instead of silently linking phantom IDs.
+    pub async fn entry_exists(&self, entry_id: &str) -> Result<bool> {
+        let entry_id = normalize_non_empty(entry_id).context("entry_id is required")?;
+        let db_path = self.db_path.clone();
+        let exists = tokio::task::spawn_blocking(move || {
+            let db = Self::open_db(&db_path)?;
+            let n: i64 = db.query_row(
+                "SELECT COUNT(*) FROM memory_entries WHERE entry_id = ?1",
+                params![entry_id],
+                |row| row.get(0),
+            )?;
+            Ok::<_, anyhow::Error>(n > 0)
+        })
+        .await??;
+        Ok(exists)
+    }
+
+    /// Restore a soft-deleted entry by clearing its `archived` flag.
+    /// Companion to [`delete_entry`]. Returns true if a row was actually
+    /// flipped (false if the entry is missing or already live).
+    pub async fn unarchive_entry(&self, entry_id: &str) -> Result<bool> {
+        let entry_id = normalize_non_empty(entry_id).context("entry_id is required")?;
+        let db_path = self.db_path.clone();
+        let now = Utc::now().to_rfc3339();
+        let updated = tokio::task::spawn_blocking(move || {
+            let db = Self::open_db(&db_path)?;
+            let rows = db.execute(
+                "UPDATE memory_entries SET archived = 0, updated_at = ?2
+                 WHERE entry_id = ?1 AND archived = 1",
+                params![entry_id, now],
+            )?;
+            Ok::<_, anyhow::Error>(rows > 0)
+        })
+        .await??;
+        Ok(updated)
+    }
+
     pub async fn link_entries(&self, from_id: &str, to_id: &str, relation: &str) -> Result<()> {
         let db_path = self.db_path.clone();
         let from = from_id.to_string();
@@ -16743,10 +16985,188 @@ mod tests {
             .await
             .unwrap();
 
+        // Default delete is now soft (archive) — `list_entries` filters
+        // archived rows out, so the live view is empty.
         let deleted = mgr.delete_entry(&created.entry_id).await.unwrap();
         assert!(deleted);
         let entries = mgr.list_entries(10, None, None).await.unwrap();
         assert!(entries.is_empty());
+
+        // But the row still exists physically — search_archived can find it.
+        let archived = mgr
+            .search_archived("delete me", 5, None)
+            .await
+            .unwrap();
+        assert!(
+            archived.iter().any(|r| r.entry.entry_id == created.entry_id),
+            "soft-deleted entry must remain recoverable via archived search"
+        );
+
+        std::fs::remove_dir_all(dir).ok();
+    }
+
+    #[tokio::test]
+    async fn hard_delete_entry_removes_links_and_kg() {
+        let dir = temp_dir("memory-plane-hard-delete");
+        let mgr = MemoryPlaneManager::new(dir.clone()).unwrap();
+        mgr.initialize().await.unwrap();
+
+        let a = mgr
+            .add_entry("note", "user", &[], None, 10, "from-side")
+            .await
+            .unwrap();
+        let b = mgr
+            .add_entry("note", "user", &[], None, 10, "to-side")
+            .await
+            .unwrap();
+        mgr.link_entries(&a.entry_id, &b.entry_id, "refers_to")
+            .await
+            .unwrap();
+
+        // FIX 4 — exercise the KG cleanup branch the previous test missed.
+        // add_triple is the only call site that populates `source_entry_id`,
+        // so without this the `DELETE ... WHERE source_entry_id = ?` line
+        // had zero coverage.
+        mgr.add_triple("hector", "owns", "laptop", 1.0, Some(&a.entry_id))
+            .await
+            .unwrap();
+
+        let deleted = mgr.hard_delete_entry(&a.entry_id).await.unwrap();
+        assert!(deleted);
+
+        let linked = mgr.get_linked(&b.entry_id).await.unwrap();
+        assert!(
+            linked.is_empty(),
+            "hard delete must purge memory_links pointing at the deleted entry"
+        );
+
+        // FIX 4 + FIX 5 — verify via raw SQL because there's no public
+        // inspector for KG triples by source_entry_id, and the embedding
+        // virtual table needs explicit cleanup.
+        let db_path = dir.join("memory.db");
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let kg_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM knowledge_graph WHERE source_entry_id = ?1",
+                params![&a.entry_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            kg_count, 0,
+            "hard delete must purge KG triples whose source_entry_id is the deleted entry"
+        );
+
+        let emb_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM memory_embeddings WHERE entry_id = ?1",
+                params![&a.entry_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            emb_count, 0,
+            "hard delete must purge memory_embeddings row for the deleted entry"
+        );
+
+        std::fs::remove_dir_all(dir).ok();
+    }
+
+    #[tokio::test]
+    async fn lexical_search_finds_decrypted_keyword() {
+        // Regression: the old lexical path filtered with `ciphertext_b64
+        // LIKE '%query%'`, which was always false because the ciphertext
+        // is AES-encrypted then base64'd. After the fix we narrow with
+        // structured filters then decrypt and score in memory.
+        let dir = temp_dir("memory-plane-lexical");
+        let mgr = MemoryPlaneManager::new(dir.clone()).unwrap();
+        mgr.initialize().await.unwrap();
+
+        mgr.add_entry(
+            "note",
+            "user",
+            &["telegram".to_string()],
+            None,
+            50,
+            "Configurar bot de telegram con TELEGRAM_BOT_TOKEN.",
+        )
+        .await
+        .unwrap();
+
+        let hits = mgr
+            .search_entries_with_mode(
+                "telegram",
+                10,
+                None,
+                MemorySearchMode::Lexical,
+            )
+            .await
+            .unwrap();
+        assert!(
+            !hits.is_empty(),
+            "lexical search must return matches for decrypted plaintext"
+        );
+
+        std::fs::remove_dir_all(dir).ok();
+    }
+
+    #[tokio::test]
+    async fn update_entry_changes_content_and_tags() {
+        let dir = temp_dir("memory-plane-update");
+        let mgr = MemoryPlaneManager::new(dir.clone()).unwrap();
+        mgr.initialize().await.unwrap();
+
+        let created = mgr
+            .add_entry("note", "user", &["old".to_string()], None, 10, "v1")
+            .await
+            .unwrap();
+
+        let new_tags = vec!["new".to_string(), "edited".to_string()];
+        let updated = mgr
+            .update_entry(
+                &created.entry_id,
+                Some("v2-edited"),
+                Some(80),
+                Some(&new_tags),
+            )
+            .await
+            .unwrap();
+        assert!(updated);
+
+        let entries = mgr.list_entries(10, None, None).await.unwrap();
+        let row = entries
+            .iter()
+            .find(|e| e.entry_id == created.entry_id)
+            .expect("entry still exists");
+        assert_eq!(row.content, "v2-edited");
+        assert_eq!(row.importance, 80);
+        assert!(row.tags.contains(&"new".to_string()));
+
+        std::fs::remove_dir_all(dir).ok();
+    }
+
+    #[tokio::test]
+    async fn delete_kg_triple_removes_match() {
+        let dir = temp_dir("memory-plane-kg-delete");
+        let mgr = MemoryPlaneManager::new(dir.clone()).unwrap();
+        mgr.initialize().await.unwrap();
+
+        mgr.add_triple("hector", "vive_en", "qro", 1.0, None)
+            .await
+            .unwrap();
+
+        let deleted = mgr
+            .delete_kg_triple("hector", "vive_en", "qro")
+            .await
+            .unwrap();
+        assert!(deleted);
+
+        // Second delete is a no-op.
+        let deleted2 = mgr
+            .delete_kg_triple("hector", "vive_en", "qro")
+            .await
+            .unwrap();
+        assert!(!deleted2);
 
         std::fs::remove_dir_all(dir).ok();
     }

--- a/daemon/src/memory_plane.rs
+++ b/daemon/src/memory_plane.rs
@@ -2304,14 +2304,6 @@ impl MemoryPlaneManager {
                 params![entry_id],
             )?;
 
-            // sqlite-vec virtual tables have no FK chain — we MUST delete
-            // the embedding row explicitly or it lingers and pollutes
-            // semantic search hits.
-            tx.execute(
-                "DELETE FROM memory_embeddings WHERE entry_id = ?",
-                params![entry_id],
-            )?;
-
             tx.commit()?;
             Ok::<_, anyhow::Error>(deleted > 0)
         })

--- a/daemon/src/memory_plane.rs
+++ b/daemon/src/memory_plane.rs
@@ -2343,8 +2343,7 @@ impl MemoryPlaneManager {
             }
             let (nonce_b64, ciphertext_b64, plaintext_sha256) = encrypt_content(content)?;
             let (embedding, embedding_source) = self.generate_embedding(content).await;
-            let embedding_bytes: Vec<u8> =
-                embedding.iter().flat_map(|f| f.to_le_bytes()).collect();
+            let embedding_bytes: Vec<u8> = embedding.iter().flat_map(|f| f.to_le_bytes()).collect();
             Some((
                 nonce_b64,
                 ciphertext_b64,
@@ -2374,8 +2373,7 @@ impl MemoryPlaneManager {
             // is used elsewhere). `updated_at` is always touched; `entry_id`
             // is always the WHERE clause; everything else is conditional.
             let mut sets: Vec<String> = vec!["updated_at = ?".to_string()];
-            let mut params_vec: Vec<Box<dyn rusqlite::ToSql>> =
-                vec![Box::new(now.clone())];
+            let mut params_vec: Vec<Box<dyn rusqlite::ToSql>> = vec![Box::new(now.clone())];
 
             if let Some((ref n, ref c, ref h, ref es, _)) = new_encrypted {
                 sets.push("nonce_b64 = ?".to_string());
@@ -2404,8 +2402,7 @@ impl MemoryPlaneManager {
                 sets.join(", ")
             );
 
-            let bound: Vec<&dyn rusqlite::ToSql> =
-                params_vec.iter().map(|p| p.as_ref()).collect();
+            let bound: Vec<&dyn rusqlite::ToSql> = params_vec.iter().map(|p| p.as_ref()).collect();
             let rows = tx.execute(&sql, bound.as_slice())?;
 
             if let Some((_, _, _, _, embedding_bytes)) = new_encrypted {
@@ -16985,12 +16982,11 @@ mod tests {
         assert!(entries.is_empty());
 
         // But the row still exists physically — search_archived can find it.
-        let archived = mgr
-            .search_archived("delete me", 5, None)
-            .await
-            .unwrap();
+        let archived = mgr.search_archived("delete me", 5, None).await.unwrap();
         assert!(
-            archived.iter().any(|r| r.entry.entry_id == created.entry_id),
+            archived
+                .iter()
+                .any(|r| r.entry.entry_id == created.entry_id),
             "soft-deleted entry must remain recoverable via archived search"
         );
 
@@ -17086,12 +17082,7 @@ mod tests {
         .unwrap();
 
         let hits = mgr
-            .search_entries_with_mode(
-                "telegram",
-                10,
-                None,
-                MemorySearchMode::Lexical,
-            )
+            .search_entries_with_mode("telegram", 10, None, MemorySearchMode::Lexical)
             .await
             .unwrap();
         assert!(

--- a/daemon/src/session_store.rs
+++ b/daemon/src/session_store.rs
@@ -315,10 +315,7 @@ impl SessionStore {
         };
         drop(mp_slot);
 
-        let session_tag = format!(
-            "session:{}:{}:{}",
-            key.channel, key.scope, key.peer_id
-        );
+        let session_tag = format!("session:{}:{}:{}", key.channel, key.scope, key.peer_id);
         let tags = vec![
             "session_summary".to_string(),
             session_tag.clone(),

--- a/daemon/src/session_store.rs
+++ b/daemon/src/session_store.rs
@@ -231,6 +231,17 @@ pub struct SessionMetadata {
 pub struct SessionStore {
     base_dir: PathBuf,
     sessions: RwLock<HashMap<String, SessionMetadata>>,
+    /// Optional memory_plane handle for "no forget" persistence. When set,
+    /// `compact_session` and `prune_stale_sessions` write the compaction
+    /// summary into memory_plane as a high-importance entry tagged with
+    /// the session_key — so 72 h TTL pruning never silently loses context.
+    /// Wired post-construction via [`SessionStore::set_memory_plane`].
+    memory_plane: RwLock<Option<Arc<RwLock<crate::memory_plane::MemoryPlaneManager>>>>,
+    /// Pending summaries that arrived BEFORE `set_memory_plane` was wired.
+    /// Flushed atomically inside `set_memory_plane`, so the boot race
+    /// (compact triggered between SessionStore::new and set_memory_plane)
+    /// no longer drops summaries on the floor.
+    pending_summaries: RwLock<Vec<(SessionKey, String)>>,
 }
 
 impl SessionStore {
@@ -239,6 +250,97 @@ impl SessionStore {
         Self {
             base_dir,
             sessions: RwLock::new(HashMap::new()),
+            memory_plane: RwLock::new(None),
+            pending_summaries: RwLock::new(Vec::new()),
+        }
+    }
+
+    /// Attach a memory_plane handle so that compaction and pruning persist
+    /// summaries into long-term memory. Idempotent — a second call replaces
+    /// the previous handle. ALSO flushes any summaries that were buffered
+    /// before this call (boot-race safety: compactions that fired between
+    /// `SessionStore::new` and this setter are NOT lost).
+    pub async fn set_memory_plane(
+        &self,
+        memory: Arc<RwLock<crate::memory_plane::MemoryPlaneManager>>,
+    ) {
+        {
+            let mut slot = self.memory_plane.write().await;
+            *slot = Some(memory);
+        }
+        // Drain and flush any buffered summaries through the now-wired plane.
+        let drained = {
+            let mut q = self.pending_summaries.write().await;
+            std::mem::take(&mut *q)
+        };
+        if drained.is_empty() {
+            return;
+        }
+        info!(
+            "[session_store] Flushing {} buffered summaries to memory_plane after set",
+            drained.len()
+        );
+        for (key, summary) in drained {
+            self.persist_summary_to_memory(&key, &summary).await;
+        }
+    }
+
+    /// Persist a compaction summary to memory_plane (if attached).
+    /// Best-effort: logs and continues on failure so it never blocks
+    /// the prune / compact flow.
+    async fn persist_summary_to_memory(&self, key: &SessionKey, summary: &str) {
+        let mp_slot = self.memory_plane.read().await;
+        let Some(mp) = mp_slot.as_ref().cloned() else {
+            // Boot race: memory_plane not wired yet. Buffer for the
+            // forthcoming `set_memory_plane` call to flush.
+            drop(mp_slot);
+            let mut pending = self.pending_summaries.write().await;
+            pending.push((key.clone(), summary.to_string()));
+            warn!(
+                "[session_store] memory_plane not ready; buffered summary for {} (queue={})",
+                key,
+                pending.len()
+            );
+            return;
+        };
+        drop(mp_slot);
+
+        let session_tag = format!(
+            "session:{}:{}:{}",
+            key.channel, key.scope, key.peer_id
+        );
+        let tags = vec![
+            "session_summary".to_string(),
+            session_tag.clone(),
+            key.channel.clone(),
+        ];
+        let content = format!(
+            "[decision] Session summary ({})\ntopic: {}\n{}",
+            key.as_canonical(),
+            session_tag,
+            summary
+        );
+        let mp_guard = mp.read().await;
+        if let Err(e) = mp_guard
+            .add_entry(
+                "decision",
+                "user",
+                &tags,
+                Some(&format!("session-store://{}", key.channel)),
+                75,
+                &content,
+            )
+            .await
+        {
+            warn!(
+                "[session_store] Failed to persist summary for {} to memory_plane: {}",
+                key, e
+            );
+        } else {
+            info!(
+                "[session_store] Persisted compaction summary for {} to memory_plane",
+                key
+            );
         }
     }
 
@@ -506,21 +608,32 @@ impl SessionStore {
     /// the `storage_housekeeping` module handles disk cleanup.
     pub async fn prune_stale_sessions(&self) -> Result<usize> {
         let cutoff = Utc::now() - chrono::Duration::hours(SESSION_TTL_HOURS as i64);
-        let mut to_remove = Vec::new();
+        let mut to_remove: Vec<(String, Option<String>)> = Vec::new();
 
         {
             let sessions = self.sessions.read().await;
             for (key, meta) in sessions.iter() {
                 if meta.last_active_at < cutoff {
-                    to_remove.push(key.clone());
+                    to_remove.push((key.clone(), meta.compaction_summary.clone()));
                 }
             }
         }
 
         let count = to_remove.len();
         if count > 0 {
+            // Persist whatever compaction summary we have to memory_plane
+            // BEFORE we drop the in-memory metadata, so 72h TTL pruning
+            // never silently loses long-running session context.
+            for (canonical, summary_opt) in &to_remove {
+                if let Some(summary) = summary_opt {
+                    if let Some(parsed) = parse_canonical_session_key(canonical) {
+                        self.persist_summary_to_memory(&parsed, summary).await;
+                    }
+                }
+            }
+
             let mut sessions = self.sessions.write().await;
-            for key in &to_remove {
+            for (key, _) in &to_remove {
                 sessions.remove(key);
             }
             info!("[session_store] Pruned {} stale sessions", count);
@@ -593,8 +706,13 @@ impl SessionStore {
         let response = router_guard.chat(&request).await?;
         drop(router_guard);
 
-        // Save summary
+        // Save summary in metadata...
+        let summary_text = response.text.clone();
         self.set_compaction_summary(key, response.text).await?;
+        // ...and ALSO persist into memory_plane so it survives the 72 h TTL
+        // and is searchable by future Axi turns. Best-effort; does not fail
+        // the compaction if memory_plane is unavailable.
+        self.persist_summary_to_memory(key, &summary_text).await;
 
         // Rewrite transcript with only recent turns
         let recent_turns = &all_turns[all_turns.len().saturating_sub(KEEP_RECENT)..];
@@ -618,6 +736,23 @@ impl SessionStore {
 
         Ok(())
     }
+}
+
+/// Parse a canonical session key string `agent:axi:<channel>:<scope>:<peer_id>`
+/// back into a [`SessionKey`]. Tolerant: peer_id may itself contain `:`,
+/// so we split on the first 4 separators and treat the rest as peer_id.
+fn parse_canonical_session_key(canonical: &str) -> Option<SessionKey> {
+    // Expected: agent:axi:channel:scope:peer_id
+    let parts: Vec<&str> = canonical.splitn(5, ':').collect();
+    if parts.len() < 5 || parts[0] != "agent" {
+        return None;
+    }
+    Some(SessionKey {
+        agent: parts[1].to_string(),
+        channel: parts[2].to_string(),
+        scope: parts[3].to_string(),
+        peer_id: parts[4].to_string(),
+    })
 }
 
 #[cfg(test)]

--- a/daemon/src/session_store.rs
+++ b/daemon/src/session_store.rs
@@ -289,12 +289,22 @@ impl SessionStore {
     /// Best-effort: logs and continues on failure so it never blocks
     /// the prune / compact flow.
     async fn persist_summary_to_memory(&self, key: &SessionKey, summary: &str) {
+        const PENDING_QUEUE_CAP: usize = 256;
         let mp_slot = self.memory_plane.read().await;
         let Some(mp) = mp_slot.as_ref().cloned() else {
             // Boot race: memory_plane not wired yet. Buffer for the
             // forthcoming `set_memory_plane` call to flush.
             drop(mp_slot);
             let mut pending = self.pending_summaries.write().await;
+            // Cap the buffer FIFO. If memory_plane never wires, we drop
+            // the oldest pending summary rather than grow unbounded.
+            while pending.len() >= PENDING_QUEUE_CAP {
+                let dropped = pending.remove(0);
+                warn!(
+                    "[session_store] pending_summaries cap reached ({}); dropping oldest summary for {}",
+                    PENDING_QUEUE_CAP, dropped.0
+                );
+            }
             pending.push((key.clone(), summary.to_string()));
             warn!(
                 "[session_store] memory_plane not ready; buffered summary for {} (queue={})",

--- a/docs/architecture/memory-system.md
+++ b/docs/architecture/memory-system.md
@@ -134,3 +134,38 @@ que sabes de, que recuerdas
 │       └── transcript.jsonl     # Linea por turno (user/assistant/tool)
 └── memory.key                   # Clave de encriptacion (fallback)
 ```
+
+## Sprint 1 — Stop Axi from forgetting (2026-04-25)
+
+Sprint 1 del plan de remediacion del audit cierra los caminos por
+los que Axi olvidaba en silencio:
+
+- **ConversationHistory 48h TTL → memory_plane.** Antes del drop de
+  un chat caducado, `drain_stale_and_persist` resume con LLM y
+  persiste la sintesis a `memory_entries`. Si el persist falla, el
+  chat queda en RAM para reintentar en el proximo turno (no se pierde).
+- **SessionStore 72h TTL → memory_plane.** `compact_session` y
+  `prune_stale_sessions` (ahora agendado cada 6h en main.rs) escriben
+  el resumen a `memory_entries` antes de borrar la sesion del disco.
+- **Lexical search funcional.** El modo lexical antes hacia
+  `LIKE '%query%'` contra contenido AES-encrypted+base64 (correctness
+  bug, devolvia ~0 resultados). Ahora filtra por scope/tag/archived
+  en SQL, descifra hasta 1000 candidatos y matchea plaintext.
+- **5 herramientas nuevas para el LLM** que cubren el ciclo CRUD
+  completo: `memory_delete`, `memory_update`, `memory_relate`,
+  `memory_unarchive`, `knowledge_delete`. Axi puede editar, borrar
+  y restaurar memorias desde chat.
+- **Soft-delete por defecto + hard-delete con cleanup de huerfanos.**
+  `delete_entry` ahora marca `archived = 1` (recuperable via
+  `memory_unarchive`). `hard_delete_entry` (usado solo por
+  `right_to_be_forgotten` y por `memory_delete` con `hard=true`)
+  envuelve en una transaccion el borrado de `memory_entries`,
+  `memory_embeddings`, triples del `knowledge_graph` cuyo
+  `source_entry_id` apunta a la entrada, y `memory_links` en ambos
+  sentidos.
+
+**Defensa contra prompt injection** sobre las nuevas tools
+destructivas: requieren `confirm: true` por defecto (gate-able via
+`LIFEOS_AXI_REQUIRE_CONFIRM_DESTRUCTIVE`), rate-limit de 10 ops/hora,
+y audit log append-only en
+`~/.local/share/lifeos/destructive_actions.log` (mode 0600).


### PR DESCRIPTION
## Summary

Sprint 1 of the Axi memory remediation plan from the **Judgment Day audit (2026-04-25)**. Closes the 5 CRITICAL findings the user explicitly worried about: \"Axi never forgets, edit/link/add/delete/relate everything\".

## What ships

### Audit fixes
1. **Lexical search no longer broken** (correctness bug — was scanning AES ciphertext with LIKE, returning ~0 results 99.9% of the time)
2. **48h ConversationHistory TTL no longer drops content silently** — persists to memory_plane BEFORE remove
3. **SessionStore feeds compactions back to memory_plane** (compact + prune both wire summaries)
4. **5 new LLM tools**: \`memory_delete\`, \`memory_update\`, \`memory_relate\`, \`memory_unarchive\`, \`knowledge_delete\`
5. **Soft-delete default + clean hard-delete** (transaction wipes memory_entries + memory_embeddings + KG + links)

### Defense-in-depth (Judgment Day adversarial round caught these)
- Confirm-gate (\`confirm: true\` required) for destructive tools
- Append-only audit log at \`~/.local/share/lifeos/destructive_actions.log\` (0600)
- Rate limit: 10 destructive ops/hour
- Self-link rejection + entry-existence check in \`memory_relate\`
- \`prune_stale_sessions\` scheduler (6h periodic) — was dead code
- Drain throttled to once per 60s + sync persist (no SIGTERM data-loss race)

## What's NOT in this PR (deferred per the 4-sprint plan)

- **Sprint 2**: SQLite PRAGMAs (WAL, synchronous=NORMAL), connection pool, vec0 KNN refactor, atomic conversation_history.json, background embedding queue
- **Sprint 3**: FTS5, dedup O(N²) refactor, embedding-source filter, meeting/session promotion, batched decay
- **Sprint 4**: Unified search across all memory layers, source_entry_id from LLM, dashboard PUT/PATCH

Audit memory: \`project_axi_memory_audit_2026_04_25.md\`

## Test plan
- [ ] CI passes (compile + clippy + tests)
- [ ] Image builds and pushes to GHCR
- [ ] On laptop: lexical search now returns matches for known-existing keywords
- [ ] On laptop: SimpleX chat older than 48h → check \`memory_entries\` for the persisted summary
- [ ] On laptop: ask Axi \"olvida memoria mem-XXX\" → soft-delete with audit log
- [ ] On laptop: \`destructive_actions.log\` written with 0600 perms