### PR TITLE
fix(image): -j1 for llama.cpp build to avoid runner OOM

### DIFF
--- a/image/Containerfile
+++ b/image/Containerfile
@@ -141,7 +141,7 @@ RUN set -eux && \
         -DLLAMA_BUILD_TESTS=OFF \
         -DLLAMA_BUILD_EXAMPLES=OFF \
         -DLLAMA_BUILD_SERVER=ON && \
-    cmake --build /tmp/llama.cpp/build -j2 --target llama-server && \
+    cmake --build /tmp/llama.cpp/build -j1 --target llama-server && \
     BUILD_BIN="$(find /tmp/llama.cpp/build -name 'llama-server' -type f | head -1)" && \
     echo ">>> Binary found at: ${BUILD_BIN}" && \
     mkdir -p /out && \


### PR DESCRIPTION
Self-hosted runner (Hector's laptop) was OOM-ing during llama-server link step when lifeosd is also active with full 128K ctx + Qwen-9B in VRAM. Symptom: 'Failed to fork process' for matmul shaders + 'collect2: ld returned 1 exit status'.

Fix: `cmake --build -j1` for llama.cpp. ~5 min slower per build, reliable.

whisper.cpp build (line 171) keeps `-j$(nproc)` — much smaller link.

Test plan:
- [ ] CI passes (this PR's own image build)
- [ ] Subsequent main rebuilds succeed without retries

Discovered while merging PRs #55+#56 (Freelance Dashboard + Benchmarker rework) which both hit this twice in a row.