### PR TITLE
feat(memory): Sprint 3+4 quick wins — filter fallback, batched decay, KG source link, PATCH endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "life"
-version = "0.8.13"
+version = "0.8.14"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2626,7 +2626,7 @@ dependencies = [
 
 [[package]]
 name = "lifeos-integration-tests"
-version = "0.8.13"
+version = "0.8.14"
 dependencies = [
  "life",
  "serde_json",
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "lifeosd"
-version = "0.8.13"
+version = "0.8.14"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.13"
+version = "0.8.14"
 
 [workspace.metadata.lifeos]
 codename = "Axolotl"

--- a/daemon/src/api/mod.rs
+++ b/daemon/src/api/mod.rs
@@ -1479,7 +1479,10 @@ pub fn create_router(state: ApiState) -> Router {
             "/memory/entries",
             get(list_memory_entries).post(add_memory_entry),
         )
-        .route("/memory/entries/:entry_id", delete(delete_memory_entry))
+        .route(
+            "/memory/entries/:entry_id",
+            delete(delete_memory_entry).patch(patch_memory_entry),
+        )
         .route("/memory/search", get(search_memory_entries))
         .route("/memory/stats", get(get_memory_stats))
         .route("/memory/graph", get(get_memory_graph))
@@ -8188,6 +8191,18 @@ struct AddMemoryEntryPayload {
     content: String,
 }
 
+/// Sprint 4 / item 18: dashboard PATCH body. Every field is optional;
+/// at least one must be present or the handler returns 400. Validation
+/// (importance range, content size, tag count) is enforced both here
+/// and again inside `MemoryPlaneManager::update_entry` — defence in
+/// depth so a future direct caller can't bypass us.
+#[derive(Debug, Deserialize)]
+struct PatchMemoryEntryPayload {
+    content: Option<String>,
+    importance: Option<u8>,
+    tags: Option<Vec<String>>,
+}
+
 #[derive(Debug, Deserialize)]
 struct ListMemoryEntriesQuery {
     limit: Option<usize>,
@@ -9965,6 +9980,99 @@ async fn delete_memory_entry(
         "deleted": deleted,
         "hard": hard,
         "entry_id": entry_id,
+    })))
+}
+
+/// Sprint 4 / item 18: PATCH /memory/entries/:entry_id — partial update
+/// from the dashboard. Maps cleanly onto `MemoryPlaneManager::update_entry`
+/// which already exists from Sprint 1. Returns the freshly-read row so
+/// the dashboard can render the new content/importance/tags without a
+/// follow-up GET.
+async fn patch_memory_entry(
+    State(state): State<ApiState>,
+    Path(entry_id): Path<String>,
+    Json(payload): Json<PatchMemoryEntryPayload>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<ApiError>)> {
+    fn bad_request(msg: impl Into<String>) -> (StatusCode, Json<ApiError>) {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ApiError {
+                error: "Bad Request".to_string(),
+                message: msg.into(),
+                code: 400,
+            }),
+        )
+    }
+
+    if payload.content.is_none() && payload.importance.is_none() && payload.tags.is_none() {
+        return Err(bad_request(
+            "at least one of content/importance/tags is required",
+        ));
+    }
+    if let Some(imp) = payload.importance {
+        if imp > 100 {
+            return Err(bad_request("importance must be in range 0..=100"));
+        }
+    }
+    // Cap tag list to 20 — the dashboard UI never offers more, and
+    // unbounded tags blow up the JSON-array LIKE filter at search time.
+    if let Some(ref t) = payload.tags {
+        if t.len() > 20 {
+            return Err(bad_request("tags max 20 items"));
+        }
+    }
+
+    let mgr = state.memory_plane_manager.read().await;
+    let updated = mgr
+        .update_entry(
+            &entry_id,
+            payload.content.as_deref(),
+            payload.importance,
+            payload.tags.as_deref(),
+        )
+        .await
+        .map_err(|e| {
+            let msg = e.to_string();
+            // `update_entry` enforces content-length and importance range
+            // again at the storage layer; surface those as 400 not 500.
+            let status =
+                if msg.contains("required") || msg.contains("range") || msg.contains("too large") {
+                    StatusCode::BAD_REQUEST
+                } else {
+                    StatusCode::INTERNAL_SERVER_ERROR
+                };
+            (
+                status,
+                Json(ApiError {
+                    error: status.canonical_reason().unwrap_or("Error").to_string(),
+                    message: msg,
+                    code: status.as_u16(),
+                }),
+            )
+        })?;
+
+    if !updated {
+        return Err((
+            StatusCode::NOT_FOUND,
+            Json(ApiError {
+                error: "Not Found".to_string(),
+                message: format!("memory entry {} not found", entry_id),
+                code: 404,
+            }),
+        ));
+    }
+
+    // Use the single-entry getter so the response carries the freshly
+    // updated row even when the user has more than the previous
+    // 200-row cap of `list_entries(200, ...)` (which silently dropped
+    // any patched row outside the recency window and returned
+    // `entry: null`).
+    let entry = mgr.get_entry(&entry_id).await.ok().flatten();
+
+    Ok(Json(serde_json::json!({
+        "status": "ok",
+        "entry_id": entry_id,
+        "entry": entry,
     })))
 }
 

--- a/daemon/src/axi_tools.rs
+++ b/daemon/src/axi_tools.rs
@@ -842,7 +842,8 @@ REGLAS FIRMES:
     Usa SDD para: crear features, refactorizar, disenar arquitectura, o tareas de desarrollo que toquen 3+ archivos.
 
 28. **graph_add** — Agrega una relacion al grafo de conocimiento (ej: "Hector trabaja_en LifeOS").
-    args: {"subject": "hector", "predicate": "trabaja_en", "object": "lifeos"}
+    args: {"subject": "hector", "predicate": "trabaja_en", "object": "lifeos", "source_entry_id": "<opcional, entry_id del recuerdo que motivó esta relación>"}
+    Si esta relacion viene de un recuerdo concreto (acabas de guardar algo con remember/note y lo enlazas), pasa su entry_id en source_entry_id para que el grafo no quede huerfano y se limpie si borras el recuerdo.
 
 29. **graph_query** — Consulta el grafo de conocimiento sobre una entidad.
     args: {"entity": "hector"}
@@ -9536,14 +9537,25 @@ REGLAS FIRMES:
         let object = args["object"]
             .as_str()
             .ok_or_else(|| anyhow::anyhow!("Falta 'object'"))?;
+        // Sprint 4 / item 17: optional link back to the memory entry that
+        // motivated this triple. Empty / whitespace counts as "absent" so
+        // the LLM can omit it without us writing a dangling foreign key.
+        let source_entry_id = args["source_entry_id"]
+            .as_str()
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty());
 
         if let Some(memory) = &ctx.memory {
             let mem = memory.read().await;
-            mem.add_triple(subject, predicate, object, 1.0, None)
+            mem.add_triple(subject, predicate, object, 1.0, source_entry_id)
                 .await?;
+            let suffix = match source_entry_id {
+                Some(id) => format!(" (origen: {})", id),
+                None => String::new(),
+            };
             Ok(format!(
-                "Relacion guardada: {} --[{}]--> {}",
-                subject, predicate, object
+                "Relacion guardada: {} --[{}]--> {}{}",
+                subject, predicate, object, suffix
             ))
         } else {
             Ok("Grafo de conocimiento no disponible (sin MemoryPlane)".into())

--- a/daemon/src/memory_plane.rs
+++ b/daemon/src/memory_plane.rs
@@ -14,7 +14,7 @@ use base64::engine::general_purpose::STANDARD as B64;
 use base64::Engine;
 use chrono::{DateTime, Utc};
 use rand::RngCore;
-use rusqlite::{params, Connection};
+use rusqlite::{params, Connection, OptionalExtension};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, HashSet};
@@ -1192,6 +1192,39 @@ enum ArchivedFilter {
     OnlyArchived,
 }
 
+/// Sprint 3 / item 13: when the llama-embeddings server is down,
+/// `add_entry` falls back to `hash_based_embedding_local()` which
+/// produces effectively random vectors. Including those rows in
+/// semantic / hybrid search is noise. Default search paths must
+/// exclude them; only an explicit "include fallback" call surfaces
+/// them. Lexical mode never applies this filter — lexical does not
+/// depend on the embedding so the fallback marker is irrelevant there.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FallbackFilter {
+    ExcludeFallback,
+    IncludeFallback,
+}
+
+impl FallbackFilter {
+    /// Returns `Some("...sql...")` when this filter actually narrows the
+    /// result set (i.e. ExcludeFallback). When the caller opted into
+    /// fallback rows we return `None` so the SQL builder skips the
+    /// clause entirely.
+    fn sql_clause(self, table_alias: &str) -> Option<String> {
+        match self {
+            Self::IncludeFallback => None,
+            Self::ExcludeFallback => {
+                let prefix = if table_alias.is_empty() {
+                    "".to_string()
+                } else {
+                    format!("{}.", table_alias)
+                };
+                Some(format!("{}embedding_source != 'fallback'", prefix))
+            }
+        }
+    }
+}
+
 impl ArchivedFilter {
     /// Returns the SQL WHERE fragment for this filter, ready to AND
     /// with the rest of the conditions. Always wrapped in parentheses
@@ -1284,6 +1317,15 @@ pub struct ReinforcedVaultStatus {
     pub idle_timeout_secs: u64,
     pub seconds_until_relock: Option<u64>,
 }
+
+/// Maximum number of importance updates flushed per short transaction
+/// inside `apply_decay`. Hoisted to module scope (instead of the
+/// previous inlined `const` inside `apply_decay`) so tests can seed
+/// enough rows to exercise the multi-chunk path. Lowered from the
+/// original 500 → 100 to keep that test cheap (a few hundred rows is
+/// enough to cross the chunk boundary several times) at the cost of a
+/// negligibly higher number of small transactions in production.
+pub(crate) const DECAY_CHUNK_SIZE: usize = 100;
 
 impl MemoryPlaneManager {
     pub fn new(data_dir: PathBuf) -> Result<Self> {
@@ -1805,6 +1847,59 @@ impl MemoryPlaneManager {
         Ok(out)
     }
 
+    /// Fetch a single non-archived entry by id, decrypted.
+    ///
+    /// Used by the PATCH handler to refetch the row it just updated
+    /// without paying the cost of `list_entries(N, …)` and without
+    /// missing the entry when the user has more than `N` rows. Returns
+    /// `Ok(None)` if the entry doesn't exist or is archived.
+    pub async fn get_entry(&self, entry_id: &str) -> Result<Option<MemoryEntry>> {
+        let db_path = self.db_path.clone();
+        let entry_id = entry_id.to_string();
+
+        let enc = tokio::task::spawn_blocking(move || {
+            let db = Self::open_db(&db_path)?;
+            let mut stmt = db.prepare(
+                "SELECT entry_id, created_at, updated_at, kind, scope, tags, source,
+                        importance, nonce_b64, ciphertext_b64, plaintext_sha256
+                 FROM memory_entries
+                 WHERE entry_id = ?1
+                   AND (archived IS NULL OR archived = 0)
+                 LIMIT 1",
+            )?;
+            let row = stmt
+                .query_row(params![entry_id], |row| {
+                    let tags_json: String = row.get(5)?;
+                    let tags: Vec<String> = serde_json::from_str(&tags_json).unwrap_or_default();
+                    Ok(EncryptedMemoryEntry {
+                        entry_id: row.get(0)?,
+                        created_at: DateTime::parse_from_rfc3339(&row.get::<_, String>(1)?)
+                            .map(|dt| dt.with_timezone(&Utc))
+                            .unwrap_or_else(|_| Utc::now()),
+                        updated_at: DateTime::parse_from_rfc3339(&row.get::<_, String>(2)?)
+                            .map(|dt| dt.with_timezone(&Utc))
+                            .unwrap_or_else(|_| Utc::now()),
+                        kind: row.get(3)?,
+                        scope: row.get(4)?,
+                        tags,
+                        source: row.get(6)?,
+                        importance: row.get::<_, i32>(7)? as u8,
+                        nonce_b64: row.get(8)?,
+                        ciphertext_b64: row.get(9)?,
+                        plaintext_sha256: row.get(10)?,
+                    })
+                })
+                .optional()?;
+            Ok::<_, anyhow::Error>(row)
+        })
+        .await??;
+
+        match enc {
+            Some(e) => Ok(Some(decrypt_entry(&e)?)),
+            None => Ok(None),
+        }
+    }
+
     /// Search memories within a UTC time range.
     ///
     /// Both `from_utc` and `to_utc` should be RFC3339 UTC strings.
@@ -1882,6 +1977,30 @@ impl MemoryPlaneManager {
             None,
             MemorySearchMode::Hybrid,
             ArchivedFilter::ExcludeArchived,
+            FallbackFilter::ExcludeFallback,
+        )
+        .await
+    }
+
+    /// Sprint 3 / item 13: opt-in escape hatch that *includes* entries
+    /// whose embedding came from the local hash fallback (i.e. when the
+    /// llama-embeddings server was down at insert time). Default search
+    /// paths exclude those rows because their semantic distance is noise.
+    pub async fn search_entries_include_fallback(
+        &self,
+        query: &str,
+        limit: usize,
+        scope: Option<&str>,
+        mode: MemorySearchMode,
+    ) -> Result<Vec<MemorySearchResult>> {
+        self.search_entries_inner(
+            query,
+            limit,
+            scope,
+            None,
+            mode,
+            ArchivedFilter::ExcludeArchived,
+            FallbackFilter::IncludeFallback,
         )
         .await
     }
@@ -1907,6 +2026,7 @@ impl MemoryPlaneManager {
             None,
             MemorySearchMode::Hybrid,
             ArchivedFilter::OnlyArchived,
+            FallbackFilter::ExcludeFallback,
         )
         .await
     }
@@ -1925,6 +2045,7 @@ impl MemoryPlaneManager {
             None,
             mode,
             ArchivedFilter::ExcludeArchived,
+            FallbackFilter::ExcludeFallback,
         )
         .await
     }
@@ -1944,6 +2065,7 @@ impl MemoryPlaneManager {
             Some(tag),
             MemorySearchMode::Hybrid,
             ArchivedFilter::ExcludeArchived,
+            FallbackFilter::ExcludeFallback,
         )
         .await
     }
@@ -1959,6 +2081,7 @@ impl MemoryPlaneManager {
         tag: Option<&str>,
         mode: MemorySearchMode,
         archived_filter: ArchivedFilter,
+        fallback_filter: FallbackFilter,
     ) -> Result<Vec<MemorySearchResult>> {
         let query = normalize_non_empty(query).context("query is required")?;
         let query_lc = query.to_lowercase();
@@ -2004,6 +2127,9 @@ impl MemoryPlaneManager {
                         vec![Box::new(query_embedding_bytes.clone())];
                     let mut where_parts: Vec<String> =
                         vec![archived_filter.sql_clause("me")];
+                    if let Some(clause) = fallback_filter.sql_clause("me") {
+                        where_parts.push(clause);
+                    }
 
                     if let Some(ref s) = scope {
                         where_parts.push("me.scope = ?".to_string());
@@ -2146,6 +2272,9 @@ impl MemoryPlaneManager {
                         vec![Box::new(query_embedding_bytes.clone())];
                     let mut where_parts: Vec<String> =
                         vec![archived_filter.sql_clause("me")];
+                    if let Some(clause) = fallback_filter.sql_clause("me") {
+                        where_parts.push(clause);
+                    }
 
                     if let Some(ref s) = scope {
                         where_parts.push("me.scope = ?".to_string());
@@ -2770,13 +2899,43 @@ impl MemoryPlaneManager {
 
         tokio::task::spawn_blocking(move || {
             let db = Self::open_db(&db_path)?;
+            // Validate source_entry_id (when provided) actually points at
+            // a real memory entry. The LLM may hallucinate IDs; rather
+            // than fail the whole tool call (which is unfriendly and
+            // discards the otherwise-valid triple), we silently drop the
+            // bogus link and keep the triple. A warn! flags it for
+            // future debugging without polluting normal logs.
+            let validated_source = match source.as_deref() {
+                Some(sid) => {
+                    let exists: bool = db
+                        .query_row(
+                            "SELECT EXISTS(SELECT 1 FROM memory_entries WHERE entry_id = ?1)",
+                            params![sid],
+                            |row| row.get::<_, i64>(0).map(|v| v != 0),
+                        )
+                        .unwrap_or(false);
+                    if exists {
+                        Some(sid.to_string())
+                    } else {
+                        log::warn!(
+                            "memory_plane: add_triple called with unknown source_entry_id={} (subject={}, predicate={}, object={}); storing triple unlinked",
+                            sid,
+                            subject,
+                            predicate,
+                            object
+                        );
+                        None
+                    }
+                }
+                None => None,
+            };
             db.execute(
                 "INSERT INTO knowledge_graph (subject, predicate, object, confidence, source_entry_id, created_at, updated_at)
                  VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?6)
                  ON CONFLICT(subject, predicate, object) DO UPDATE SET
                     confidence = MAX(confidence, ?4),
                     updated_at = ?6",
-                params![subject, predicate, object, confidence, source, now],
+                params![subject, predicate, object, confidence, validated_source, now],
             )?;
             Ok(())
         })
@@ -3407,21 +3566,42 @@ impl MemoryPlaneManager {
     /// fine for the daily cadence even at hundreds of thousands of
     /// rows.
     pub async fn apply_decay(&self) -> Result<DecayReport> {
+        // Sprint 3 / item 15: at 500k+ rows the previous implementation
+        // wrapped phase 1 (per-row UPDATE for every decayed entry) inside
+        // a single big transaction, which holds a write lock on the DB
+        // for 30-90s and starves every other writer (add_entry, recall
+        // boost, supervisor sessions). We keep the exact same Rust-side
+        // math (no dependency on SQLite's optional POWER extension) but:
+        //   1. SELECT candidates with NO open transaction
+        //   2. UPDATE phase 1 in CHUNKS of 500 rows per short transaction
+        //   3. PHASE 2 archive stays as a single set-based UPDATE (it
+        //      already was — that's not the slow path)
+        // Lock windows go from ~minutes to ~tens of milliseconds per
+        // chunk, letting writers interleave.
+        //
+        // Chunk size is exposed at module scope (`DECAY_CHUNK_SIZE`) so
+        // tests can seed enough rows to exercise the multi-chunk path
+        // without depending on a literal hidden inside this function.
+
         let db_path = self.db_path.clone();
         tokio::task::spawn_blocking(move || {
             let db = Self::open_db(&db_path)?;
-            let tx = db.unchecked_transaction()?;
             let now_utc = chrono::Utc::now();
 
-            // -- Phase 1: collect all candidate rows in one SELECT.
-            //
-            // We pull the link count via a correlated subquery so the
-            // result already carries everything needed to compute the
-            // new importance in Rust. The query also includes
-            // importance >= 70 entries because they CAN still receive
-            // the connection bonus (just not the decay term).
-            let updates: Vec<(String, i32)> = {
-                let mut stmt = tx.prepare(
+            // -- Phase 1a: collect all candidate rows in one SELECT,
+            // outside any transaction so writers are not blocked while
+            // we read+compute. We pull the link count via a correlated
+            // subquery so the result already carries everything needed
+            // to compute the new importance in Rust. The query also
+            // includes importance >= 70 entries because they CAN still
+            // receive the connection bonus (just not the decay term).
+            // Each row carries (entry_id, old_importance, new_importance)
+            // so the chunked UPDATE can guard against lost updates: if
+            // a concurrent writer modified `importance` between this
+            // SELECT and the UPDATE, the WHERE clause won't match and
+            // the decay simply skips that row.
+            let updates: Vec<(String, i32, i32)> = {
+                let mut stmt = db.prepare(
                     "SELECT
                         e.entry_id,
                         e.importance,
@@ -3446,7 +3626,7 @@ impl MemoryPlaneManager {
                     ))
                 })?;
 
-                let mut out: Vec<(String, i32)> = Vec::new();
+                let mut out: Vec<(String, i32, i32)> = Vec::new();
                 for row in rows {
                     let (entry_id, importance, ts, access_count, link_count) = row?;
 
@@ -3475,18 +3655,39 @@ impl MemoryPlaneManager {
                     let new_importance = (decayed + bonus).clamp(0.0, 100.0).round() as i32;
 
                     if new_importance != importance {
-                        out.push((entry_id, new_importance));
+                        out.push((entry_id, importance, new_importance));
                     }
                 }
                 out
             };
 
-            let decayed = updates.len();
-            for (id, new_imp) in &updates {
-                tx.execute(
-                    "UPDATE memory_entries SET importance = ?1 WHERE entry_id = ?2",
-                    params![new_imp, id],
-                )?;
+            // -- Phase 1b: apply UPDATEs in chunks. Each chunk gets its
+            // own short transaction so the write lock is released
+            // between chunks; other writers can interleave. We do not
+            // sleep between chunks: SQLite's busy_timeout already gives
+            // contending writers room to grab the lock at commit time.
+            // The `AND importance = ?4` guard prevents lost updates: if
+            // a concurrent writer (e.g. boost_on_access, add_entry on
+            // duplicate, dashboard PATCH) modified the row between the
+            // outer SELECT and this UPDATE, the row count is 0 and we
+            // simply skip — the concurrent write wins. Decay will
+            // re-evaluate on the next daily run.
+            let now_ts = now_utc.to_rfc3339();
+            let mut total_decayed: usize = 0;
+            for chunk in updates.chunks(DECAY_CHUNK_SIZE) {
+                let tx = db.unchecked_transaction()?;
+                {
+                    let mut stmt = tx.prepare(
+                        "UPDATE memory_entries
+                            SET importance = ?1, updated_at = ?2
+                          WHERE entry_id = ?3 AND importance = ?4",
+                    )?;
+                    for (id, old_imp, new_imp) in chunk {
+                        let changed = stmt.execute(params![new_imp, now_ts, id, old_imp])?;
+                        total_decayed += changed;
+                    }
+                }
+                tx.commit()?;
             }
 
             // -- Phase 2: ARCHIVE low-importance old entries.
@@ -3510,7 +3711,7 @@ impl MemoryPlaneManager {
             let cutoff_90 = (now_utc - chrono::Duration::days(90)).to_rfc3339();
             let cutoff_180 = (now_utc - chrono::Duration::days(180)).to_rfc3339();
 
-            let archived = tx.execute(
+            let archived = db.execute(
                 "UPDATE memory_entries
                  SET archived = 1
                  WHERE (permanent IS NULL OR permanent = 0)
@@ -3521,13 +3722,11 @@ impl MemoryPlaneManager {
                    )",
                 params![cutoff_90, cutoff_180],
             )?;
-
-            tx.commit()?;
             // The `deleted` field now means "newly archived this pass".
             // We keep the field name for backward compatibility with
             // existing logging / dashboards that already read it.
             Ok::<_, anyhow::Error>(DecayReport {
-                decayed,
+                decayed: total_decayed,
                 deleted: archived,
             })
         })
@@ -23850,6 +24049,291 @@ mod tests {
             .suggested_questions
             .iter()
             .any(|q| q.contains("control de diabetes")));
+
+        std::fs::remove_dir_all(dir).ok();
+    }
+
+    /// Sprint 3 / item 13: when the embeddings server is down every new
+    /// row gets `embedding_source = 'fallback'` (random vector). The
+    /// default semantic / hybrid search MUST exclude those so callers
+    /// don't get noise; an explicit opt-in include path must surface
+    /// them when the user asks for it.
+    #[tokio::test]
+    async fn semantic_search_excludes_fallback_by_default() {
+        let dir = temp_dir("memory-plane-fallback");
+        let mgr = MemoryPlaneManager::new(dir.clone()).unwrap();
+        mgr.initialize().await.unwrap();
+
+        // Both rows are inserted with hash fallback (no ai_manager wired
+        // in tests). We then promote one to 'real' via raw SQL so the
+        // filter has something to keep.
+        let real = mgr
+            .add_entry("note", "user", &[], None, 60, "alpha bravo charlie")
+            .await
+            .unwrap();
+        let fb = mgr
+            .add_entry("note", "user", &[], None, 60, "delta echo foxtrot")
+            .await
+            .unwrap();
+
+        let db_path = dir.join("memory.db");
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute(
+            "UPDATE memory_entries SET embedding_source = 'real' WHERE entry_id = ?1",
+            params![&real.entry_id],
+        )
+        .unwrap();
+        drop(conn);
+
+        // Default path: fallback row must be filtered out.
+        let hits = mgr
+            .search_entries_with_mode("alpha", 10, None, MemorySearchMode::Semantic)
+            .await
+            .unwrap();
+        assert!(
+            hits.iter().any(|h| h.entry.entry_id == real.entry_id),
+            "real-embedding row must be returned"
+        );
+        assert!(
+            !hits.iter().any(|h| h.entry.entry_id == fb.entry_id),
+            "fallback-embedding row must be filtered out by default"
+        );
+
+        // Opt-in path: caller asked for fallbacks, so both can appear.
+        let all = mgr
+            .search_entries_include_fallback("alpha", 10, None, MemorySearchMode::Semantic)
+            .await
+            .unwrap();
+        assert!(
+            all.iter().any(|h| h.entry.entry_id == fb.entry_id),
+            "include_fallback path must surface fallback rows"
+        );
+
+        std::fs::remove_dir_all(dir).ok();
+    }
+
+    /// Sprint 3 / item 15: chunked decay must produce the same end
+    /// state as the old single-tx version — permanent entries are
+    /// untouched, importance decays for old rows, low+old rows get
+    /// archived. Boundary check: more rows than DECAY_CHUNK_SIZE so we
+    /// actually exercise the multi-chunk path.
+    #[tokio::test]
+    async fn apply_decay_chunked_preserves_semantics() {
+        let dir = temp_dir("memory-plane-decay-chunked");
+        let mgr = MemoryPlaneManager::new(dir.clone()).unwrap();
+        mgr.initialize().await.unwrap();
+
+        // Seed 3 representative rows + back-date them via raw SQL so
+        // decay actually fires (it's a no-op for fresh rows).
+        let perm = mgr
+            .add_entry("note", "user", &[], None, 50, "permanent")
+            .await
+            .unwrap();
+        let decay_target = mgr
+            .add_entry("note", "user", &[], None, 50, "should-decay")
+            .await
+            .unwrap();
+        let archive_target = mgr
+            .add_entry("note", "user", &[], None, 5, "should-archive")
+            .await
+            .unwrap();
+
+        let db_path = dir.join("memory.db");
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let old_ts = (chrono::Utc::now() - chrono::Duration::days(120)).to_rfc3339();
+        conn.execute(
+            "UPDATE memory_entries SET permanent = 1 WHERE entry_id = ?1",
+            params![&perm.entry_id],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE memory_entries SET updated_at = ?1, last_accessed = ?1
+             WHERE entry_id IN (?2, ?3)",
+            params![&old_ts, &decay_target.entry_id, &archive_target.entry_id],
+        )
+        .unwrap();
+        drop(conn);
+
+        let report = mgr.apply_decay().await.unwrap();
+        assert!(report.decayed >= 1, "decay_target should have decayed");
+        assert!(report.deleted >= 1, "archive_target should have archived");
+
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let perm_imp: i32 = conn
+            .query_row(
+                "SELECT importance FROM memory_entries WHERE entry_id = ?1",
+                params![&perm.entry_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(perm_imp, 50, "permanent rows must not decay");
+
+        let archived: i32 = conn
+            .query_row(
+                "SELECT archived FROM memory_entries WHERE entry_id = ?1",
+                params![&archive_target.entry_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(archived, 1, "low+old row must be archived");
+
+        std::fs::remove_dir_all(dir).ok();
+    }
+
+    /// Sprint 3 / item 15 — boundary check: seed more rows than
+    /// `DECAY_CHUNK_SIZE` so phase 1b actually iterates over multiple
+    /// chunks. The 3-row sibling above only covers the single-chunk
+    /// path; this one validates the loop itself plus the lost-update
+    /// guard (`AND importance = ?`) by asserting the reported decay
+    /// count matches what we expect after back-dating every row.
+    #[tokio::test]
+    async fn apply_decay_chunked_with_many_rows() {
+        let dir = temp_dir("memory-plane-decay-many");
+        let mgr = MemoryPlaneManager::new(dir.clone()).unwrap();
+        mgr.initialize().await.unwrap();
+
+        // Seed > 2 * DECAY_CHUNK_SIZE rows so the chunk loop runs at
+        // least three times. Importance is set to 50 (decays) and
+        // every row will be back-dated below.
+        let rows = DECAY_CHUNK_SIZE * 2 + 50;
+        let mut ids = Vec::with_capacity(rows);
+        for i in 0..rows {
+            let entry = mgr
+                .add_entry("note", "user", &[], None, 50, &format!("decay row {}", i))
+                .await
+                .unwrap();
+            ids.push(entry.entry_id);
+        }
+
+        // Back-date every seeded row 120 days so decay actually fires.
+        let db_path = dir.join("memory.db");
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let old_ts = (chrono::Utc::now() - chrono::Duration::days(120)).to_rfc3339();
+        conn.execute(
+            "UPDATE memory_entries SET updated_at = ?1, last_accessed = ?1",
+            params![&old_ts],
+        )
+        .unwrap();
+        drop(conn);
+
+        let report = mgr.apply_decay().await.unwrap();
+        // Every row had identical inputs → all should decay.
+        assert_eq!(
+            report.decayed, rows,
+            "every back-dated row should have decayed across multiple chunks"
+        );
+
+        std::fs::remove_dir_all(dir).ok();
+    }
+
+    /// Sprint 4 / item 17: when `add_triple` is called with a
+    /// `source_entry_id`, hard_delete on that entry must cascade-clean
+    /// the triple. This is the behavioural proof that Axi tools should
+    /// pass the source instead of `None`.
+    #[tokio::test]
+    async fn add_triple_with_source_entry_id_links_to_entry() {
+        let dir = temp_dir("memory-plane-kg-source");
+        let mgr = MemoryPlaneManager::new(dir.clone()).unwrap();
+        mgr.initialize().await.unwrap();
+
+        let entry = mgr
+            .add_entry("note", "user", &[], None, 50, "hector compro una laptop")
+            .await
+            .unwrap();
+        mgr.add_triple("hector", "owns", "laptop", 1.0, Some(&entry.entry_id))
+            .await
+            .unwrap();
+
+        let db_path = dir.join("memory.db");
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM knowledge_graph WHERE source_entry_id = ?1",
+                params![&entry.entry_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1, "triple must be linked to the source entry");
+
+        std::fs::remove_dir_all(dir).ok();
+    }
+
+    /// LLM hallucination guard: if `add_triple` is called with a
+    /// `source_entry_id` that doesn't exist, the triple is still
+    /// stored (we don't lose the LLM's output) but the bogus link is
+    /// dropped to NULL so we never end up with orphan FKs in the KG.
+    #[tokio::test]
+    async fn add_triple_with_unknown_source_entry_id_stores_unlinked() {
+        let dir = temp_dir("memory-plane-kg-bogus-source");
+        let mgr = MemoryPlaneManager::new(dir.clone()).unwrap();
+        mgr.initialize().await.unwrap();
+
+        mgr.add_triple(
+            "alice",
+            "knows",
+            "bob",
+            0.9,
+            Some("entry-that-does-not-exist"),
+        )
+        .await
+        .unwrap();
+
+        let db_path = dir.join("memory.db");
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let (count, source): (i64, Option<String>) = conn
+            .query_row(
+                "SELECT COUNT(*), MAX(source_entry_id) FROM knowledge_graph
+                 WHERE subject = 'alice' AND predicate = 'knows' AND object = 'bob'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(count, 1, "triple must be stored even if source is bogus");
+        assert!(
+            source.is_none(),
+            "bogus source_entry_id must be dropped to NULL, got {:?}",
+            source
+        );
+
+        std::fs::remove_dir_all(dir).ok();
+    }
+
+    /// FIX 4: `get_entry` returns the freshly-updated row even when
+    /// the entry sits beyond any list-recency window. Excludes
+    /// archived rows.
+    #[tokio::test]
+    async fn get_entry_returns_single_row_and_skips_archived() {
+        let dir = temp_dir("memory-plane-get-entry");
+        let mgr = MemoryPlaneManager::new(dir.clone()).unwrap();
+        mgr.initialize().await.unwrap();
+
+        let entry = mgr
+            .add_entry("note", "user", &[], None, 42, "single-entry getter probe")
+            .await
+            .unwrap();
+
+        let fetched = mgr.get_entry(&entry.entry_id).await.unwrap();
+        assert!(fetched.is_some(), "fresh entry must be fetched by id");
+        assert_eq!(fetched.as_ref().unwrap().entry_id, entry.entry_id);
+
+        // Missing id → None, not Err.
+        let missing = mgr.get_entry("not-a-real-id").await.unwrap();
+        assert!(missing.is_none(), "unknown id must yield None");
+
+        // Archived row must be skipped (matches list_entries behavior).
+        let db_path = dir.join("memory.db");
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute(
+            "UPDATE memory_entries SET archived = 1 WHERE entry_id = ?1",
+            params![&entry.entry_id],
+        )
+        .unwrap();
+        drop(conn);
+        let after_archive = mgr.get_entry(&entry.entry_id).await.unwrap();
+        assert!(
+            after_archive.is_none(),
+            "archived rows must not surface via get_entry"
+        );
 
         std::fs::remove_dir_all(dir).ok();
     }

--- a/daemon/src/memory_plane.rs
+++ b/daemon/src/memory_plane.rs
@@ -17125,6 +17125,13 @@ mod tests {
         .await
         .unwrap();
 
+        // Promote both rows to 'real' so the default fallback filter doesn't
+        // hide them (test env has no LLM, so add_entry stores 'fallback').
+        let conn = Connection::open(dir.join(DB_FILE)).unwrap();
+        conn.execute("UPDATE memory_entries SET embedding_source = 'real'", [])
+            .unwrap();
+        drop(conn);
+
         let hits = mgr
             .search_entries_with_mode(
                 "runtime approval automation",
@@ -17173,6 +17180,16 @@ mod tests {
             .add_entry("note", "user", &[], None, 10, "delete me")
             .await
             .unwrap();
+
+        // Promote to 'real' so search_archived (which excludes fallback by
+        // default) can surface the soft-deleted row below.
+        let conn = Connection::open(dir.join(DB_FILE)).unwrap();
+        conn.execute(
+            "UPDATE memory_entries SET embedding_source = 'real' WHERE entry_id = ?1",
+            params![created.entry_id.as_str()],
+        )
+        .unwrap();
+        drop(conn);
 
         // Default delete is now soft (archive) — `list_entries` filters
         // archived rows out, so the live view is empty.
@@ -17370,6 +17387,12 @@ mod tests {
         )
         .await
         .unwrap();
+
+        // Promote to 'real' so the default fallback filter doesn't hide it.
+        let conn = Connection::open(dir.join(DB_FILE)).unwrap();
+        conn.execute("UPDATE memory_entries SET embedding_source = 'real'", [])
+            .unwrap();
+        drop(conn);
 
         let hits = mgr
             .search_entries_with_mode(
@@ -18571,6 +18594,14 @@ mod tests {
             )
             .await
             .unwrap();
+
+        // Promote both rows to 'real' so the default fallback filter (used
+        // by search_entries / search_archived) doesn't hide them.
+        let conn = Connection::open(dir.join(DB_FILE)).unwrap();
+        conn.execute("UPDATE memory_entries SET embedding_source = 'real'", [])
+            .unwrap();
+        drop(conn);
+
         // Force the old one to be archived via decay.
         backdate(&dir, &old.entry_id, 100);
         let _ = mgr.apply_decay().await.unwrap();

--- a/daemon/src/memory_plane.rs
+++ b/daemon/src/memory_plane.rs
@@ -2073,6 +2073,7 @@ impl MemoryPlaneManager {
     /// Inner implementation; the public wrappers fix the
     /// `archived_filter` so callers cannot accidentally surface
     /// archived entries from the live search path.
+    #[allow(clippy::too_many_arguments)]
     async fn search_entries_inner(
         &self,
         query: &str,

--- a/docs/architecture/memory-system.md
+++ b/docs/architecture/memory-system.md
@@ -169,3 +169,22 @@ destructivas: requieren `confirm: true` por defecto (gate-able via
 `LIFEOS_AXI_REQUIRE_CONFIRM_DESTRUCTIVE`), rate-limit de 10 ops/hora,
 y audit log append-only en
 `~/.local/share/lifeos/destructive_actions.log` (mode 0600).
+
+## Sprint 3+4 quick wins (2026-04-26 — PR #46)
+
+- **Filter `embedding_source != 'fallback'` in semantic search defaults**: when
+  the embedding server is down, hash-fallback embeddings produce noise in
+  cosine search. Excluded by default; opt-in via
+  `search_entries_include_fallback()` for diagnostics.
+- **Batched `apply_decay`**: replaces single 30-90s lock at 500k rows with
+  chunked transactions (`DECAY_CHUNK_SIZE = 100`). Lost-update guard via
+  `WHERE importance = ?old` so concurrent writers win.
+- **`source_entry_id` from LLM in KG triples**: the `graph_add` tool now
+  accepts an optional `source_entry_id` arg so the LLM can link a fact back
+  to the memory entry that motivated it. `add_triple` validates existence;
+  hallucinated IDs drop to `NULL` with a `warn!` log (triple still stored,
+  just unlinked).
+- **`PATCH /api/v1/memory/entries/:id`**: dashboard can now edit an entry's
+  content / importance / tags without going through the LLM tool path. New
+  `MemoryPlaneManager::get_entry()` single-row getter avoids the prior
+  `list_entries(200, ...)` workaround.


### PR DESCRIPTION
## Summary

Phase A of Sprint 3+4 from the 2026-04-25 audit. 4 surgical changes shipped after JD round 1 + targeted fixes.

## What ships

### Item 13: Filter \`embedding_source != 'fallback'\` in semantic search defaults
When llama-embeddings is down, hash-fallback embeddings are random vectors. Excluding them from semantic search by default removes noise. New \`FallbackFilter\` enum mirrors \`ArchivedFilter\`. Lexical untouched.

### Item 15: Batched \`apply_decay\` (no giant tx)
Replace single-tx 30-90s lock with chunked transactions (100 rows each). Lost-update guard added: \`WHERE importance = ?old\` so concurrent writes win.

### Item 17: \`source_entry_id\` from LLM in KG triples
\`execute_graph_add\` reads optional \`args["source_entry_id"]\` and passes to \`add_triple\`. \`add_triple\` validates existence; hallucinated IDs drop to NULL with warn (triple still stored, just unlinked).

### Item 18: PATCH \`/api/v1/memory/entries/:id\`
New handler. Validates importance 0-100, tags ≤ 20. New \`get_entry\` single-row getter replaces the list_entries refetch (no more silent null past 200 entries).

## JD round 1 findings — addressed

- ✅ source_entry_id existence validation
- ✅ DECAY_CHUNK_SIZE module-level const + new multi-chunk test
- ✅ Lost-update guard in chunked UPDATE
- ✅ get_entry replaces list_entries refetch

## Tests added (6 new)

semantic_search_excludes_fallback_by_default · apply_decay_chunked_preserves_semantics · apply_decay_chunked_with_many_rows · add_triple_with_source_entry_id_links_to_entry · add_triple_with_unknown_source_entry_id_stores_unlinked · get_entry_returns_single_row_and_skips_archived

## Test plan
- [ ] CI passes (compile + clippy + tests)
- [ ] Image builds + pushes to GHCR
- [ ] On laptop: semantic search returns relevant results
- [ ] On laptop: decay daily task completes without long lock
- [ ] On laptop: dashboard PATCH endpoint accessible

## Out of scope (deferred)

Sprint 2 leftovers (connection pool, vec0 KNN proper, embedding queue), Sprint 3 items 11-12-14 (FTS5, dedup streaming, meeting promotion), Sprint 4 item 16 (unified search). Memory audit at \`project_axi_memory_audit_2026_04_25.md\`.