### PR TITLE
chore: batched local main updates — BLS fix, perf-baseline recovery, per-profile model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "life"
-version = "0.8.16"
+version = "0.8.17"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2626,7 +2626,7 @@ dependencies = [
 
 [[package]]
 name = "lifeos-integration-tests"
-version = "0.8.16"
+version = "0.8.17"
 dependencies = [
  "life",
  "serde_json",
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "lifeosd"
-version = "0.8.16"
+version = "0.8.17"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.16"
+version = "0.8.17"
 
 [workspace.metadata.lifeos]
 codename = "Axolotl"

--- a/daemon/src/ai_runtime_profile.rs
+++ b/daemon/src/ai_runtime_profile.rs
@@ -54,18 +54,36 @@ pub struct RuntimeSettings {
     pub parallel: u32,
     pub batch_size: u32,
     pub ubatch_size: u32,
+    /// Model GGUF filename to load with this profile. None = inherit from
+    /// /etc/lifeos/llama-server.env (the base config). Set per-profile when
+    /// a different model is preferred — e.g. `game_guard_cpu_fallback` runs
+    /// a smaller 4B model on CPU while the game keeps the GPU, vs. the 9B
+    /// that `normal_gpu` uses with full GPU offload.
+    #[serde(default)]
+    pub model: Option<String>,
+    /// Multimodal projector filename. Must match the model's architecture
+    /// (a 4B mmproj will not load alongside a 9B base model). None = inherit.
+    #[serde(default)]
+    pub mmproj: Option<String>,
 }
 
 impl RuntimeSettings {
     pub fn to_env_lines(&self) -> Vec<String> {
-        vec![
+        let mut lines = vec![
             format!("LIFEOS_AI_CTX_SIZE={}", self.ctx_size),
             format!("LIFEOS_AI_THREADS={}", self.threads),
             format!("LIFEOS_AI_GPU_LAYERS={}", self.gpu_layers),
             format!("LIFEOS_AI_PARALLEL={}", self.parallel),
             format!("LIFEOS_AI_BATCH_SIZE={}", self.batch_size),
             format!("LIFEOS_AI_UBATCH_SIZE={}", self.ubatch_size),
-        ]
+        ];
+        if let Some(model) = &self.model {
+            lines.push(format!("LIFEOS_AI_MODEL={model}"));
+        }
+        if let Some(mmproj) = &self.mmproj {
+            lines.push(format!("LIFEOS_AI_MMPROJ={mmproj}"));
+        }
+        lines
     }
 
     pub fn to_env_content(&self, header: &str) -> String {
@@ -550,6 +568,8 @@ fn heuristic_cpu_profile(
         parallel: 1,
         batch_size,
         ubatch_size,
+        model: None,
+        mmproj: None,
     }
 }
 
@@ -591,6 +611,11 @@ fn heuristic_gpu_profile(
         parallel,
         batch_size,
         ubatch_size,
+        // 9B is the canonical LifeOS model for full-GPU operation; pin it
+        // here so a profile-driven write of /var/lib/lifeos/llama-server-runtime-profile.env
+        // restores the 9B even if game_guard had previously swapped to 4B.
+        model: Some("Qwen3.5-9B-Q4_K_M.gguf".into()),
+        mmproj: Some("Qwen3.5-9B-mmproj-F16.gguf".into()),
     })
 }
 
@@ -608,13 +633,32 @@ fn heuristic_game_guard_profile(
     } else {
         384
     };
+    // Game guard runs a smaller 4B model in CPU while the game keeps the GPU.
+    // The user's request: keep the SAME large ctx (up to 131K) so tool-calling
+    // and conversational state stay consistent across profile swaps. RAM cost
+    // for 4B Q4 + Q8 KV cache at 131K ≈ ~6 GB; safe on 32GB+ machines.
+    // Lower-RAM tiers fall back to a smaller ceiling.
+    let ctx_size = if fingerprint.total_ram_mb >= 64 * 1024 {
+        inputs.requested_ctx_size.min(131_072)
+    } else if fingerprint.total_ram_mb >= 32 * 1024 {
+        inputs.requested_ctx_size.min(65_536)
+    } else if fingerprint.total_ram_mb >= 16 * 1024 {
+        inputs.requested_ctx_size.min(16_384)
+    } else {
+        inputs.requested_ctx_size.min(4_096)
+    };
     Some(RuntimeSettings {
-        ctx_size: inputs.requested_ctx_size.min(4096),
+        ctx_size,
         threads: physical.clamp(4, 12),
         gpu_layers: 0,
         parallel: 1,
         batch_size,
         ubatch_size: 128,
+        // Smaller model so tool-calling and chat stay responsive on CPU while
+        // the game holds the GPU. Same Qwen 3.5 family as the 9B → consistent
+        // tool-calling templates and personality.
+        model: Some("Qwen3.5-4B-Q4_K_M.gguf".into()),
+        mmproj: Some("Qwen3.5-4B-mmproj-F16.gguf".into()),
     })
 }
 
@@ -1762,7 +1806,8 @@ async fn run_benchmark_request(
 
 fn build_cpu_candidates(profile: &RuntimeProfile) -> Vec<RuntimeCandidate> {
     let physical = profile.fingerprint.physical_cpus.max(1) as u32;
-    let ctx_size = profile.profiles.cpu_ram.ctx_size;
+    let base = profile.profiles.cpu_ram.clone();
+    let ctx_size = base.ctx_size;
     let ram_mb = profile.fingerprint.total_ram_mb;
     let ubatch_large = if ram_mb >= 32 * 1024 { 256 } else { 128 };
 
@@ -1776,6 +1821,7 @@ fn build_cpu_candidates(profile: &RuntimeProfile) -> Vec<RuntimeCandidate> {
                 parallel: 1,
                 batch_size: 256,
                 ubatch_size: 128,
+                ..base.clone()
             },
         },
         RuntimeCandidate {
@@ -1787,6 +1833,7 @@ fn build_cpu_candidates(profile: &RuntimeProfile) -> Vec<RuntimeCandidate> {
                 parallel: 1,
                 batch_size: if ram_mb >= 16 * 1024 { 384 } else { 256 },
                 ubatch_size: 128,
+                ..base.clone()
             },
         },
         RuntimeCandidate {
@@ -1798,6 +1845,7 @@ fn build_cpu_candidates(profile: &RuntimeProfile) -> Vec<RuntimeCandidate> {
                 parallel: 1,
                 batch_size: if ram_mb >= 16 * 1024 { 512 } else { 384 },
                 ubatch_size: ubatch_large,
+                ..base
             },
         },
     ])
@@ -1805,12 +1853,10 @@ fn build_cpu_candidates(profile: &RuntimeProfile) -> Vec<RuntimeCandidate> {
 
 fn build_game_guard_candidates(profile: &RuntimeProfile) -> Vec<RuntimeCandidate> {
     let physical = profile.fingerprint.physical_cpus.max(1) as u32;
-    let ctx_size = profile
-        .profiles
-        .game_guard_cpu_fallback
-        .as_ref()
-        .map(|settings| settings.ctx_size)
-        .unwrap_or_else(|| profile.inputs.requested_ctx_size.min(4096));
+    let Some(base) = profile.profiles.game_guard_cpu_fallback.clone() else {
+        return Vec::new();
+    };
+    let ctx_size = base.ctx_size;
     let ram_mb = profile.fingerprint.total_ram_mb;
 
     dedupe_candidates(vec![
@@ -1823,6 +1869,7 @@ fn build_game_guard_candidates(profile: &RuntimeProfile) -> Vec<RuntimeCandidate
                 parallel: 1,
                 batch_size: 256,
                 ubatch_size: 128,
+                ..base.clone()
             },
         },
         RuntimeCandidate {
@@ -1834,6 +1881,7 @@ fn build_game_guard_candidates(profile: &RuntimeProfile) -> Vec<RuntimeCandidate
                 parallel: 1,
                 batch_size: if ram_mb >= 16 * 1024 { 384 } else { 256 },
                 ubatch_size: 128,
+                ..base.clone()
             },
         },
         RuntimeCandidate {
@@ -1845,6 +1893,7 @@ fn build_game_guard_candidates(profile: &RuntimeProfile) -> Vec<RuntimeCandidate
                 parallel: 1,
                 batch_size: if ram_mb >= 32 * 1024 { 512 } else { 384 },
                 ubatch_size: 128,
+                ..base
             },
         },
     ])
@@ -1936,11 +1985,26 @@ Available devices:
             parallel: 1,
             batch_size: 384,
             ubatch_size: 128,
+            model: None,
+            mmproj: None,
         };
         let content = settings.to_env_content("test");
         assert!(content.contains("LIFEOS_AI_CTX_SIZE=4096"));
         assert!(content.contains("LIFEOS_AI_THREADS=6"));
         assert!(content.contains("LIFEOS_AI_UBATCH_SIZE=128"));
+        // Without explicit model/mmproj, the env file must NOT pin them so
+        // the base /etc/lifeos/llama-server.env wins.
+        assert!(!content.contains("LIFEOS_AI_MODEL="));
+        assert!(!content.contains("LIFEOS_AI_MMPROJ="));
+
+        let with_model = RuntimeSettings {
+            model: Some("Qwen3.5-4B-Q4_K_M.gguf".into()),
+            mmproj: Some("Qwen3.5-4B-mmproj-F16.gguf".into()),
+            ..settings
+        };
+        let content = with_model.to_env_content("test");
+        assert!(content.contains("LIFEOS_AI_MODEL=Qwen3.5-4B-Q4_K_M.gguf"));
+        assert!(content.contains("LIFEOS_AI_MMPROJ=Qwen3.5-4B-mmproj-F16.gguf"));
     }
 
     #[test]
@@ -1982,6 +2046,8 @@ Available devices:
                     parallel: 1,
                     batch_size: 256,
                     ubatch_size: 128,
+                    model: None,
+                    mmproj: None,
                 },
                 normal_gpu: None,
                 game_guard_cpu_fallback: None,
@@ -2044,6 +2110,8 @@ Available devices:
             parallel: 1,
             batch_size: 256,
             ubatch_size: 128,
+            model: None,
+            mmproj: None,
         };
         let deduped = dedupe_candidates(vec![
             RuntimeCandidate {
@@ -2253,6 +2321,8 @@ EnvironmentFiles=/var/lib/lifeos/llama-server-game-guard.env (ignore_errors=yes)
                 parallel: 1,
                 batch_size: 512,
                 ubatch_size: 256,
+                model: Some("Qwen3.5-9B-Q4_K_M.gguf".into()),
+                mmproj: Some("Qwen3.5-9B-mmproj-F16.gguf".into()),
             });
         }
         profile
@@ -2337,6 +2407,8 @@ EnvironmentFiles=/var/lib/lifeos/llama-server-game-guard.env (ignore_errors=yes)
             parallel: 1,
             batch_size: 512,
             ubatch_size: 256,
+            model: None,
+            mmproj: None,
         };
         // Default path applies the user override (overwriting candidate).
         apply_runtime_env(&candidate).expect("apply");

--- a/daemon/src/api/mod.rs
+++ b/daemon/src/api/mod.rs
@@ -13119,6 +13119,8 @@ mod tests {
                     parallel: 1,
                     batch_size: 256,
                     ubatch_size: 64,
+                    model: None,
+                    mmproj: None,
                 },
                 normal_gpu: Some(RuntimeSettings {
                     ctx_size: 16384,
@@ -13127,6 +13129,8 @@ mod tests {
                     parallel: 1,
                     batch_size: 512,
                     ubatch_size: 128,
+                    model: Some("Qwen3.5-9B-Q4_K_M.gguf".into()),
+                    mmproj: Some("Qwen3.5-9B-mmproj-F16.gguf".into()),
                 }),
                 game_guard_cpu_fallback: Some(RuntimeSettings {
                     ctx_size: 8192,
@@ -13135,6 +13139,8 @@ mod tests {
                     parallel: 1,
                     batch_size: 256,
                     ubatch_size: 64,
+                    model: Some("Qwen3.5-4B-Q4_K_M.gguf".into()),
+                    mmproj: Some("Qwen3.5-4B-mmproj-F16.gguf".into()),
                 }),
             },
             probe_completed: false,

--- a/daemon/src/axi_tools.rs
+++ b/daemon/src/axi_tools.rs
@@ -1896,6 +1896,44 @@ LifeOS lleva el inventario de tus autos, sus mantenimientos, seguros y cargas de
             assert!(simple_glob_match("file-??.txt", "file-01.txt"));
             assert!(!simple_glob_match("*.rs", "main.py"));
         }
+
+        #[tokio::test]
+        async fn history_persist_locked_writes_atomically_with_safe_perms() {
+            // Sprint 2 contract for persist_locked: tempfile + fsync +
+            // rename + parent fsync, with mode 0600 on the resulting file.
+            // We can't observe atomicity directly without crashing the test
+            // process mid-write, but we CAN observe the public surface:
+            //   - the file exists and parses
+            //   - mode is 0o600 (sensitive chat content not world-readable)
+            //   - no .json.tmp leak left behind on success
+            use std::os::unix::fs::PermissionsExt;
+            let history = history_for_tests("persist-perms");
+            let chat_id: i64 = 7;
+            history
+                .append(
+                    chat_id,
+                    &[ChatMessage {
+                        role: "user".into(),
+                        content: serde_json::Value::String("ping".into()),
+                    }],
+                )
+                .await;
+
+            let path = history.persist_path.clone();
+            let meta = std::fs::metadata(&path).expect("persist file should exist after append");
+            assert!(meta.is_file(), "persist path is a file");
+            assert_eq!(
+                meta.permissions().mode() & 0o777,
+                0o600,
+                "persisted history must be mode 0600"
+            );
+            let bytes = std::fs::read(&path).expect("persist file readable");
+            let parsed: HashMap<i64, ConversationEntry> =
+                serde_json::from_slice(&bytes).expect("persist file is valid JSON");
+            assert!(parsed.contains_key(&chat_id), "chat survived round-trip");
+            let tmp = path.with_extension("json.tmp");
+            assert!(!tmp.exists(), "tempfile should not leak on success path");
+        }
     }
 
     // -----------------------------------------------------------------------

--- a/daemon/src/axi_tools.rs
+++ b/daemon/src/axi_tools.rs
@@ -1750,8 +1750,60 @@ LifeOS lleva el inventario de tus autos, sus mantenimientos, seguros y cargas de
             if let Some(parent) = self.persist_path.parent() {
                 std::fs::create_dir_all(parent).ok();
             }
-            if let Ok(json) = serde_json::to_string(chats) {
-                std::fs::write(&self.persist_path, json).ok();
+            // Atomic write: serialize -> tempfile -> fsync -> rename. The
+            // previous std::fs::write was a single non-atomic syscall: a
+            // crash mid-flight (power loss, OOM kill, signal during the
+            // write) leaves a half-written JSON file that fails to parse on
+            // next boot, silently dropping the user's entire conversation
+            // history. rename(2) is atomic for files within the same
+            // directory on Linux, so readers see either the old or the new
+            // contents, never a partial.
+            let json = match serde_json::to_vec(chats) {
+                Ok(j) => j,
+                Err(e) => {
+                    warn!("[history] failed to serialize chats: {}", e);
+                    return;
+                }
+            };
+            let tmp = self.persist_path.with_extension("json.tmp");
+            let write_result = (|| -> std::io::Result<()> {
+                use std::os::unix::fs::OpenOptionsExt;
+                // mode 0600: chat content is sensitive. Without explicit
+                // mode, OpenOptions inherits the umask default (0644) and
+                // rename(2) propagates the tempfile's mode to the target,
+                // silently downgrading the persisted file's perms.
+                let mut f = std::fs::OpenOptions::new()
+                    .create(true)
+                    .write(true)
+                    .truncate(true)
+                    .mode(0o600)
+                    .open(&tmp)?;
+                std::io::Write::write_all(&mut f, &json)?;
+                f.sync_all()?;
+                Ok(())
+            })();
+            if let Err(e) = write_result {
+                warn!("[history] failed to write tempfile {:?}: {}", tmp, e);
+                let _ = std::fs::remove_file(&tmp);
+                return;
+            }
+            if let Err(e) = std::fs::rename(&tmp, &self.persist_path) {
+                warn!(
+                    "[history] failed to rename {:?} -> {:?}: {}",
+                    tmp, self.persist_path, e
+                );
+                let _ = std::fs::remove_file(&tmp);
+                return;
+            }
+            // Parent-directory fsync: rename(2) is atomic, but the new
+            // dirent isn't durable until the parent dir's metadata is
+            // flushed. Without this, a power-loss between rename and the
+            // next implicit flush leaves the directory entry stale and
+            // both names (old+new) potentially gone.
+            if let Some(parent) = self.persist_path.parent() {
+                if let Ok(dir) = std::fs::File::open(parent) {
+                    let _ = dir.sync_all();
+                }
             }
         }
     }

--- a/daemon/src/game_guard.rs
+++ b/daemon/src/game_guard.rs
@@ -1089,6 +1089,10 @@ pub fn effective_gpu_layers(env_path: &str) -> Option<i32> {
 /// while the game runs. On machines with 16 GB+ RAM this is fine; on
 /// lower-memory machines the runtime profile should pick a smaller model.
 pub fn persist_game_guard_override(profile: Option<&RuntimeSettings>) -> Result<()> {
+    // Defensive fallback when the daemon hasn't computed a runtime profile yet
+    // (first boot, missing fingerprint, etc). Pin the smaller 4B model so the
+    // game keeps the GPU; the runtime-profile.env will override these once the
+    // first benchmark completes.
     let profile = profile.cloned().unwrap_or(RuntimeSettings {
         ctx_size: 4096,
         threads: 4,
@@ -1096,6 +1100,8 @@ pub fn persist_game_guard_override(profile: Option<&RuntimeSettings>) -> Result<
         parallel: 1,
         batch_size: 256,
         ubatch_size: 128,
+        model: Some("Qwen3.5-4B-Q4_K_M.gguf".into()),
+        mmproj: Some("Qwen3.5-4B-mmproj-F16.gguf".into()),
     });
     crate::ai_runtime_profile::write_game_guard_override(&profile)?;
     restart_llama_server()?;

--- a/daemon/src/memory_plane.rs
+++ b/daemon/src/memory_plane.rs
@@ -1864,6 +1864,28 @@ impl MemoryPlaneManager {
         }
         let db = Connection::open(db_path).context("Failed to open memory database")?;
         crate::sqlite_protection::ensure_sensitive_perms(db_path);
+
+        // Performance PRAGMAs.
+        //
+        // - journal_mode=WAL: 3-10x write throughput, readers no longer
+        //   blocked by writers. Set via query_row because it returns the
+        //   chosen mode as a result row (pragma_update may error on some
+        //   rusqlite versions). WAL persists at the file level.
+        // - synchronous=NORMAL: paired with WAL, durable enough for our
+        //   use case (tiny power-loss window vs huge perf gain).
+        // - busy_timeout=5000: avoids immediate SQLITE_BUSY when readers
+        //   and writers race; waits up to 5s instead.
+        // - cache_size=-64000: SQLite reads negative as KiB (so 64MB).
+        // - mmap_size=256MB: lets SQLite read pages via mmap once the DB
+        //   exceeds the page cache.
+        // - temp_store=MEMORY: keeps temp btrees in RAM.
+        let _: String = db.query_row("PRAGMA journal_mode = WAL", [], |row| row.get(0))?;
+        db.pragma_update(None, "synchronous", "NORMAL")?;
+        db.pragma_update(None, "busy_timeout", 5000)?;
+        db.pragma_update(None, "cache_size", -64000)?;
+        db.pragma_update(None, "mmap_size", 268435456i64)?;
+        db.pragma_update(None, "temp_store", "MEMORY")?;
+
         Ok(db)
     }
 

--- a/daemon/static/dashboard/index.html
+++ b/daemon/static/dashboard/index.html
@@ -27,20 +27,6 @@
         <span class="sidebar-brand-text">LifeOS</span>
       </div>
       <span class="badge badge-beta" title="LifeOS esta en beta">Beta</span>
-      <button id="privacy-mode-toggle" class="privacy-toggle privacy-off"
-              type="button"
-              aria-pressed="false"
-              title="Modo Privacidad: cuando esta activo, el router solo usa modelos locales (sin nube)">
-        <svg class="privacy-icon" width="14" height="14" viewBox="0 0 24 24" fill="none"
-             stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect>
-          <path d="M7 11V7a5 5 0 0 1 10 0v4"></path>
-        </svg>
-        <span class="privacy-text">Privacidad</span>
-        <span class="privacy-switch" aria-hidden="true">
-          <span class="privacy-switch-thumb"></span>
-        </span>
-      </button>
     </div>
 
     <nav class="sidebar-nav">
@@ -119,6 +105,20 @@
         <span id="connection-badge" class="badge badge-offline">Desconectado</span>
         <span id="ws-badge" class="badge badge-ws badge-offline" title="WebSocket">WS</span>
       </div>
+      <button id="privacy-mode-toggle" class="privacy-toggle privacy-off"
+              type="button"
+              aria-pressed="false"
+              title="Modo Privacidad: cuando esta activo, el router solo usa modelos locales (sin nube)">
+        <svg class="privacy-icon" width="14" height="14" viewBox="0 0 24 24" fill="none"
+             stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect>
+          <path d="M7 11V7a5 5 0 0 1 10 0v4"></path>
+        </svg>
+        <span class="privacy-text">Privacidad</span>
+        <span class="privacy-switch" aria-hidden="true">
+          <span class="privacy-switch-thumb"></span>
+        </span>
+      </button>
       <div class="sidebar-footer-actions">
         <div class="time-display">
           <span id="header-clock" class="time-clock">--:--</span>

--- a/daemon/static/dashboard/style.css
+++ b/daemon/static/dashboard/style.css
@@ -2719,8 +2719,11 @@ details[open] .transcript-toggle::before { transform: rotate(90deg); }
   align-items: center;
   gap: 8px;
   width: 100%;
-  margin: 8px 0 0 0;
-  padding: 8px 12px;
+  /* Lives inside .sidebar-footer (gap:8px between children handles spacing).
+     No margin needed here — setting 0 keeps it pegadito entre Conectado/WS
+     arriba y la hora/tema abajo. */
+  margin: 0;
+  padding: 8px 10px;
   border: 1px solid var(--border, #2a2d3a);
   border-radius: 10px;
   background: var(--bg-elevated, rgba(255, 255, 255, 0.03));

--- a/docs/architecture/service-runtime.md
+++ b/docs/architecture/service-runtime.md
@@ -64,6 +64,16 @@ journalctl -u llama-server -f
   - `/var/lib/lifeos/llama-server-runtime-profile.env`
   - `/var/lib/lifeos/llama-server-game-guard.env`
 
+## Profile model selection (Qwen3.5 9B vs 4B)
+
+`RuntimeSettings` en `daemon/src/ai_runtime_profile.rs` lleva ahora dos campos opcionales `model` y `mmproj` que se emiten como `LIFEOS_AI_MODEL` y `LIFEOS_AI_MMPROJ` en los archivos `runtime-profile.env` y `game-guard.env`. Reglas vigentes:
+
+- **`normal_gpu`**: pinea Qwen3.5-9B-Q4_K_M.gguf + Qwen3.5-9B-mmproj-F16.gguf con `gpu_layers=99`. Es el modelo canónico cuando la GPU está disponible.
+- **`game_guard_cpu_fallback`**: pinea Qwen3.5-4B-Q4_K_M.gguf + Qwen3.5-4B-mmproj-F16.gguf con `gpu_layers=0`. Cuando game_guard detecta un juego, libera la VRAM al juego y deja a Axi corriendo el modelo más chico en CPU pero **conservando ctx grande (hasta 131K en máquinas con ≥ 64GB RAM)** para no perder tool-calling ni contexto conversacional.
+- **`cpu_ram`**: deja `model=None`/`mmproj=None`, hereda lo que esté en `/etc/lifeos/llama-server.env` (default 9B). Es el perfil "no hay GPU disponible" y el usuario decide si bumpea a 4B manualmente.
+
+Como los `EnvironmentFile=` cargan en orden (`llama-server.env` → `runtime-profile.env` → `game-guard.env`), el último archivo presente gana — game_guard puede sobrescribir el modelo del runtime profile, y al limpiarse vuelve al runtime profile (9B en GPU).
+
 ## Fuentes de verdad
 
 Orden de prioridad para entender el runtime real:

--- a/docs/operations/system-admin.md
+++ b/docs/operations/system-admin.md
@@ -204,6 +204,25 @@ not the primary runtime model.
 
 When bumping these in `image/Containerfile`, also update this table and the canonical upgrade checklist.
 
+### Memory plane SQLite tuning
+
+Every connection opened by `MemoryPlaneManager::open_db` enables WAL +
+synchronous=NORMAL + busy_timeout=5000 + cache_size=64 MiB +
+mmap_size=256 MiB + temp_store=MEMORY. WAL gives 3–10× write throughput
+and lets readers proceed during writes; the small power-loss durability
+window is acceptable for a personal assistant. To verify on a running
+host:
+
+```bash
+sqlite3 ~/.local/share/lifeos/memory.db 'PRAGMA journal_mode; PRAGMA synchronous;'
+# expect: wal / 1
+```
+
+`conversation_history.json` is now persisted with a tempfile + fsync +
+rename + parent-dir fsync sequence, with mode 0600 on the resulting
+file. Crash mid-write no longer corrupts the file, and the file is no
+longer world-readable across the rename.
+
 ```bash
 # Manage default system service
 sudo systemctl start llama-server

--- a/docs/operations/system-admin.md
+++ b/docs/operations/system-admin.md
@@ -35,7 +35,8 @@ LifeOS System Services
 │   ├── lifeos-flatpak-nvidia-sync.service system  GPU driver ↔ Flatpak GL sync
 │   ├── lifeos-security-baseline.service   system  CIS hardening baseline
 │   ├── lifeos-sentinel.service            system  System monitoring
-│   └── lifeos-cosmic-greeter-branding.service system Login screen branding
+│   ├── lifeos-cosmic-greeter-branding.service system Login screen branding
+│   └── lifeos-refresh-bls-titles.service   system  Refresh GRUB titles after bootc upgrade
 │
 ├── Hardware Management
 │   ├── lifeos-thermal.service             system  Thermal throttling

--- a/image/Containerfile
+++ b/image/Containerfile
@@ -932,6 +932,7 @@ COPY image/files/usr/local/bin/lifeos-detect-ecores.sh        /usr/local/bin/lif
 COPY image/files/usr/local/bin/lifeos-epp-switch.sh           /usr/local/bin/lifeos-epp-switch.sh
 COPY image/files/usr/local/bin/lifeos-thermal-grant.sh        /usr/local/bin/lifeos-thermal-grant.sh
 COPY image/files/usr/local/bin/lifeos-isolate-process.sh      /usr/local/bin/lifeos-isolate-process
+COPY image/files/usr/local/bin/lifeos-refresh-bls-titles.sh   /usr/local/bin/lifeos-refresh-bls-titles.sh
 RUN chmod +x /usr/local/bin/lifeos-first-boot.sh \
              /usr/local/bin/lifeos-apply-default-layout.sh \
              /usr/local/bin/lifeos-cosmic-snapshot \
@@ -959,7 +960,8 @@ RUN chmod +x /usr/local/bin/lifeos-first-boot.sh \
              /usr/local/bin/lifeos-detect-ecores.sh \
              /usr/local/bin/lifeos-epp-switch.sh \
              /usr/local/bin/lifeos-thermal-grant.sh \
-             /usr/local/bin/lifeos-isolate-process
+             /usr/local/bin/lifeos-isolate-process \
+             /usr/local/bin/lifeos-refresh-bls-titles.sh
 
 # --- Pre-trained wake word model (works from first boot) ---
 # Generate synthetic "Axi" samples with espeak-ng and build the rustpotter .rpw model.
@@ -1104,6 +1106,7 @@ RUN ln -sf /usr/lib/systemd/system/cosmic-greeter.service /etc/systemd/system/di
 # Copiar unit files desde el repo
 COPY image/files/etc/systemd/system/lifeos-first-boot.service /usr/lib/systemd/system/lifeos-first-boot.service
 COPY image/files/etc/systemd/system/lifeos-cosmic-greeter-branding.service /usr/lib/systemd/system/lifeos-cosmic-greeter-branding.service
+COPY image/files/etc/systemd/system/lifeos-refresh-bls-titles.service /usr/lib/systemd/system/lifeos-refresh-bls-titles.service
 COPY image/files/etc/systemd/system/llama-server.service       /usr/lib/systemd/system/llama-server.service
 COPY image/files/etc/systemd/system/llama-server.service.d/10-fast-kill.conf /etc/systemd/system/llama-server.service.d/10-fast-kill.conf
 COPY image/files/etc/systemd/system/llama-embeddings.service   /usr/lib/systemd/system/llama-embeddings.service
@@ -1181,6 +1184,7 @@ RUN mkdir -p /usr/lib/systemd/system/multi-user.target.wants \
     ln -sf /usr/lib/systemd/system/lifeos-nvidia-signed-modules.service /usr/lib/systemd/system/multi-user.target.wants/lifeos-nvidia-signed-modules.service && \
     ln -sf /usr/lib/systemd/system/lifeos-security-baseline.service /usr/lib/systemd/system/multi-user.target.wants/lifeos-security-baseline.service && \
     ln -sf /usr/lib/systemd/system/lifeos-sentinel.service /usr/lib/systemd/system/multi-user.target.wants/lifeos-sentinel.service && \
+    ln -sf /usr/lib/systemd/system/lifeos-refresh-bls-titles.service /usr/lib/systemd/system/multi-user.target.wants/lifeos-refresh-bls-titles.service && \
     ln -sf /usr/lib/systemd/system/simplex-chat.service /usr/lib/systemd/system/multi-user.target.wants/simplex-chat.service && \
     # Canonical enablement: lifeosd starts from the graphical session target
     # so it waits for the display server to be ready (fixes the tray-icon

--- a/image/Containerfile
+++ b/image/Containerfile
@@ -141,6 +141,7 @@ RUN set -eux && \
         -DLLAMA_BUILD_TESTS=OFF \
         -DLLAMA_BUILD_EXAMPLES=OFF \
         -DLLAMA_BUILD_SERVER=ON && \
+    cmake --build /tmp/llama.cpp/build -j2 --target vulkan-shaders-gen 2>/dev/null || true && \
     cmake --build /tmp/llama.cpp/build -j1 --target llama-server && \
     BUILD_BIN="$(find /tmp/llama.cpp/build -name 'llama-server' -type f | head -1)" && \
     echo ">>> Binary found at: ${BUILD_BIN}" && \

--- a/image/files/etc/systemd/system/lifeos-refresh-bls-titles.service
+++ b/image/files/etc/systemd/system/lifeos-refresh-bls-titles.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=LifeOS — refresh BLS entry titles after bootc upgrade
+DefaultDependencies=no
+After=local-fs.target
+Before=multi-user.target shutdown.target
+Conflicts=shutdown.target
+ConditionPathIsDirectory=/boot/loader/entries
+ConditionPathExists=/usr/bin/bootc
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/lifeos-refresh-bls-titles.sh
+RemainAfterExit=yes
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=lifeos-refresh-bls-titles
+
+[Install]
+WantedBy=multi-user.target

--- a/image/files/usr/local/bin/lifeos-refresh-bls-titles.sh
+++ b/image/files/usr/local/bin/lifeos-refresh-bls-titles.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Refreshes /boot/loader/entries/*.conf titles to match each ostree deploy's PRETTY_NAME.
+#
+# bootc upgrade does not regenerate BLS entries when the kernel is unchanged
+# across versions, so the title field can stay stale across version bumps
+# (e.g. GRUB shows "LifeOS 0.8.11" while the running deploy is 0.8.16).
+# This service runs at boot, reads PRETTY_NAME from each deploy's own
+# /etc/os-release, and rewrites the title accordingly. Idempotent.
+
+set -euo pipefail
+
+BLS_DIR=/boot/loader/entries
+DEPLOY_ROOT=/ostree/deploy/default/deploy
+
+[ -d "$BLS_DIR" ] || exit 0
+command -v bootc >/dev/null 2>&1 || exit 0
+command -v python3 >/dev/null 2>&1 || exit 0
+
+bootc_status=$(bootc status --format=json 2>/dev/null) || exit 0
+
+read_csum() {
+    printf '%s' "$bootc_status" | python3 -c "
+import json, sys
+d = json.load(sys.stdin).get('status', {}).get('$1') or {}
+print((d.get('ostree') or {}).get('checksum', ''))
+"
+}
+
+booted_csum=$(read_csum booted)
+rollback_csum=$(read_csum rollback)
+
+declare -A CSUM_BY_IDX=( [0]="$booted_csum" [1]="$rollback_csum" )
+
+shopt -s nullglob
+for entry in "$BLS_DIR"/ostree-*.conf; do
+    idx=$(grep -oE '\(ostree:[0-9]+\)' "$entry" | head -1 | grep -oE '[0-9]+' || true)
+    [ -n "${idx:-}" ] || continue
+    csum="${CSUM_BY_IDX[$idx]:-}"
+    [ -n "$csum" ] || continue
+
+    deploy_dir=$(printf '%s\n' "$DEPLOY_ROOT/$csum".[0-9]* 2>/dev/null | head -1)
+    [ -d "$deploy_dir" ] || continue
+
+    pretty=$(awk -F= '$1=="PRETTY_NAME"{val=$2; gsub(/^"|"$/, "", val); print val; exit}' \
+                 "$deploy_dir/etc/os-release" 2>/dev/null || true)
+    [ -n "$pretty" ] || continue
+
+    new_title="title $pretty (ostree:$idx)"
+    current_title=$(grep -E '^title ' "$entry" | head -1 || true)
+
+    if [ "$current_title" != "$new_title" ]; then
+        # /boot is mutable on bootc; write atomically.
+        tmp=$(mktemp "$entry.XXXXXX")
+        sed "s|^title .*|$new_title|" "$entry" > "$tmp"
+        mv -f "$tmp" "$entry"
+        chmod 0644 "$entry"
+        echo "lifeos-refresh-bls-titles: $(basename "$entry") -> $new_title" >&2
+    fi
+done


### PR DESCRIPTION
## Summary

Batched 8 commits that were sitting locally. Mix of image fixes, perf, polish, and one architectural feat. Bumps version to 0.8.17.

### What ships

- **fix(image): refresh BLS entry titles after bootc upgrade** (`fe8ccd6`) — adds `lifeos-refresh-bls-titles.service` (oneshot at boot) that rewrites `/boot/loader/entries/*.conf` titles using each ostree deploy's own `PRETTY_NAME`. Solves the issue where GRUB shows stale version labels (e.g. "0.8.10/0.8.11") when the kernel doesn't change across bootc upgrades.

- **polish(dashboard): move privacy toggle to sidebar-footer** (`1214081`) — recovered from the dropped `chore/polish-batch-1` branch. UX preview-validated 2026-04-24.

- **perf(memory): SQLite PRAGMAs + atomic write + tests + docs** (`160799f` + `ad790e6` + `33d603e`) — recovered from the closed PR #45. WAL + synchronous=NORMAL + 64MB cache + 256MB mmap; atomic temp+rename for `conversation_history.json`; regression test for atomic-persist + 0600 perms; system-admin doc.

- **fix(image): serialize llama.cpp link to avoid Vulkan shader race** (`1a8cebf`) — pre-builds `vulkan-shaders-gen` with `-j2` (small target) before the main `-j1` server build from PR #57. Both fixes complement each other.

- **feat(ai-runtime): per-profile model selection — 9B normal_gpu, 4B game_guard fallback** (`b4d3a74`) — adds optional `model`/`mmproj` fields to `RuntimeSettings` so each profile pins its own llama-server model:
  - \`normal_gpu\` → Qwen3.5-9B-Q4_K_M (gpu_layers=99)
  - \`game_guard_cpu_fallback\` → Qwen3.5-4B-Q4_K_M (gpu_layers=0, ctx up to 131K on 64GB+ RAM hosts)
  - \`cpu_ram\` → inherits base config

  Replaces the previous "9B in CPU at 4K ctx" fallback that was destroying tool-calling and language quality during gameplay. Refactors \`build_cpu_candidates\` and \`build_game_guard_candidates\` to use struct spread so benchmark candidates inherit the profile model.

- **chore: bump version to 0.8.17** (\`7063738\`)

### Pending after merge

- Image rebuild + deploy to laptop. BLS title fix only applies on the next bootc upgrade.
- **Silent-forgetting bug** (Axi narrating tool calls without invoking them) is INDEPENDENT of this PR — user confirmed it occurred before game_guard activated. Tracked in engram #777, follow-up PR.

## Test plan

- [ ] CI green
- [ ] After deploy: verify privacy toggle in \`.sidebar-footer\` (not \`.sidebar-brand\`)
- [ ] After deploy: trigger \`re9.exe\` and verify \`ps\` shows \`Qwen3.5-4B-Q4_K_M.gguf\` (not 9B)
- [ ] After deploy: close game and verify llama-server back on 9B + GPU
- [ ] After deploy: verify GRUB titles match running PRETTY_NAME after bootc upgrade