### PR TITLE
feat(dashboard): Freelance UI — clientes, sesiones, facturas, tarifas, resumen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "life"
-version = "0.8.15"
+version = "0.8.16"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2626,7 +2626,7 @@ dependencies = [
 
 [[package]]
 name = "lifeos-integration-tests"
-version = "0.8.15"
+version = "0.8.16"
 dependencies = [
  "life",
  "serde_json",
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "lifeosd"
-version = "0.8.15"
+version = "0.8.16"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.15"
+version = "0.8.16"
 
 [workspace.metadata.lifeos]
 codename = "Axolotl"

--- a/daemon/static/dashboard/app.js
+++ b/daemon/static/dashboard/app.js
@@ -4392,6 +4392,557 @@ async function togglePrivacyMode() {
   if (btn) btn.addEventListener('click', togglePrivacyMode);
 })();
 
+// ==================== Freelance Module ====================
+const freelanceState = {
+  clientes: [],
+  sesiones: [],
+  facturas: [],
+  loaded: { clientes: false, sesiones: false, facturas: false, overview: false, tarifas: false },
+};
+
+function flFmtMoney(n) {
+  if (n === null || n === undefined || Number.isNaN(Number(n))) return '—';
+  return Number(n).toLocaleString('es-MX', { style: 'currency', currency: 'MXN', minimumFractionDigits: 2 });
+}
+function flFmtHours(n) {
+  if (n === null || n === undefined) return '—';
+  return `${Number(n).toFixed(2)}h`;
+}
+function flFmtDate(s) {
+  if (!s) return '—';
+  return s.length > 10 ? s.slice(0, 10) : s;
+}
+function flEsc(s) {
+  if (s === null || s === undefined) return '';
+  return String(s).replace(/[&<>"']/g, c => ({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;' }[c]));
+}
+function flClienteNombre(id) {
+  const c = freelanceState.clientes.find(x => x.cliente_id === id);
+  return c ? c.nombre : id;
+}
+
+// --- API wrappers ---
+async function freelanceListClientes(estado) {
+  const q = estado ? `?estado=${encodeURIComponent(estado)}` : '';
+  const data = await api('GET', `/freelance/clientes${q}`);
+  return data.clientes || [];
+}
+async function freelanceCreateCliente(body) {
+  return api('POST', '/freelance/clientes', body);
+}
+async function freelanceUpdateCliente(id, body) {
+  return api('PATCH', `/freelance/clientes/${encodeURIComponent(id)}`, body);
+}
+async function freelanceDeleteCliente(id) {
+  return api('DELETE', `/freelance/clientes/${encodeURIComponent(id)}`);
+}
+async function freelanceListSesiones(filters) {
+  const params = new URLSearchParams();
+  if (filters?.cliente_id) params.set('cliente_id', filters.cliente_id);
+  if (filters?.desde) params.set('desde', filters.desde);
+  if (filters?.hasta) params.set('hasta', filters.hasta);
+  const qs = params.toString();
+  const data = await api('GET', `/freelance/sesiones${qs ? '?' + qs : ''}`);
+  return data.sesiones || [];
+}
+async function freelanceCreateSesion(body) {
+  return api('POST', '/freelance/sesiones', body);
+}
+async function freelanceUpdateSesion(id, body) {
+  return api('PATCH', `/freelance/sesiones/${encodeURIComponent(id)}`, body);
+}
+async function freelanceDeleteSesion(id) {
+  return api('DELETE', `/freelance/sesiones/${encodeURIComponent(id)}`);
+}
+async function freelanceListFacturas(filters) {
+  const params = new URLSearchParams();
+  if (filters?.cliente_id) params.set('cliente_id', filters.cliente_id);
+  if (filters?.estado) params.set('estado', filters.estado);
+  const qs = params.toString();
+  const data = await api('GET', `/freelance/facturas${qs ? '?' + qs : ''}`);
+  return data.facturas || [];
+}
+async function freelanceCreateFactura(body) {
+  return api('POST', '/freelance/facturas', body);
+}
+async function freelancePagarFactura(id, fecha) {
+  return api('PATCH', `/freelance/facturas/${encodeURIComponent(id)}`, { fecha_pago: fecha });
+}
+async function freelanceCancelarFactura(id, razon) {
+  return api('PATCH', `/freelance/facturas/${encodeURIComponent(id)}`, { cancelar: true, razon_cancelacion: razon || null });
+}
+async function freelanceOverview(mes) {
+  const q = mes ? `?mes=${encodeURIComponent(mes)}` : '';
+  const data = await api('GET', `/freelance/overview${q}`);
+  return data.overview || {};
+}
+async function freelanceTopClientes() {
+  const data = await api('GET', '/freelance/top-clientes');
+  return data.clientes || [];
+}
+
+// --- Cliente helpers ---
+async function ensureClientesLoaded(force) {
+  if (!force && freelanceState.loaded.clientes) return freelanceState.clientes;
+  const estado = document.getElementById('fl-clientes-filter-estado')?.value || '';
+  freelanceState.clientes = await freelanceListClientes(estado || null);
+  freelanceState.loaded.clientes = true;
+  populateClienteSelectors();
+  return freelanceState.clientes;
+}
+
+function populateClienteSelectors() {
+  const selectors = ['fl-sesion-filter-cliente', 'fl-factura-filter-cliente', 'fl-sesion-cliente', 'fl-factura-cliente'];
+  selectors.forEach(id => {
+    const sel = document.getElementById(id);
+    if (!sel) return;
+    const includeAll = id.includes('filter');
+    const current = sel.value;
+    sel.innerHTML = '';
+    if (includeAll) {
+      const opt = document.createElement('option');
+      opt.value = '';
+      opt.textContent = 'Todos';
+      sel.appendChild(opt);
+    } else {
+      const opt = document.createElement('option');
+      opt.value = '';
+      opt.textContent = 'Selecciona cliente...';
+      sel.appendChild(opt);
+    }
+    freelanceState.clientes.forEach(c => {
+      const opt = document.createElement('option');
+      opt.value = c.cliente_id;
+      opt.textContent = c.nombre;
+      sel.appendChild(opt);
+    });
+    if (current) sel.value = current;
+  });
+}
+
+// --- Render: Clientes ---
+function renderFreelanceClientes() {
+  const container = document.getElementById('fl-clientes-list');
+  if (!container) return;
+  const list = freelanceState.clientes;
+  if (!list.length) {
+    container.innerHTML = '<p class="task-empty">Sin clientes. Crea el primero con "+ Nuevo cliente".</p>';
+    return;
+  }
+  const rows = list.map(c => `
+    <tr>
+      <td><strong>${flEsc(c.nombre)}</strong>${c.contacto_principal ? `<br><small class="fl-muted">${flEsc(c.contacto_principal)}</small>` : ''}</td>
+      <td>${flEsc(c.modalidad || 'horas')}</td>
+      <td>${c.tarifa_hora != null ? flFmtMoney(c.tarifa_hora) : '—'}</td>
+      <td>${c.retainer_mensual != null ? flFmtMoney(c.retainer_mensual) : '—'}</td>
+      <td><span class="fl-badge fl-badge-${flEsc(c.estado)}">${flEsc(c.estado)}</span></td>
+      <td class="fl-actions">
+        <button type="button" class="quick-action-btn fl-btn-sm" data-fl-edit-cliente="${flEsc(c.cliente_id)}">Editar</button>
+        <button type="button" class="quick-action-btn quick-action-secondary fl-btn-sm" data-fl-del-cliente="${flEsc(c.cliente_id)}">Terminar</button>
+      </td>
+    </tr>
+  `).join('');
+  container.innerHTML = `
+    <table class="freelance-table">
+      <thead><tr><th>Nombre</th><th>Modalidad</th><th>Tarifa/h</th><th>Retainer</th><th>Estado</th><th>Acciones</th></tr></thead>
+      <tbody>${rows}</tbody>
+    </table>`;
+  container.querySelectorAll('[data-fl-edit-cliente]').forEach(btn => {
+    btn.addEventListener('click', () => openClienteDialog(btn.dataset.flEditCliente));
+  });
+  container.querySelectorAll('[data-fl-del-cliente]').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      if (!confirm('Marcar cliente como terminado?')) return;
+      try {
+        await freelanceDeleteCliente(btn.dataset.flDelCliente);
+        await ensureClientesLoaded(true);
+        renderFreelanceClientes();
+      } catch (e) { alert('Error: ' + e.message); }
+    });
+  });
+}
+
+function openClienteDialog(id) {
+  const dlg = document.getElementById('fl-cliente-dialog');
+  if (!dlg) return;
+  document.getElementById('fl-cliente-form-error').textContent = '';
+  const editRow = document.getElementById('fl-cliente-estado-row');
+  if (id) {
+    const c = freelanceState.clientes.find(x => x.cliente_id === id);
+    if (!c) return;
+    document.getElementById('fl-cliente-form-title').textContent = 'Editar cliente';
+    document.getElementById('fl-cliente-id').value = c.cliente_id;
+    document.getElementById('fl-cliente-nombre').value = c.nombre || '';
+    document.getElementById('fl-cliente-modalidad').value = c.modalidad || 'horas';
+    document.getElementById('fl-cliente-tarifa').value = c.tarifa_hora ?? '';
+    document.getElementById('fl-cliente-retainer').value = c.retainer_mensual ?? '';
+    document.getElementById('fl-cliente-horas-comp').value = c.horas_comprometidas_mes ?? '';
+    document.getElementById('fl-cliente-fecha-inicio').value = flFmtDate(c.fecha_inicio);
+    document.getElementById('fl-cliente-contacto').value = c.contacto_principal || '';
+    document.getElementById('fl-cliente-email').value = c.contacto_email || '';
+    document.getElementById('fl-cliente-telefono').value = c.contacto_telefono || '';
+    document.getElementById('fl-cliente-rfc').value = c.rfc || '';
+    document.getElementById('fl-cliente-notas').value = c.notas || '';
+    document.getElementById('fl-cliente-estado').value = c.estado || 'activo';
+    if (editRow) editRow.style.display = '';
+  } else {
+    document.getElementById('fl-cliente-form-title').textContent = 'Nuevo cliente';
+    document.getElementById('fl-cliente-id').value = '';
+    document.getElementById('fl-cliente-form').reset();
+    if (editRow) editRow.style.display = 'none';
+  }
+  dlg.showModal();
+}
+
+async function submitClienteForm(ev) {
+  ev.preventDefault();
+  const id = document.getElementById('fl-cliente-id').value;
+  const errEl = document.getElementById('fl-cliente-form-error');
+  errEl.textContent = '';
+  const body = {
+    nombre: document.getElementById('fl-cliente-nombre').value.trim(),
+    modalidad: document.getElementById('fl-cliente-modalidad').value || null,
+    tarifa_hora: parseFloat(document.getElementById('fl-cliente-tarifa').value) || null,
+    retainer_mensual: parseFloat(document.getElementById('fl-cliente-retainer').value) || null,
+    horas_comprometidas_mes: parseInt(document.getElementById('fl-cliente-horas-comp').value) || null,
+    fecha_inicio: document.getElementById('fl-cliente-fecha-inicio').value || null,
+    contacto_principal: document.getElementById('fl-cliente-contacto').value || null,
+    contacto_email: document.getElementById('fl-cliente-email').value || null,
+    contacto_telefono: document.getElementById('fl-cliente-telefono').value || null,
+    rfc: document.getElementById('fl-cliente-rfc').value || null,
+    notas: document.getElementById('fl-cliente-notas').value || null,
+  };
+  if (id) body.estado = document.getElementById('fl-cliente-estado').value;
+  if (!body.nombre) { errEl.textContent = 'Nombre requerido'; return; }
+  try {
+    if (id) await freelanceUpdateCliente(id, body);
+    else await freelanceCreateCliente(body);
+    document.getElementById('fl-cliente-dialog').close();
+    await ensureClientesLoaded(true);
+    renderFreelanceClientes();
+    renderFreelanceTarifas();
+  } catch (e) { errEl.textContent = e.message; }
+}
+
+// --- Render: Sesiones ---
+function renderFreelanceSesiones() {
+  const container = document.getElementById('fl-sesiones-list');
+  if (!container) return;
+  const list = freelanceState.sesiones;
+  if (!list.length) {
+    container.innerHTML = '<p class="task-empty">Sin sesiones registradas.</p>';
+    return;
+  }
+  const rows = list.map(s => `
+    <tr>
+      <td>${flFmtDate(s.fecha)}</td>
+      <td>${flEsc(flClienteNombre(s.cliente_id))}</td>
+      <td>${flFmtHours(s.horas)}</td>
+      <td>${flEsc(s.descripcion || '')}</td>
+      <td>${s.facturable ? '<span class="val-ok">Si</span>' : '<span class="val-error">No</span>'}</td>
+      <td>${s.factura_id ? '<span class="fl-badge fl-badge-pagada">Facturada</span>' : '<span class="fl-badge">Pendiente</span>'}</td>
+      <td class="fl-actions">
+        <button type="button" class="quick-action-btn quick-action-secondary fl-btn-sm" data-fl-del-sesion="${flEsc(s.sesion_id)}">Borrar</button>
+      </td>
+    </tr>`).join('');
+  container.innerHTML = `
+    <table class="freelance-table">
+      <thead><tr><th>Fecha</th><th>Cliente</th><th>Horas</th><th>Descripcion</th><th>Facturable</th><th>Estado</th><th>Acciones</th></tr></thead>
+      <tbody>${rows}</tbody>
+    </table>`;
+  container.querySelectorAll('[data-fl-del-sesion]').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      if (!confirm('Borrar sesion?')) return;
+      try {
+        await freelanceDeleteSesion(btn.dataset.flDelSesion);
+        await refreshSesiones();
+      } catch (e) { alert('Error: ' + e.message); }
+    });
+  });
+}
+
+async function refreshSesiones() {
+  const filters = {
+    cliente_id: document.getElementById('fl-sesion-filter-cliente')?.value || null,
+    desde: document.getElementById('fl-sesion-filter-desde')?.value || null,
+    hasta: document.getElementById('fl-sesion-filter-hasta')?.value || null,
+  };
+  freelanceState.sesiones = await freelanceListSesiones(filters);
+  renderFreelanceSesiones();
+}
+
+function openSesionDialog() {
+  const dlg = document.getElementById('fl-sesion-dialog');
+  if (!dlg) return;
+  document.getElementById('fl-sesion-form-error').textContent = '';
+  document.getElementById('fl-sesion-form').reset();
+  document.getElementById('fl-sesion-facturable').checked = true;
+  document.getElementById('fl-sesion-fecha').value = new Date().toISOString().slice(0, 10);
+  populateClienteSelectors();
+  dlg.showModal();
+}
+
+async function submitSesionForm(ev) {
+  ev.preventDefault();
+  const errEl = document.getElementById('fl-sesion-form-error');
+  errEl.textContent = '';
+  const cliente_id = document.getElementById('fl-sesion-cliente').value;
+  const horas = parseFloat(document.getElementById('fl-sesion-horas').value);
+  if (!cliente_id) { errEl.textContent = 'Cliente requerido'; return; }
+  if (!horas || horas <= 0) { errEl.textContent = 'Horas debe ser > 0'; return; }
+  const body = {
+    cliente_id,
+    horas,
+    fecha: document.getElementById('fl-sesion-fecha').value || null,
+    hora_inicio: document.getElementById('fl-sesion-hora-inicio').value || null,
+    hora_fin: document.getElementById('fl-sesion-hora-fin').value || null,
+    descripcion: document.getElementById('fl-sesion-descripcion').value || null,
+    facturable: document.getElementById('fl-sesion-facturable').checked,
+  };
+  try {
+    await freelanceCreateSesion(body);
+    document.getElementById('fl-sesion-dialog').close();
+    await refreshSesiones();
+  } catch (e) { errEl.textContent = e.message; }
+}
+
+// --- Render: Facturas ---
+function renderFreelanceFacturas() {
+  const container = document.getElementById('fl-facturas-list');
+  if (!container) return;
+  const list = freelanceState.facturas;
+  if (!list.length) {
+    container.innerHTML = '<p class="task-empty">Sin facturas.</p>';
+    return;
+  }
+  const rows = list.map(f => `
+    <tr>
+      <td>${flEsc(f.numero_externo || f.factura_id.slice(0, 10))}</td>
+      <td>${flEsc(flClienteNombre(f.cliente_id))}</td>
+      <td>${flFmtDate(f.fecha_emision)}</td>
+      <td>${flFmtDate(f.fecha_vencimiento)}</td>
+      <td>${flFmtMoney(f.monto_total)}</td>
+      <td><span class="fl-badge fl-badge-${flEsc(f.estado)}">${flEsc(f.estado)}</span></td>
+      <td class="fl-actions">
+        ${f.estado === 'emitida' || f.estado === 'vencida' ? `<button type="button" class="quick-action-btn fl-btn-sm" data-fl-pay="${flEsc(f.factura_id)}">Marcar pagada</button>` : ''}
+        ${f.estado !== 'cancelada' && f.estado !== 'pagada' ? `<button type="button" class="quick-action-btn quick-action-secondary fl-btn-sm" data-fl-cancel="${flEsc(f.factura_id)}">Cancelar</button>` : ''}
+      </td>
+    </tr>`).join('');
+  container.innerHTML = `
+    <table class="freelance-table">
+      <thead><tr><th>Numero</th><th>Cliente</th><th>Emision</th><th>Vencimiento</th><th>Total</th><th>Estado</th><th>Acciones</th></tr></thead>
+      <tbody>${rows}</tbody>
+    </table>`;
+  container.querySelectorAll('[data-fl-pay]').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const fecha = prompt('Fecha de pago (YYYY-MM-DD):', new Date().toISOString().slice(0, 10));
+      if (!fecha) return;
+      try {
+        await freelancePagarFactura(btn.dataset.flPay, fecha);
+        await refreshFacturas();
+      } catch (e) { alert('Error: ' + e.message); }
+    });
+  });
+  container.querySelectorAll('[data-fl-cancel]').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const razon = prompt('Razon de cancelacion (opcional):', '');
+      if (razon === null) return;
+      try {
+        await freelanceCancelarFactura(btn.dataset.flCancel, razon);
+        await refreshFacturas();
+      } catch (e) { alert('Error: ' + e.message); }
+    });
+  });
+}
+
+async function refreshFacturas() {
+  const filters = {
+    cliente_id: document.getElementById('fl-factura-filter-cliente')?.value || null,
+    estado: document.getElementById('fl-factura-filter-estado')?.value || null,
+  };
+  freelanceState.facturas = await freelanceListFacturas(filters);
+  renderFreelanceFacturas();
+}
+
+function openFacturaDialog() {
+  const dlg = document.getElementById('fl-factura-dialog');
+  if (!dlg) return;
+  document.getElementById('fl-factura-form-error').textContent = '';
+  document.getElementById('fl-factura-form').reset();
+  document.getElementById('fl-factura-fecha-emision').value = new Date().toISOString().slice(0, 10);
+  populateClienteSelectors();
+  dlg.showModal();
+}
+
+async function submitFacturaForm(ev) {
+  ev.preventDefault();
+  const errEl = document.getElementById('fl-factura-form-error');
+  errEl.textContent = '';
+  const cliente_id = document.getElementById('fl-factura-cliente').value;
+  const monto_subtotal = parseFloat(document.getElementById('fl-factura-subtotal').value);
+  if (!cliente_id) { errEl.textContent = 'Cliente requerido'; return; }
+  if (!monto_subtotal || monto_subtotal <= 0) { errEl.textContent = 'Subtotal debe ser > 0'; return; }
+  const body = {
+    cliente_id,
+    monto_subtotal,
+    monto_iva: parseFloat(document.getElementById('fl-factura-iva').value) || null,
+    fecha_emision: document.getElementById('fl-factura-fecha-emision').value || null,
+    fecha_vencimiento: document.getElementById('fl-factura-fecha-vencimiento').value || null,
+    numero_externo: document.getElementById('fl-factura-numero').value || null,
+    concepto: document.getElementById('fl-factura-concepto').value || null,
+  };
+  try {
+    await freelanceCreateFactura(body);
+    document.getElementById('fl-factura-dialog').close();
+    await refreshFacturas();
+  } catch (e) { errEl.textContent = e.message; }
+}
+
+// --- Render: Resumen ---
+async function refreshFreelanceOverview() {
+  try {
+    const mes = document.getElementById('fl-overview-mes')?.value || null;
+    const ov = await freelanceOverview(mes);
+    const set = (id, val) => { const el = document.getElementById(id); if (el) el.textContent = val; };
+    set('fl-stat-horas', flFmtHours(ov.horas_trabajadas ?? 0));
+    set('fl-stat-horas-comp', `${ov.horas_comprometidas ?? 0}h`);
+    set('fl-stat-clientes', String(ov.clientes_activos ?? 0));
+    set('fl-stat-cxc', flFmtMoney(ov.cuentas_por_cobrar ?? 0));
+    set('fl-stat-emitido', flFmtMoney(ov.facturacion_emitida ?? 0));
+    set('fl-stat-pagado', flFmtMoney(ov.facturacion_pagada ?? 0));
+
+    // Alertas
+    const alertasEl = document.getElementById('fl-overview-alertas');
+    if (alertasEl) {
+      const alertas = ov.alertas || [];
+      if (!alertas.length) alertasEl.innerHTML = '';
+      else {
+        alertasEl.innerHTML = `<h3 style="margin:8px 0;">Alertas</h3>` +
+          alertas.map(a => `<div class="fl-badge fl-badge-vencida" style="display:block;margin:4px 0;padding:8px;">${flEsc(typeof a === 'string' ? a : (a.mensaje || JSON.stringify(a)))}</div>`).join('');
+      }
+    }
+
+    // Top clientes list
+    const topList = document.getElementById('fl-top-clientes-list');
+    if (topList) {
+      try {
+        const top = await freelanceTopClientes();
+        if (!top.length) topList.innerHTML = '<p class="task-empty">Sin facturacion en el periodo</p>';
+        else {
+          const rows = top.slice(0, 10).map((c, i) => `
+            <tr><td>${i + 1}</td><td>${flEsc(c.nombre || c.cliente_nombre || c.cliente_id)}</td><td>${flFmtMoney(c.total ?? c.facturado ?? c.monto)}</td></tr>`).join('');
+          topList.innerHTML = `<table class="freelance-table"><thead><tr><th>#</th><th>Cliente</th><th>Total</th></tr></thead><tbody>${rows}</tbody></table>`;
+        }
+      } catch (e) {
+        topList.innerHTML = `<p class="task-empty">Error: ${flEsc(e.message)}</p>`;
+      }
+    }
+  } catch (e) {
+    console.warn('freelance overview failed', e);
+  }
+}
+
+// --- Render: Tarifas ---
+function renderFreelanceTarifas() {
+  const container = document.getElementById('fl-tarifas-list');
+  if (!container) return;
+  const list = freelanceState.clientes;
+  if (!list.length) {
+    container.innerHTML = '<p class="task-empty">Sin clientes para mostrar tarifas.</p>';
+    return;
+  }
+  const rows = list.map(c => `
+    <tr>
+      <td><strong>${flEsc(c.nombre)}</strong></td>
+      <td>${flEsc(c.modalidad || 'horas')}</td>
+      <td>${c.tarifa_hora != null ? flFmtMoney(c.tarifa_hora) : '—'}</td>
+      <td>${c.retainer_mensual != null ? flFmtMoney(c.retainer_mensual) : '—'}</td>
+      <td class="fl-actions">
+        <button type="button" class="quick-action-btn fl-btn-sm" data-fl-tarifa="${flEsc(c.cliente_id)}">Cambiar tarifa</button>
+      </td>
+    </tr>`).join('');
+  container.innerHTML = `
+    <table class="freelance-table">
+      <thead><tr><th>Cliente</th><th>Modalidad</th><th>Tarifa/h</th><th>Retainer</th><th>Acciones</th></tr></thead>
+      <tbody>${rows}</tbody>
+    </table>`;
+  container.querySelectorAll('[data-fl-tarifa]').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const id = btn.dataset.flTarifa;
+      const c = freelanceState.clientes.find(x => x.cliente_id === id);
+      const current = c?.tarifa_hora ?? '';
+      const next = prompt(`Nueva tarifa por hora (MXN) para ${c?.nombre}:`, String(current));
+      if (next === null) return;
+      const val = parseFloat(next);
+      if (!val || val <= 0) { alert('Tarifa invalida'); return; }
+      try {
+        await freelanceUpdateCliente(id, { tarifa_hora: val });
+        await ensureClientesLoaded(true);
+        renderFreelanceTarifas();
+        renderFreelanceClientes();
+      } catch (e) { alert('Error: ' + e.message); }
+    });
+  });
+}
+
+// --- Init ---
+function initFreelance() {
+  // Cliente form
+  document.getElementById('fl-cliente-new-btn')?.addEventListener('click', () => openClienteDialog(null));
+  document.getElementById('fl-cliente-form')?.addEventListener('submit', submitClienteForm);
+  document.getElementById('fl-cliente-cancel')?.addEventListener('click', () => document.getElementById('fl-cliente-dialog').close());
+  document.getElementById('fl-clientes-refresh')?.addEventListener('click', async () => {
+    await ensureClientesLoaded(true); renderFreelanceClientes();
+  });
+  document.getElementById('fl-clientes-filter-estado')?.addEventListener('change', async () => {
+    await ensureClientesLoaded(true); renderFreelanceClientes();
+  });
+
+  // Sesion form
+  document.getElementById('fl-sesion-new-btn')?.addEventListener('click', async () => {
+    await ensureClientesLoaded(); openSesionDialog();
+  });
+  document.getElementById('fl-sesion-form')?.addEventListener('submit', submitSesionForm);
+  document.getElementById('fl-sesion-cancel')?.addEventListener('click', () => document.getElementById('fl-sesion-dialog').close());
+  document.getElementById('fl-sesiones-refresh')?.addEventListener('click', refreshSesiones);
+
+  // Factura form
+  document.getElementById('fl-factura-new-btn')?.addEventListener('click', async () => {
+    await ensureClientesLoaded(); openFacturaDialog();
+  });
+  document.getElementById('fl-factura-form')?.addEventListener('submit', submitFacturaForm);
+  document.getElementById('fl-factura-cancel')?.addEventListener('click', () => document.getElementById('fl-factura-dialog').close());
+  document.getElementById('fl-facturas-refresh')?.addEventListener('click', refreshFacturas);
+
+  // Overview
+  const mesInput = document.getElementById('fl-overview-mes');
+  if (mesInput) {
+    const now = new Date();
+    mesInput.value = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+  }
+  document.getElementById('fl-overview-refresh')?.addEventListener('click', refreshFreelanceOverview);
+
+  // Lazy-load when freelance section becomes active
+  document.querySelectorAll('.sidebar-submenu-item[data-parent="freelance"]').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const target = btn.dataset.subsectionTarget;
+      try {
+        if (target === 'fl-clientes') {
+          await ensureClientesLoaded(); renderFreelanceClientes();
+        } else if (target === 'fl-sesiones') {
+          await ensureClientesLoaded(); await refreshSesiones();
+        } else if (target === 'fl-facturas') {
+          await ensureClientesLoaded(); await refreshFacturas();
+        } else if (target === 'fl-tarifas') {
+          await ensureClientesLoaded(true); renderFreelanceTarifas();
+        } else if (target === 'fl-resumen') {
+          await refreshFreelanceOverview();
+        }
+      } catch (e) { console.warn('freelance load', target, e); }
+    });
+  });
+}
+
 (async () => {
   initTabs();
   await ensureBootstrapToken();
@@ -4421,5 +4972,6 @@ async function togglePrivacyMode() {
   loadMeetings();
   loadCalendar();
   loadTtsVoiceSelector();
+  initFreelance();
   runWelcomeSequence().catch(err => console.warn('welcome sequence failed:', err));
 })();

--- a/daemon/static/dashboard/app.js
+++ b/daemon/static/dashboard/app.js
@@ -4393,10 +4393,13 @@ async function togglePrivacyMode() {
 })();
 
 // ==================== Freelance Module ====================
+const FL_SESIONES_PAGE = 100;
 const freelanceState = {
   clientes: [],
   sesiones: [],
   facturas: [],
+  sesionesOffset: 0,
+  sesionesHasMore: false,
   loaded: { clientes: false, sesiones: false, facturas: false, overview: false, tarifas: false },
 };
 
@@ -4421,6 +4424,74 @@ function flClienteNombre(id) {
   return c ? c.nombre : id;
 }
 
+// Safe numeric parser: preserves 0 as legitimate value, returns null only for non-finite input.
+function flParseNum(input) {
+  if (input === null || input === undefined || input === '') return null;
+  const v = parseFloat(input);
+  return Number.isFinite(v) ? v : null;
+}
+function flParseInt(input) {
+  if (input === null || input === undefined || input === '') return null;
+  const v = parseInt(input, 10);
+  return Number.isFinite(v) ? v : null;
+}
+// Local-time YYYY-MM-DD (avoids UTC offset bug from toISOString().slice(0,10)).
+function flLocalDateToday() {
+  const d = new Date();
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+// In-flight guard: prevents double-click races on async action buttons.
+const flInFlight = new WeakSet();
+async function flGuardClick(btn, fn) {
+  if (flInFlight.has(btn)) return;
+  flInFlight.add(btn);
+  const wasDisabled = btn.disabled;
+  btn.disabled = true;
+  try {
+    await fn();
+  } finally {
+    flInFlight.delete(btn);
+    btn.disabled = wasDisabled;
+  }
+}
+// Replacement for prompt() — uses a transient <dialog> with proper input.
+// Returns Promise<string|null> (null = cancelled, '' allowed for empty input).
+function flPromptDialog({ title, label, value = '', type = 'text', placeholder = '', allowEmpty = true }) {
+  return new Promise(resolve => {
+    const dlg = document.createElement('dialog');
+    dlg.className = 'freelance-dialog';
+    dlg.innerHTML = `
+      <form method="dialog" style="display:flex;flex-direction:column;gap:10px;min-width:280px;">
+        <h3 style="margin:0;">${flEsc(title || 'Confirmar')}</h3>
+        <label style="display:flex;flex-direction:column;gap:4px;">
+          <span>${flEsc(label || '')}</span>
+          <input type="${flEsc(type)}" data-fl-prompt-input placeholder="${flEsc(placeholder)}">
+        </label>
+        <div class="freelance-dialog-actions">
+          <button type="button" class="quick-action-btn quick-action-secondary" data-fl-prompt-cancel>Cancelar</button>
+          <button type="submit" class="quick-action-btn" data-fl-prompt-ok>Confirmar</button>
+        </div>
+      </form>`;
+    document.body.appendChild(dlg);
+    const input = dlg.querySelector('[data-fl-prompt-input]');
+    input.value = value;
+    const cleanup = (result) => { dlg.close(); dlg.remove(); resolve(result); };
+    dlg.querySelector('[data-fl-prompt-cancel]').addEventListener('click', () => cleanup(null));
+    dlg.querySelector('form').addEventListener('submit', (e) => {
+      e.preventDefault();
+      const v = input.value;
+      if (!allowEmpty && !v) { input.focus(); return; }
+      cleanup(v);
+    });
+    dlg.addEventListener('cancel', (e) => { e.preventDefault(); cleanup(null); });
+    dlg.showModal();
+    setTimeout(() => input.focus(), 0);
+  });
+}
+
 // --- API wrappers ---
 async function freelanceListClientes(estado) {
   const q = estado ? `?estado=${encodeURIComponent(estado)}` : '';
@@ -4441,6 +4512,8 @@ async function freelanceListSesiones(filters) {
   if (filters?.cliente_id) params.set('cliente_id', filters.cliente_id);
   if (filters?.desde) params.set('desde', filters.desde);
   if (filters?.hasta) params.set('hasta', filters.hasta);
+  if (filters?.limit) params.set('limit', String(filters.limit));
+  if (filters?.offset) params.set('offset', String(filters.offset));
   const qs = params.toString();
   const data = await api('GET', `/freelance/sesiones${qs ? '?' + qs : ''}`);
   return data.sesiones || [];
@@ -4538,7 +4611,7 @@ function renderFreelanceClientes() {
       <td><span class="fl-badge fl-badge-${flEsc(c.estado)}">${flEsc(c.estado)}</span></td>
       <td class="fl-actions">
         <button type="button" class="quick-action-btn fl-btn-sm" data-fl-edit-cliente="${flEsc(c.cliente_id)}">Editar</button>
-        <button type="button" class="quick-action-btn quick-action-secondary fl-btn-sm" data-fl-del-cliente="${flEsc(c.cliente_id)}">Terminar</button>
+        ${c.estado !== 'terminado' ? `<button type="button" class="quick-action-btn quick-action-secondary fl-btn-sm" data-fl-del-cliente="${flEsc(c.cliente_id)}">Terminar</button>` : ''}
       </td>
     </tr>
   `).join('');
@@ -4551,14 +4624,14 @@ function renderFreelanceClientes() {
     btn.addEventListener('click', () => openClienteDialog(btn.dataset.flEditCliente));
   });
   container.querySelectorAll('[data-fl-del-cliente]').forEach(btn => {
-    btn.addEventListener('click', async () => {
-      if (!confirm('Marcar cliente como terminado?')) return;
+    btn.addEventListener('click', () => flGuardClick(btn, async () => {
+      if (!confirm('¿Marcar cliente como terminado?')) return;
       try {
         await freelanceDeleteCliente(btn.dataset.flDelCliente);
         await ensureClientesLoaded(true);
         renderFreelanceClientes();
       } catch (e) { alert('Error: ' + e.message); }
-    });
+    }));
   });
 }
 
@@ -4602,9 +4675,9 @@ async function submitClienteForm(ev) {
   const body = {
     nombre: document.getElementById('fl-cliente-nombre').value.trim(),
     modalidad: document.getElementById('fl-cliente-modalidad').value || null,
-    tarifa_hora: parseFloat(document.getElementById('fl-cliente-tarifa').value) || null,
-    retainer_mensual: parseFloat(document.getElementById('fl-cliente-retainer').value) || null,
-    horas_comprometidas_mes: parseInt(document.getElementById('fl-cliente-horas-comp').value) || null,
+    tarifa_hora: flParseNum(document.getElementById('fl-cliente-tarifa').value),
+    retainer_mensual: flParseNum(document.getElementById('fl-cliente-retainer').value),
+    horas_comprometidas_mes: flParseInt(document.getElementById('fl-cliente-horas-comp').value),
     fecha_inicio: document.getElementById('fl-cliente-fecha-inicio').value || null,
     contacto_principal: document.getElementById('fl-cliente-contacto').value || null,
     contacto_email: document.getElementById('fl-cliente-email').value || null,
@@ -4638,26 +4711,36 @@ function renderFreelanceSesiones() {
       <td>${flFmtDate(s.fecha)}</td>
       <td>${flEsc(flClienteNombre(s.cliente_id))}</td>
       <td>${flFmtHours(s.horas)}</td>
-      <td>${flEsc(s.descripcion || '')}</td>
-      <td>${s.facturable ? '<span class="val-ok">Si</span>' : '<span class="val-error">No</span>'}</td>
+      <td class="fl-truncate" title="${flEsc(s.descripcion || '')}">${flEsc(s.descripcion || '')}</td>
+      <td>${s.facturable ? '<span class="val-ok">Sí</span>' : '<span class="val-error">No</span>'}</td>
       <td>${s.factura_id ? '<span class="fl-badge fl-badge-pagada">Facturada</span>' : '<span class="fl-badge">Pendiente</span>'}</td>
       <td class="fl-actions">
         <button type="button" class="quick-action-btn quick-action-secondary fl-btn-sm" data-fl-del-sesion="${flEsc(s.sesion_id)}">Borrar</button>
       </td>
     </tr>`).join('');
+  const loadMoreBtn = freelanceState.sesionesHasMore
+    ? `<div style="margin-top:10px;text-align:center;"><button type="button" class="quick-action-btn" data-fl-load-more-sesiones>Cargar más</button></div>`
+    : '';
   container.innerHTML = `
     <table class="freelance-table">
-      <thead><tr><th>Fecha</th><th>Cliente</th><th>Horas</th><th>Descripcion</th><th>Facturable</th><th>Estado</th><th>Acciones</th></tr></thead>
+      <thead><tr><th>Fecha</th><th>Cliente</th><th>Horas</th><th>Descripción</th><th>Facturable</th><th>Estado</th><th>Acciones</th></tr></thead>
       <tbody>${rows}</tbody>
-    </table>`;
+    </table>${loadMoreBtn}`;
+  const moreBtn = container.querySelector('[data-fl-load-more-sesiones]');
+  if (moreBtn) {
+    moreBtn.addEventListener('click', () => flGuardClick(moreBtn, async () => {
+      try { await loadMoreSesiones(); }
+      catch (e) { alert('Error: ' + e.message); }
+    }));
+  }
   container.querySelectorAll('[data-fl-del-sesion]').forEach(btn => {
-    btn.addEventListener('click', async () => {
-      if (!confirm('Borrar sesion?')) return;
+    btn.addEventListener('click', () => flGuardClick(btn, async () => {
+      if (!confirm('¿Borrar sesión?')) return;
       try {
         await freelanceDeleteSesion(btn.dataset.flDelSesion);
         await refreshSesiones();
       } catch (e) { alert('Error: ' + e.message); }
-    });
+    }));
   });
 }
 
@@ -4666,8 +4749,29 @@ async function refreshSesiones() {
     cliente_id: document.getElementById('fl-sesion-filter-cliente')?.value || null,
     desde: document.getElementById('fl-sesion-filter-desde')?.value || null,
     hasta: document.getElementById('fl-sesion-filter-hasta')?.value || null,
+    limit: FL_SESIONES_PAGE,
+    offset: 0,
   };
-  freelanceState.sesiones = await freelanceListSesiones(filters);
+  const page = await freelanceListSesiones(filters);
+  freelanceState.sesiones = page;
+  freelanceState.sesionesOffset = page.length;
+  freelanceState.sesionesHasMore = page.length === FL_SESIONES_PAGE;
+  renderFreelanceSesiones();
+}
+
+async function loadMoreSesiones() {
+  if (!freelanceState.sesionesHasMore) return;
+  const filters = {
+    cliente_id: document.getElementById('fl-sesion-filter-cliente')?.value || null,
+    desde: document.getElementById('fl-sesion-filter-desde')?.value || null,
+    hasta: document.getElementById('fl-sesion-filter-hasta')?.value || null,
+    limit: FL_SESIONES_PAGE,
+    offset: freelanceState.sesionesOffset,
+  };
+  const page = await freelanceListSesiones(filters);
+  freelanceState.sesiones = freelanceState.sesiones.concat(page);
+  freelanceState.sesionesOffset += page.length;
+  freelanceState.sesionesHasMore = page.length === FL_SESIONES_PAGE;
   renderFreelanceSesiones();
 }
 
@@ -4677,7 +4781,7 @@ function openSesionDialog() {
   document.getElementById('fl-sesion-form-error').textContent = '';
   document.getElementById('fl-sesion-form').reset();
   document.getElementById('fl-sesion-facturable').checked = true;
-  document.getElementById('fl-sesion-fecha').value = new Date().toISOString().slice(0, 10);
+  document.getElementById('fl-sesion-fecha').value = flLocalDateToday();
   populateClienteSelectors();
   dlg.showModal();
 }
@@ -4687,9 +4791,9 @@ async function submitSesionForm(ev) {
   const errEl = document.getElementById('fl-sesion-form-error');
   errEl.textContent = '';
   const cliente_id = document.getElementById('fl-sesion-cliente').value;
-  const horas = parseFloat(document.getElementById('fl-sesion-horas').value);
+  const horas = flParseNum(document.getElementById('fl-sesion-horas').value);
   if (!cliente_id) { errEl.textContent = 'Cliente requerido'; return; }
-  if (!horas || horas <= 0) { errEl.textContent = 'Horas debe ser > 0'; return; }
+  if (horas === null || horas <= 0) { errEl.textContent = 'Horas debe ser > 0'; return; }
   const body = {
     cliente_id,
     horas,
@@ -4717,7 +4821,7 @@ function renderFreelanceFacturas() {
   }
   const rows = list.map(f => `
     <tr>
-      <td>${flEsc(f.numero_externo || f.factura_id.slice(0, 10))}</td>
+      <td>${f.numero_externo ? flEsc(f.numero_externo) : '<span class="fl-muted">(sin número)</span>'}</td>
       <td>${flEsc(flClienteNombre(f.cliente_id))}</td>
       <td>${flFmtDate(f.fecha_emision)}</td>
       <td>${flFmtDate(f.fecha_vencimiento)}</td>
@@ -4730,28 +4834,40 @@ function renderFreelanceFacturas() {
     </tr>`).join('');
   container.innerHTML = `
     <table class="freelance-table">
-      <thead><tr><th>Numero</th><th>Cliente</th><th>Emision</th><th>Vencimiento</th><th>Total</th><th>Estado</th><th>Acciones</th></tr></thead>
+      <thead><tr><th>Número</th><th>Cliente</th><th>Emisión</th><th>Vencimiento</th><th>Total</th><th>Estado</th><th>Acciones</th></tr></thead>
       <tbody>${rows}</tbody>
     </table>`;
   container.querySelectorAll('[data-fl-pay]').forEach(btn => {
-    btn.addEventListener('click', async () => {
-      const fecha = prompt('Fecha de pago (YYYY-MM-DD):', new Date().toISOString().slice(0, 10));
+    btn.addEventListener('click', () => flGuardClick(btn, async () => {
+      const fecha = await flPromptDialog({
+        title: 'Marcar factura como pagada',
+        label: 'Fecha de pago',
+        value: flLocalDateToday(),
+        type: 'date',
+        allowEmpty: false,
+      });
       if (!fecha) return;
       try {
         await freelancePagarFactura(btn.dataset.flPay, fecha);
         await refreshFacturas();
       } catch (e) { alert('Error: ' + e.message); }
-    });
+    }));
   });
   container.querySelectorAll('[data-fl-cancel]').forEach(btn => {
-    btn.addEventListener('click', async () => {
-      const razon = prompt('Razon de cancelacion (opcional):', '');
+    btn.addEventListener('click', () => flGuardClick(btn, async () => {
+      const razon = await flPromptDialog({
+        title: 'Cancelar factura',
+        label: 'Razón de cancelación (opcional)',
+        value: '',
+        type: 'text',
+        allowEmpty: true,
+      });
       if (razon === null) return;
       try {
         await freelanceCancelarFactura(btn.dataset.flCancel, razon);
         await refreshFacturas();
       } catch (e) { alert('Error: ' + e.message); }
-    });
+    }));
   });
 }
 
@@ -4769,7 +4885,7 @@ function openFacturaDialog() {
   if (!dlg) return;
   document.getElementById('fl-factura-form-error').textContent = '';
   document.getElementById('fl-factura-form').reset();
-  document.getElementById('fl-factura-fecha-emision').value = new Date().toISOString().slice(0, 10);
+  document.getElementById('fl-factura-fecha-emision').value = flLocalDateToday();
   populateClienteSelectors();
   dlg.showModal();
 }
@@ -4779,13 +4895,13 @@ async function submitFacturaForm(ev) {
   const errEl = document.getElementById('fl-factura-form-error');
   errEl.textContent = '';
   const cliente_id = document.getElementById('fl-factura-cliente').value;
-  const monto_subtotal = parseFloat(document.getElementById('fl-factura-subtotal').value);
+  const monto_subtotal = flParseNum(document.getElementById('fl-factura-subtotal').value);
   if (!cliente_id) { errEl.textContent = 'Cliente requerido'; return; }
-  if (!monto_subtotal || monto_subtotal <= 0) { errEl.textContent = 'Subtotal debe ser > 0'; return; }
+  if (monto_subtotal === null || monto_subtotal <= 0) { errEl.textContent = 'Subtotal debe ser > 0'; return; }
   const body = {
     cliente_id,
     monto_subtotal,
-    monto_iva: parseFloat(document.getElementById('fl-factura-iva').value) || null,
+    monto_iva: flParseNum(document.getElementById('fl-factura-iva').value),
     fecha_emision: document.getElementById('fl-factura-fecha-emision').value || null,
     fecha_vencimiento: document.getElementById('fl-factura-fecha-vencimiento').value || null,
     numero_externo: document.getElementById('fl-factura-numero').value || null,
@@ -4827,7 +4943,7 @@ async function refreshFreelanceOverview() {
     if (topList) {
       try {
         const top = await freelanceTopClientes();
-        if (!top.length) topList.innerHTML = '<p class="task-empty">Sin facturacion en el periodo</p>';
+        if (!top.length) topList.innerHTML = '<p class="task-empty">Sin facturación en el período</p>';
         else {
           const rows = top.slice(0, 10).map((c, i) => `
             <tr><td>${i + 1}</td><td>${flEsc(c.nombre || c.cliente_nombre || c.cliente_id)}</td><td>${flFmtMoney(c.total ?? c.facturado ?? c.monto)}</td></tr>`).join('');
@@ -4867,21 +4983,32 @@ function renderFreelanceTarifas() {
       <tbody>${rows}</tbody>
     </table>`;
   container.querySelectorAll('[data-fl-tarifa]').forEach(btn => {
-    btn.addEventListener('click', async () => {
+    btn.addEventListener('click', () => flGuardClick(btn, async () => {
       const id = btn.dataset.flTarifa;
       const c = freelanceState.clientes.find(x => x.cliente_id === id);
       const current = c?.tarifa_hora ?? '';
-      const next = prompt(`Nueva tarifa por hora (MXN) para ${c?.nombre}:`, String(current));
+      const next = await flPromptDialog({
+        title: `Cambiar tarifa de ${c?.nombre || ''}`,
+        label: 'Nueva tarifa por hora (MXN)',
+        value: String(current),
+        type: 'number',
+        allowEmpty: false,
+      });
       if (next === null) return;
-      const val = parseFloat(next);
-      if (!val || val <= 0) { alert('Tarifa invalida'); return; }
+      const val = flParseNum(next);
+      if (val === null || val <= 0) { alert('Tarifa inválida'); return; }
+      const horasComp = c?.horas_comprometidas_mes;
+      const proyeccion = (horasComp && horasComp > 0)
+        ? `\n\nProyección mensual estimada: ${flFmtMoney(val * horasComp)} (${horasComp}h × ${flFmtMoney(val)})`
+        : '';
+      if (!confirm(`Confirmar cambio de tarifa a ${flFmtMoney(val)} por hora.${proyeccion}`)) return;
       try {
         await freelanceUpdateCliente(id, { tarifa_hora: val });
         await ensureClientesLoaded(true);
         renderFreelanceTarifas();
         renderFreelanceClientes();
       } catch (e) { alert('Error: ' + e.message); }
-    });
+    }));
   });
 }
 

--- a/daemon/static/dashboard/index.html
+++ b/daemon/static/dashboard/index.html
@@ -66,6 +66,21 @@
       </div>
 
       <div class="sidebar-nav-group">
+        <button class="sidebar-nav-item has-submenu" data-section="freelance">
+          <svg width="18" height="18" viewBox="0 0 18 18" fill="none"><path d="M3 5h12v9.5a1.5 1.5 0 01-1.5 1.5h-9A1.5 1.5 0 013 14.5V5z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/><path d="M6 5V3.5A1.5 1.5 0 017.5 2h3A1.5 1.5 0 0112 3.5V5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><path d="M3 9h12" stroke="currentColor" stroke-width="1.5"/></svg>
+          <span>Freelance</span>
+          <span class="submenu-chevron"></span>
+        </button>
+        <div class="sidebar-submenu">
+          <button class="sidebar-submenu-item" data-parent="freelance" data-subsection-target="fl-resumen">Resumen</button>
+          <button class="sidebar-submenu-item" data-parent="freelance" data-subsection-target="fl-clientes">Clientes</button>
+          <button class="sidebar-submenu-item" data-parent="freelance" data-subsection-target="fl-sesiones">Sesiones</button>
+          <button class="sidebar-submenu-item" data-parent="freelance" data-subsection-target="fl-facturas">Facturas</button>
+          <button class="sidebar-submenu-item" data-parent="freelance" data-subsection-target="fl-tarifas">Tarifas</button>
+        </div>
+      </div>
+
+      <div class="sidebar-nav-group">
         <button class="sidebar-nav-item has-submenu" data-section="config">
           <svg width="18" height="18" viewBox="0 0 18 18" fill="none"><circle cx="9" cy="9" r="2.5" stroke="currentColor" stroke-width="1.5"/><path d="M14.7 11.2a1.2 1.2 0 00.24 1.32l.04.04a1.45 1.45 0 11-2.05 2.05l-.04-.04a1.2 1.2 0 00-1.32-.24 1.2 1.2 0 00-.73 1.1v.12a1.45 1.45 0 11-2.9 0v-.06a1.2 1.2 0 00-.78-1.1 1.2 1.2 0 00-1.32.24l-.04.04a1.45 1.45 0 11-2.05-2.05l.04-.04a1.2 1.2 0 00.24-1.32 1.2 1.2 0 00-1.1-.73H3.5a1.45 1.45 0 010-2.9h.06a1.2 1.2 0 001.1-.78 1.2 1.2 0 00-.24-1.32l-.04-.04a1.45 1.45 0 112.05-2.05l.04.04a1.2 1.2 0 001.32.24h.06a1.2 1.2 0 00.73-1.1V3.5a1.45 1.45 0 012.9 0v.06a1.2 1.2 0 00.73 1.1 1.2 1.2 0 001.32-.24l.04-.04a1.45 1.45 0 112.05 2.05l-.04.04a1.2 1.2 0 00-.24 1.32v.06a1.2 1.2 0 001.1.73h.12a1.45 1.45 0 010 2.9h-.06a1.2 1.2 0 00-1.1.73z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
           <span>Configuracion</span>
@@ -748,6 +763,169 @@
             <div id="vp-vault-msg" class="vp-status"></div>
           </div>
         </section>
+      </div>
+
+      <!-- ==================== SECTION: Freelance ==================== -->
+      <div class="content-section" id="section-freelance">
+
+        <section class="freelance-section" data-subsection="fl-resumen">
+          <h2>Resumen Freelance</h2>
+          <div class="freelance-toolbar">
+            <label>Mes:
+              <input type="month" id="fl-overview-mes">
+            </label>
+            <button type="button" class="quick-action-btn" id="fl-overview-refresh">Refrescar</button>
+          </div>
+          <div class="hero-stats" id="fl-overview-stats">
+            <div class="hero-stat"><span>Horas trabajadas</span><strong id="fl-stat-horas">—</strong></div>
+            <div class="hero-stat"><span>Horas comprometidas</span><strong id="fl-stat-horas-comp">—</strong></div>
+            <div class="hero-stat"><span>Clientes activos</span><strong id="fl-stat-clientes">—</strong></div>
+            <div class="hero-stat"><span>Cuentas por cobrar</span><strong id="fl-stat-cxc">—</strong></div>
+            <div class="hero-stat"><span>Facturado emitido</span><strong id="fl-stat-emitido">—</strong></div>
+            <div class="hero-stat"><span>Facturado pagado</span><strong id="fl-stat-pagado">—</strong></div>
+          </div>
+          <div id="fl-overview-alertas" style="margin-top:12px;"></div>
+          <h3 style="margin-top:18px;">Top clientes (facturado)</h3>
+          <div id="fl-top-clientes-list"><p class="task-empty">Sin datos</p></div>
+        </section>
+
+        <section class="freelance-section" data-subsection="fl-clientes">
+          <h2>Clientes</h2>
+          <div class="freelance-toolbar">
+            <label>Estado:
+              <select id="fl-clientes-filter-estado">
+                <option value="">Todos</option>
+                <option value="activo" selected>Activo</option>
+                <option value="pausado">Pausado</option>
+                <option value="terminado">Terminado</option>
+              </select>
+            </label>
+            <button type="button" class="quick-action-btn" id="fl-clientes-refresh">Refrescar</button>
+            <button type="button" class="quick-action-btn" id="fl-cliente-new-btn">+ Nuevo cliente</button>
+          </div>
+          <div id="fl-clientes-list" class="freelance-table-wrap"><p class="task-empty">Cargando clientes...</p></div>
+        </section>
+
+        <section class="freelance-section" data-subsection="fl-sesiones">
+          <h2>Sesiones</h2>
+          <div class="freelance-toolbar">
+            <label>Cliente:
+              <select id="fl-sesion-filter-cliente"><option value="">Todos</option></select>
+            </label>
+            <label>Desde: <input type="date" id="fl-sesion-filter-desde"></label>
+            <label>Hasta: <input type="date" id="fl-sesion-filter-hasta"></label>
+            <button type="button" class="quick-action-btn" id="fl-sesiones-refresh">Buscar</button>
+            <button type="button" class="quick-action-btn" id="fl-sesion-new-btn">+ Registrar sesion</button>
+          </div>
+          <div id="fl-sesiones-list" class="freelance-table-wrap"><p class="task-empty">Cargando sesiones...</p></div>
+        </section>
+
+        <section class="freelance-section" data-subsection="fl-facturas">
+          <h2>Facturas</h2>
+          <div class="freelance-toolbar">
+            <label>Cliente:
+              <select id="fl-factura-filter-cliente"><option value="">Todos</option></select>
+            </label>
+            <label>Estado:
+              <select id="fl-factura-filter-estado">
+                <option value="">Todos</option>
+                <option value="emitida">Emitida</option>
+                <option value="pagada">Pagada</option>
+                <option value="vencida">Vencida</option>
+                <option value="cancelada">Cancelada</option>
+              </select>
+            </label>
+            <button type="button" class="quick-action-btn" id="fl-facturas-refresh">Buscar</button>
+            <button type="button" class="quick-action-btn" id="fl-factura-new-btn">+ Nueva factura</button>
+          </div>
+          <div id="fl-facturas-list" class="freelance-table-wrap"><p class="task-empty">Cargando facturas...</p></div>
+        </section>
+
+        <section class="freelance-section" data-subsection="fl-tarifas">
+          <h2>Tarifas por cliente</h2>
+          <p class="setting-hint">Editar la tarifa por hora desde la ficha de cada cliente. Cada cambio queda archivado en el historial.</p>
+          <div id="fl-tarifas-list" class="freelance-table-wrap"><p class="task-empty">Cargando tarifas...</p></div>
+        </section>
+
+        <!-- Cliente form dialog -->
+        <dialog id="fl-cliente-dialog" class="freelance-dialog">
+          <form method="dialog" id="fl-cliente-form">
+            <h3 id="fl-cliente-form-title">Nuevo cliente</h3>
+            <input type="hidden" id="fl-cliente-id">
+            <label>Nombre *<input type="text" id="fl-cliente-nombre" required></label>
+            <label>Modalidad
+              <select id="fl-cliente-modalidad">
+                <option value="horas">Por horas</option>
+                <option value="retainer">Retainer</option>
+                <option value="proyecto">Proyecto</option>
+              </select>
+            </label>
+            <label>Tarifa por hora (MXN)<input type="number" step="0.01" id="fl-cliente-tarifa"></label>
+            <label>Retainer mensual (MXN)<input type="number" step="0.01" id="fl-cliente-retainer"></label>
+            <label>Horas comprometidas/mes<input type="number" id="fl-cliente-horas-comp"></label>
+            <label>Fecha inicio<input type="date" id="fl-cliente-fecha-inicio"></label>
+            <label>Contacto<input type="text" id="fl-cliente-contacto"></label>
+            <label>Email<input type="email" id="fl-cliente-email"></label>
+            <label>Telefono<input type="text" id="fl-cliente-telefono"></label>
+            <label>RFC<input type="text" id="fl-cliente-rfc"></label>
+            <label>Notas<textarea id="fl-cliente-notas" rows="2"></textarea></label>
+            <label class="fl-row-only-edit" id="fl-cliente-estado-row" style="display:none;">Estado
+              <select id="fl-cliente-estado">
+                <option value="activo">Activo</option>
+                <option value="pausado">Pausado</option>
+                <option value="terminado">Terminado</option>
+              </select>
+            </label>
+            <p id="fl-cliente-form-error" class="fl-form-error"></p>
+            <div class="freelance-dialog-actions">
+              <button type="button" class="quick-action-btn quick-action-secondary" id="fl-cliente-cancel">Cancelar</button>
+              <button type="submit" class="quick-action-btn" id="fl-cliente-save">Guardar</button>
+            </div>
+          </form>
+        </dialog>
+
+        <!-- Sesion form dialog -->
+        <dialog id="fl-sesion-dialog" class="freelance-dialog">
+          <form method="dialog" id="fl-sesion-form">
+            <h3 id="fl-sesion-form-title">Registrar sesion</h3>
+            <input type="hidden" id="fl-sesion-id">
+            <label>Cliente *
+              <select id="fl-sesion-cliente" required></select>
+            </label>
+            <label>Fecha<input type="date" id="fl-sesion-fecha"></label>
+            <label>Hora inicio<input type="time" id="fl-sesion-hora-inicio"></label>
+            <label>Hora fin<input type="time" id="fl-sesion-hora-fin"></label>
+            <label>Horas *<input type="number" step="0.25" id="fl-sesion-horas" required></label>
+            <label>Descripcion<textarea id="fl-sesion-descripcion" rows="2"></textarea></label>
+            <label><input type="checkbox" id="fl-sesion-facturable" checked> Facturable</label>
+            <p id="fl-sesion-form-error" class="fl-form-error"></p>
+            <div class="freelance-dialog-actions">
+              <button type="button" class="quick-action-btn quick-action-secondary" id="fl-sesion-cancel">Cancelar</button>
+              <button type="submit" class="quick-action-btn" id="fl-sesion-save">Guardar</button>
+            </div>
+          </form>
+        </dialog>
+
+        <!-- Factura form dialog -->
+        <dialog id="fl-factura-dialog" class="freelance-dialog">
+          <form method="dialog" id="fl-factura-form">
+            <h3>Nueva factura</h3>
+            <label>Cliente *
+              <select id="fl-factura-cliente" required></select>
+            </label>
+            <label>Subtotal (MXN) *<input type="number" step="0.01" id="fl-factura-subtotal" required></label>
+            <label>IVA (MXN)<input type="number" step="0.01" id="fl-factura-iva"></label>
+            <label>Fecha emision<input type="date" id="fl-factura-fecha-emision"></label>
+            <label>Fecha vencimiento<input type="date" id="fl-factura-fecha-vencimiento"></label>
+            <label>Numero externo<input type="text" id="fl-factura-numero"></label>
+            <label>Concepto<textarea id="fl-factura-concepto" rows="2"></textarea></label>
+            <p id="fl-factura-form-error" class="fl-form-error"></p>
+            <div class="freelance-dialog-actions">
+              <button type="button" class="quick-action-btn quick-action-secondary" id="fl-factura-cancel">Cancelar</button>
+              <button type="submit" class="quick-action-btn" id="fl-factura-save">Emitir</button>
+            </div>
+          </form>
+        </dialog>
       </div>
     </main>
   </div>

--- a/daemon/static/dashboard/index.html
+++ b/daemon/static/dashboard/index.html
@@ -815,7 +815,7 @@
             <label>Desde: <input type="date" id="fl-sesion-filter-desde"></label>
             <label>Hasta: <input type="date" id="fl-sesion-filter-hasta"></label>
             <button type="button" class="quick-action-btn" id="fl-sesiones-refresh">Buscar</button>
-            <button type="button" class="quick-action-btn" id="fl-sesion-new-btn">+ Registrar sesion</button>
+            <button type="button" class="quick-action-btn" id="fl-sesion-new-btn">+ Registrar sesión</button>
           </div>
           <div id="fl-sesiones-list" class="freelance-table-wrap"><p class="task-empty">Cargando sesiones...</p></div>
         </section>
@@ -866,7 +866,7 @@
             <label>Fecha inicio<input type="date" id="fl-cliente-fecha-inicio"></label>
             <label>Contacto<input type="text" id="fl-cliente-contacto"></label>
             <label>Email<input type="email" id="fl-cliente-email"></label>
-            <label>Telefono<input type="text" id="fl-cliente-telefono"></label>
+            <label>Teléfono<input type="text" id="fl-cliente-telefono"></label>
             <label>RFC<input type="text" id="fl-cliente-rfc"></label>
             <label>Notas<textarea id="fl-cliente-notas" rows="2"></textarea></label>
             <label class="fl-row-only-edit" id="fl-cliente-estado-row" style="display:none;">Estado
@@ -887,7 +887,7 @@
         <!-- Sesion form dialog -->
         <dialog id="fl-sesion-dialog" class="freelance-dialog">
           <form method="dialog" id="fl-sesion-form">
-            <h3 id="fl-sesion-form-title">Registrar sesion</h3>
+            <h3 id="fl-sesion-form-title">Registrar sesión</h3>
             <input type="hidden" id="fl-sesion-id">
             <label>Cliente *
               <select id="fl-sesion-cliente" required></select>
@@ -896,7 +896,7 @@
             <label>Hora inicio<input type="time" id="fl-sesion-hora-inicio"></label>
             <label>Hora fin<input type="time" id="fl-sesion-hora-fin"></label>
             <label>Horas *<input type="number" step="0.25" id="fl-sesion-horas" required></label>
-            <label>Descripcion<textarea id="fl-sesion-descripcion" rows="2"></textarea></label>
+            <label>Descripción<textarea id="fl-sesion-descripcion" rows="2"></textarea></label>
             <label><input type="checkbox" id="fl-sesion-facturable" checked> Facturable</label>
             <p id="fl-sesion-form-error" class="fl-form-error"></p>
             <div class="freelance-dialog-actions">
@@ -915,9 +915,9 @@
             </label>
             <label>Subtotal (MXN) *<input type="number" step="0.01" id="fl-factura-subtotal" required></label>
             <label>IVA (MXN)<input type="number" step="0.01" id="fl-factura-iva"></label>
-            <label>Fecha emision<input type="date" id="fl-factura-fecha-emision"></label>
+            <label>Fecha emisión<input type="date" id="fl-factura-fecha-emision"></label>
             <label>Fecha vencimiento<input type="date" id="fl-factura-fecha-vencimiento"></label>
-            <label>Numero externo<input type="text" id="fl-factura-numero"></label>
+            <label>Número externo<input type="text" id="fl-factura-numero"></label>
             <label>Concepto<textarea id="fl-factura-concepto" rows="2"></textarea></label>
             <p id="fl-factura-form-error" class="fl-form-error"></p>
             <div class="freelance-dialog-actions">

--- a/daemon/static/dashboard/style.css
+++ b/daemon/static/dashboard/style.css
@@ -2772,3 +2772,75 @@ details[open] .transcript-toggle::before { transform: rotate(90deg); }
 .privacy-toggle.privacy-on .privacy-switch-thumb {
   transform: translateX(14px);
 }
+
+/* ==================== Freelance ==================== */
+.freelance-section { margin-bottom: 24px; }
+.freelance-toolbar {
+  display: flex; flex-wrap: wrap; gap: 10px; align-items: center;
+  margin: 12px 0 16px;
+}
+.freelance-toolbar label {
+  display: inline-flex; align-items: center; gap: 6px;
+  color: var(--text-muted); font-size: 0.85rem;
+}
+.freelance-toolbar input,
+.freelance-toolbar select {
+  background: var(--bg-card); color: var(--text);
+  border: 1px solid rgba(255,255,255,0.08); border-radius: 6px;
+  padding: 6px 10px; font-size: 0.85rem;
+}
+.freelance-table-wrap { overflow-x: auto; background: var(--bg-card); border-radius: 8px; }
+.freelance-table {
+  width: 100%; border-collapse: collapse; font-size: 0.88rem;
+}
+.freelance-table th,
+.freelance-table td {
+  padding: 10px 12px; text-align: left;
+  border-bottom: 1px solid rgba(255,255,255,0.05);
+}
+.freelance-table th {
+  color: var(--text-muted); font-weight: 600; text-transform: uppercase;
+  font-size: 0.72rem; letter-spacing: 0.04em;
+  background: rgba(255,255,255,0.02);
+}
+.freelance-table tbody tr:hover { background: var(--bg-card-hover); }
+.fl-actions { display: flex; gap: 6px; flex-wrap: wrap; }
+.fl-btn-sm { font-size: 0.75rem; padding: 4px 10px; }
+.fl-muted { color: var(--text-muted); font-size: 0.78rem; }
+.fl-badge {
+  display: inline-block; padding: 2px 8px; border-radius: 10px;
+  font-size: 0.72rem; font-weight: 600;
+  background: rgba(255,255,255,0.08); color: var(--text);
+}
+.fl-badge-activo,
+.fl-badge-pagada { background: rgba(0,212,170,0.15); color: var(--accent); }
+.fl-badge-pausado,
+.fl-badge-emitida { background: rgba(255,193,7,0.15); color: #ffc107; }
+.fl-badge-vencida { background: rgba(244,67,54,0.18); color: #ff6b6b; }
+.fl-badge-cancelada,
+.fl-badge-terminado { background: rgba(255,255,255,0.08); color: var(--text-muted); }
+
+.freelance-dialog {
+  background: var(--bg-card); color: var(--text);
+  border: 1px solid rgba(255,255,255,0.08);
+  border-radius: 10px; padding: 20px; max-width: 480px; width: 90vw;
+}
+.freelance-dialog::backdrop { background: rgba(0,0,0,0.55); }
+.freelance-dialog h3 { margin: 0 0 14px; color: var(--accent); }
+.freelance-dialog form { display: flex; flex-direction: column; gap: 10px; }
+.freelance-dialog label {
+  display: flex; flex-direction: column; gap: 4px;
+  font-size: 0.82rem; color: var(--text-muted);
+}
+.freelance-dialog input,
+.freelance-dialog select,
+.freelance-dialog textarea {
+  background: var(--bg); color: var(--text);
+  border: 1px solid rgba(255,255,255,0.08); border-radius: 6px;
+  padding: 7px 10px; font-size: 0.9rem; font-family: inherit;
+}
+.freelance-dialog input[type="checkbox"] { width: auto; }
+.freelance-dialog-actions {
+  display: flex; justify-content: flex-end; gap: 8px; margin-top: 8px;
+}
+.fl-form-error { color: #ff6b6b; font-size: 0.82rem; min-height: 1em; margin: 0; }

--- a/daemon/static/dashboard/style.css
+++ b/daemon/static/dashboard/style.css
@@ -2807,6 +2807,10 @@ details[open] .transcript-toggle::before { transform: rotate(90deg); }
 .fl-actions { display: flex; gap: 6px; flex-wrap: wrap; }
 .fl-btn-sm { font-size: 0.75rem; padding: 4px 10px; }
 .fl-muted { color: var(--text-muted); font-size: 0.78rem; }
+.freelance-table td.fl-truncate,
+.freelance-table td .fl-truncate {
+  max-width: 300px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
 .fl-badge {
   display: inline-block; padding: 2px 8px; border-radius: 10px;
   font-size: 0.72rem; font-weight: 600;

--- a/docs/user/user-guide.md
+++ b/docs/user/user-guide.md
@@ -402,6 +402,18 @@ The *Vida Plena* section of the dashboard now exposes three interactive surfaces
 
 All Vida Plena endpoints require the same `x-bootstrap-token` header. Vault errors map to `403` (locked / wrong passphrase) and `400` (missing/invalid input) so the UI surfaces the actual reason on failure.
 
+## Freelance Dashboard (Clientes, Sesiones, Facturas, Tarifas, Resumen)
+
+The dashboard at `http://127.0.0.1:8081/dashboard` includes a *Freelance* group in the sidebar with five tabs that consume the `/api/v1/freelance/*` endpoints:
+
+- **Resumen** — month picker (defaults to current month) shows horas trabajadas, horas comprometidas, clientes activos, cuentas por cobrar, facturado emitido, facturado pagado, plus a top-clientes table and any active `alertas`. Backed by `GET /api/v1/freelance/overview` and `GET /api/v1/freelance/top-clientes`.
+- **Clientes** — list with filter by estado (activo/pausado/terminado/todos), inline edit and "terminar" actions, plus a *+ Nuevo cliente* dialog covering nombre, modalidad (horas/retainer/proyecto), tarifa por hora, retainer mensual, horas comprometidas/mes, fecha inicio, contacto, email, telefono, RFC, notas. Edit also lets you change estado. Backed by `GET/POST/PATCH/DELETE /api/v1/freelance/clientes(/:id)`.
+- **Sesiones** — filter by cliente, fecha desde/hasta. *+ Registrar sesion* dialog logs cliente + fecha + hora_inicio/fin + horas + descripcion + facturable flag. Each row has delete. Backed by `GET/POST/PATCH/DELETE /api/v1/freelance/sesiones(/:id)`.
+- **Facturas** — filter by cliente y estado. *+ Nueva factura* dialog (cliente, subtotal, IVA, fechas emision/vencimiento, numero externo, concepto). Per-row actions: *Marcar pagada* (prompts fecha de pago) y *Cancelar* (prompts razon). Backed by `GET/POST/PATCH /api/v1/freelance/facturas(/:id)`.
+- **Tarifas** — tabla de clientes con su tarifa por hora actual. El boton *Cambiar tarifa* hace `PATCH /clientes/:id` con la nueva `tarifa_hora`; el backend archiva automaticamente el cambio en `freelance_tarifas_history`.
+
+Todos los dialogos usan `<dialog>` nativo. Los montos se muestran en MXN (`Intl.NumberFormat`).
+
 ## Nutrition pipeline (photo / voice → `nutrition_log`)
 
 Item BI.3 turns food photos and voice notes into structured entries in the existing `nutrition_log` table without a manual form.


### PR DESCRIPTION
## Summary

Vanilla-JS Freelance section in the dashboard backed by the existing `/api/v1/freelance/*` endpoints (deployed in #49).

Five tabs under a new sidebar group:

| Tab | Funcionalidad |
|-----|---------------|
| **Resumen** | Selector de mes + 6 KPIs (horas trabajadas / comprometidas, clientes activos, cuentas por cobrar, facturado emitido, facturado pagado), alertas y top-clientes table |
| **Clientes** | Lista con filtro de estado, dialog crear/editar (modalidad, tarifa, retainer, contacto, RFC, notas), accion Terminar |
| **Sesiones** | Filtros por cliente y rango de fechas, dialog para registrar sesion con descripcion + flag facturable, delete por fila |
| **Facturas** | Filtros cliente/estado, dialog para emitir, acciones *Marcar pagada* (prompt fecha) y *Cancelar* (prompt razon) |
| **Tarifas** | Tabla por cliente con boton para cambiar `tarifa_hora`; backend auto-archiva en `freelance_tarifas_history` |

## Implementation

- **`index.html`**: nav entry + 5 `<section data-subsection>` blocks + 3 `<dialog>` modals.
- **`app.js`**: `freelanceState`, 12 API wrappers, render functions, lazy load por subseccion. `initFreelance()` desde el IIFE final.
- **`style.css`**: `.freelance-table`, `.freelance-toolbar`, `.freelance-dialog`, `.fl-badge-*` reutilizando los tokens LifeOS Dark.
- **No build step** — dashboard se sirve via `ServeDir` desde `/usr/share/lifeos/dashboard`.

## Backend shape — descubrimientos

- `GET /freelance/overview` devuelve `horas_trabajadas`, `horas_comprometidas`, `clientes_activos`, `cuentas_por_cobrar`, `facturacion_emitida`, `facturacion_pagada`, `alertas[]` (NO `horas_mes` ni `top_cliente` como sugeria el prompt inicial — UI ajustada).
- Montos son `REAL` (decimal MXN), **no `_centavos`** como otros dominios.
- No existe `GET /tarifas` — la edicion vive en el cliente (`PATCH /clientes/:id` con `tarifa_hora` auto-archiva en `freelance_tarifas_history`).
- No existe `DELETE /facturas/:id` — solo cancelacion via `PATCH { cancelar: true }`.

## Test plan

- [ ] Bootc upgrade en laptop, abrir `http://127.0.0.1:8081/dashboard`, navegar a *Freelance*
- [ ] Crear un cliente nuevo, editar tarifa, verificar que aparece en *Tarifas*
- [ ] Registrar una sesion con horas y descripcion
- [ ] Emitir una factura y marcarla como pagada
- [ ] Verificar que el *Resumen* refleja los datos del mes
- [ ] Probar filtros de estado en clientes/facturas