### PR TITLE
hotfix(image): drop --target llama-server so vulkan-shaders-gen actually runs (ubuntu-latest)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "life"
-version = "0.8.19"
+version = "0.8.20"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2626,7 +2626,7 @@ dependencies = [
 
 [[package]]
 name = "lifeos-integration-tests"
-version = "0.8.19"
+version = "0.8.20"
 dependencies = [
  "life",
  "serde_json",
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "lifeosd"
-version = "0.8.19"
+version = "0.8.20"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.19"
+version = "0.8.20"
 
 [workspace.metadata.lifeos]
 codename = "Axolotl"

--- a/image/Containerfile
+++ b/image/Containerfile
@@ -141,13 +141,16 @@ RUN set -eux && \
         -DLLAMA_BUILD_TESTS=OFF \
         -DLLAMA_BUILD_EXAMPLES=OFF \
         -DLLAMA_BUILD_SERVER=ON && \
-    # -j1 alone resolves the Vulkan shader race intrinsically — CMake builds
-    # vulkan-shaders-gen first because llama-server depends on it. The earlier
-    # split build (`-j2 vulkan-shaders-gen 2>/dev/null || true` then `-j1
-    # llama-server`) silently swallowed shader-gen failures (OOM under -j2 on
-    # the self-hosted runner) and the linker then failed with thousands of
-    # `undefined reference to matmul_id_subgroup_*` symbols.
-    cmake --build /tmp/llama.cpp/build -j1 --target llama-server && \
+    # Build the full default target chain (no --target). This runs the
+    # vulkan-shaders-gen executable AND its add_custom_command that generates
+    # ggml-vulkan-shaders source — passing only `--target llama-server`
+    # builds the gen executable but does not always trigger the generation
+    # step on ubuntu-latest, which then fails the link with thousands of
+    # `undefined reference to matmul_id_subgroup_*` symbols. -j1 keeps memory
+    # pressure low (matters on self-hosted under llama-server stress and
+    # equally on the 16GB ubuntu-latest runner) and lets CMake walk the
+    # dependency graph serially.
+    cmake --build /tmp/llama.cpp/build -j1 && \
     BUILD_BIN="$(find /tmp/llama.cpp/build -name 'llama-server' -type f | head -1)" && \
     echo ">>> Binary found at: ${BUILD_BIN}" && \
     mkdir -p /out && \


### PR DESCRIPTION
## What broke

Release Channels has been failing on main since PR #58 with thousands of:

```
undefined reference to `matmul_id_subgroup_iq2_s_f32_aligned_f16acc_cm1_data'
```

PR #60 thought the cause was the broken `-j2 vulkan-shaders-gen 2>/dev/null || true` pre-build line. Removing it didn't fix Release Channels (passes on self-hosted, still fails on ubuntu-latest).

## Real root cause

`Release Channels` runs on `ubuntu-latest` (GitHub-hosted). The PR-level `Build and Push Image` runs on self-hosted (Hector's hardware). Same Containerfile, different result.

`cmake --build --target llama-server -j1` builds the `vulkan-shaders-gen` executable as a dep, but does not always trigger the `add_custom_command` that runs it to generate `ggml-vulkan-shaders.cpp`. On self-hosted that step somehow happens (cmake/podman cache); on a clean ubuntu-latest it gets skipped, and ggml-vulkan.cpp links against extern declarations to symbols that don't exist.

## The fix

Drop `--target llama-server`. With no target, `cmake --build` walks the full default target chain — runs ALL custom commands including the shader-source generation. Keep `-j1` to limit memory pressure (16GB on ubuntu-latest, plus general OOM safety).

Bumps version to 0.8.20.

## Test plan

- [ ] CI green on this PR
- [ ] After merge: Release Channels passes on main
- [ ] After merge: deploy to laptop succeeds and `llama-server --version` works