### PR TITLE
feat(axi): tool-calling via OpenAI tools API + intent inference + ambiguity rule

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "life"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2626,7 +2626,7 @@ dependencies = [
 
 [[package]]
 name = "lifeos-integration-tests"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "life",
  "serde_json",
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "lifeosd"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.20"
+version = "0.8.21"
 
 [workspace.metadata.lifeos]
 codename = "Axolotl"

--- a/daemon/src/agent_loop.rs
+++ b/daemon/src/agent_loop.rs
@@ -208,7 +208,7 @@ Rules:
         preferred_provider: None,
         max_tokens: Some(100),
         task_type: None,
-    tools: None,
+        tools: None,
     };
 
     let router_guard = router.read().await;

--- a/daemon/src/agent_loop.rs
+++ b/daemon/src/agent_loop.rs
@@ -208,6 +208,7 @@ Rules:
         preferred_provider: None,
         max_tokens: Some(100),
         task_type: None,
+    tools: None,
     };
 
     let router_guard = router.read().await;

--- a/daemon/src/api/mod.rs
+++ b/daemon/src/api/mod.rs
@@ -12434,7 +12434,7 @@ async fn post_llm_chat(
             preferred_provider: None,
             max_tokens: None,
             task_type: None,
-        tools: None,
+            tools: None,
         };
 
         let router = state.llm_router.read().await;

--- a/daemon/src/api/mod.rs
+++ b/daemon/src/api/mod.rs
@@ -12434,6 +12434,7 @@ async fn post_llm_chat(
             preferred_provider: None,
             max_tokens: None,
             task_type: None,
+        tools: None,
         };
 
         let router = state.llm_router.read().await;

--- a/daemon/src/axi_tools.rs
+++ b/daemon/src/axi_tools.rs
@@ -1644,7 +1644,7 @@ LifeOS lleva el inventario de tus autos, sus mantenimientos, seguros y cargas de
                 preferred_provider: None,
                 max_tokens: Some(256),
                 task_type: None,
-            tools: None,
+                tools: None,
             };
 
             let r = router.read().await;
@@ -2229,7 +2229,7 @@ Listo!"#;
             preferred_provider: None,
             max_tokens: Some(512),
             task_type: None,
-        tools: None,
+            tools: None,
         };
 
         let router = ctx.router.read().await;
@@ -4092,7 +4092,7 @@ Listo!"#;
             preferred_provider: None,
             max_tokens: Some(1024),
             task_type: None,
-        tools: None,
+            tools: None,
         };
 
         let router = ctx.router.read().await;
@@ -10673,7 +10673,7 @@ Listo!"#;
             preferred_provider: model.map(|m| m.to_string()),
             max_tokens: Some(2048),
             task_type: None,
-        tools: None,
+            tools: None,
         };
 
         let router = ctx.router.read().await;
@@ -11450,7 +11450,7 @@ Listo!"#;
             preferred_provider: None,
             max_tokens: Some(512),
             task_type: None,
-        tools: None,
+            tools: None,
         };
 
         let router = ctx.router.read().await;

--- a/daemon/src/axi_tools.rs
+++ b/daemon/src/axi_tools.rs
@@ -96,31 +96,32 @@ REGLAS DE TIEMPO:
 - SIEMPRE confirma la hora calculada: "Te recuerdo el lunes 31 de marzo a las 15:00 (CST)."
 - Si no estas seguro de la hora que quiere el usuario, PREGUNTA.
 
-REGLAS DE RECORDATORIOS (CRITICAS — obligatorio usar herramienta):
-- Si el usuario dice "recuerdame", "avisame", "a las X recordame", "en N minutos dime", etc., DEBES llamar la herramienta reminder_add INMEDIATAMENTE. NUNCA digas "programado" sin haber ejecutado la herramienta.
-- Para un recordatorio ONE-SHOT (una sola vez), usa reminder_add — NO uses cron_add.
-- Para tareas RECURRENTES ("todos los dias a las 7", "cada lunes"), usa cron_add.
-- Si no ejecutaste la herramienta, NO afirmes que el recordatorio quedo programado — es una mentira.
-- Despues de ejecutar reminder_add, confirma al usuario el ID y la hora exacta devuelta por la herramienta.
+## Cómo invocar herramientas (NATIVO, no en texto)
 
-EJEMPLOS OBLIGATORIOS de recordatorios:
+Las herramientas viajan en el canal `tool_calls` del API (no en el cuerpo del mensaje). El runtime te las pasa como functions estructuradas; vos respondés llamándolas con sus argumentos JSON. NUNCA pegues el JSON en el texto del mensaje al usuario — eso no ejecuta nada y termina pareciendo una mentira: Axi diría "ya guardé X" sin haber guardado nada. Si el tool_call no aparece en tu salida estructurada, **no afirmes que ejecutaste la acción**.
 
-Usuario: "Recuerdame en 1 minuto que te diga hola"
-Tu respuesta DEBE empezar con el tool call:
-<tool>reminder_add</tool>
-<args>{"in_minutes": 1, "message": "te diga hola"}</args>
-(Despues de ver el resultado, confirmas al usuario.)
+## Reglas de inferencia de intención
 
-Usuario: "Avisame a las 17:00 que me tengo que ir a banar"
-Tu respuesta DEBE empezar con el tool call:
-<tool>reminder_add</tool>
-<args>{"when": "17:00", "message": "Ir a banarse"}</args>
+Vos decidís cuándo llamar tools — el usuario NO necesita decir "guardá", "registrá" ni "anotá". Inferí del contexto:
 
-FORMATO ESTRICTO: el nombre de la herramienta va DIRECTAMENTE entre <tool>...</tool>, en la misma linea, sin <name> ni saltos. Despues, en una linea separada, <args>{...}</args>. Si emites cualquier otro formato (envoltorio <name>, <tool> con saltos internos, espacios), el parser falla y la herramienta NO se ejecuta — Axi narra que hizo algo sin haberlo hecho.
+- **Datos con formato reconocible** (números de presión arterial `116/78`, glucosa `glucose 110 mg/dL en ayunas`, peso `63.8 kg`, temperatura, IMC, pulso) → ejecutá `vital_record` directo, una llamada por métrica. Confirmá con cifras concretas.
+- **Hechos permanentes declarativos** ("soy alérgico a X", "mi tipo de sangre es O+", "tomo metformina 500mg cada 12h") → ejecutá la tool correspondiente (`health_fact_add`, `medication_start`, etc.) inmediatamente.
+- **Recordatorios y alarmas** ("avisame en 30 min", "recuerdame mañana") → `reminder_add` siempre. Si decís "ya te recuerdo" sin emitir el tool_call, mentís.
+- **Pedidos de búsqueda/recuperación** ("qué guardé sobre X", "tráeme mis vitales") → la tool de listado/recall correspondiente.
 
-NUNCA respondas "Listo, te recordaré" sin haber emitido un <tool>...</tool> para reminder_add PRIMERO.
+## Regla de ambigüedad — preguntá antes de actuar
 
-Cuando el usuario te pida algo que requiera una accion real, usa las herramientas. Si es solo conversacion, responde directamente.
+Si el mensaje del usuario podría ser un **registro** O una **pregunta/preocupación**, NO ejecutes la tool sin más; preguntá primero. Ejemplos:
+
+- *"Sentí una bola en el cuello hace 2 semanas"* — ambiguo entre síntoma compartido y antecedente médico. Respondé sugiriendo ver al médico Y preguntá: "¿Querés que lo registre como antecedente médico?"
+- *"Me duele la cabeza"* — ambiguo entre conversación y registro de dolor. Preguntá: "¿Lo registro como una entrada de dolor con intensidad / duración?"
+- *"Hoy dormí poco"* — ambiguo. Si querés precisión, preguntá horas y registrá `sleep_hours`; si es comentario social, no llames tool.
+
+Cuando preguntes, hacelo CONCRETO ("¿lo guardo como X o lo dejamos para hablar y nada más?") — no genérico.
+
+## Anti-mentira (regla absoluta)
+
+Después de emitir tu respuesta, mirá lo que dijiste. Si tu texto contiene "ya guardé", "lo anoté", "queda registrado", "ya programé el recordatorio" — y NO emitiste el tool_call correspondiente — **estás mintiéndole al usuario**. Reformulá: o ejecutá la tool ahora, o decí honestamente "no logré guardarlo, intentémoslo de nuevo". El usuario confía en que cuando decís que algo está guardado, está guardado.
 
 ## Protocolo de Memoria (OBLIGATORIO — siempre activo)
 
@@ -140,12 +141,11 @@ Si el usuario pide CREAR, DESARROLLAR, REFACTORIZAR o DISENAR algo de software (
 
 ## Herramientas disponibles
 
-Para usar una herramienta, escribe EXACTAMENTE este formato (una herramienta por bloque):
+Las herramientas con schema estructurado (`remember`, `recall`, `reminder_add`, `health_fact_add`, `health_fact_list`, `vital_record`, `vital_history`, `medication_start`, `medication_stop`, `medication_active`, `lab_add`, `health_summary`) viajan vía el canal `tools` del API y vos las invocás como function calls — NO escribas su JSON en el cuerpo del mensaje.
 
-<tool>nombre_herramienta</tool>
-<args>{"param": "valor"}</args>
+Para todas las DEMÁS herramientas listadas abajo, el runtime aún acepta el formato textual legacy `<tool>nombre</tool>\n<args>{...}</args>` (una por bloque). Idealmente movemos todo al canal estructurado a futuro; mientras tanto, ambos modos coexisten.
 
-Herramientas:
+Herramientas (formato legacy):
 
 1. **screenshot** — Captura la pantalla actual.
    args: {} (sin parametros)
@@ -1644,6 +1644,7 @@ LifeOS lleva el inventario de tus autos, sus mantenimientos, seguros y cargas de
                 preferred_provider: None,
                 max_tokens: Some(256),
                 task_type: None,
+            tools: None,
             };
 
             let r = router.read().await;
@@ -2228,6 +2229,7 @@ Listo!"#;
             preferred_provider: None,
             max_tokens: Some(512),
             task_type: None,
+        tools: None,
         };
 
         let router = ctx.router.read().await;
@@ -2489,6 +2491,201 @@ Listo!"#;
     pub struct ToolCall {
         pub name: String,
         pub args: serde_json::Value,
+    }
+
+    /// OpenAI-format tool specs forwarded to the LLM via `RouterRequest.tools`.
+    ///
+    /// `--jinja` on llama-server renders these via the Qwen3.5 chat template,
+    /// so the model emits a structured `choices[0].message.tool_calls` array
+    /// instead of stuffing markdown JSON into `content`. That removes a long-
+    /// standing class of silent-forgetting bugs where the model claimed to
+    /// have saved data but never actually invoked the tool because its output
+    /// format did not match the legacy `<tool>...</tool>` text scanner.
+    ///
+    /// Schema design notes:
+    /// - Coverage is intentionally narrow: the highest-leverage write tools
+    ///   (memory, reminders, health facts/vitals, finance) get specs; deeper
+    ///   tools still rely on the legacy text scanner via `parse_tool_calls`.
+    /// - Descriptions are written for the model, not the user. They tell it
+    ///   when to fire (`when the user reports a measurement`) and crucially
+    ///   when NOT to fire (`do not invoke for ambiguous symptom reports —
+    ///   ask first`).
+    /// - Required vs optional args mirror the executor's `arg_str` calls so
+    ///   the model gets useful 4xx feedback if it hallucinates a missing key.
+    pub fn build_axi_tool_specs() -> Vec<serde_json::Value> {
+        use serde_json::json;
+        let f = |name: &str, description: &str, parameters: serde_json::Value| {
+            json!({
+                "type": "function",
+                "function": {
+                    "name": name,
+                    "description": description,
+                    "parameters": parameters,
+                }
+            })
+        };
+        let obj = |required: &[&str], properties: serde_json::Value| {
+            json!({
+                "type": "object",
+                "properties": properties,
+                "required": required.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+            })
+        };
+
+        vec![
+            f(
+                "remember",
+                "Save a fact to long-term memory that should survive across sessions. \
+                 Call this any time the user states a stable preference, fact about \
+                 themselves, decision, or anything they would expect Axi to recall \
+                 weeks later. Do NOT use this for fleeting context (use the \
+                 conversation buffer instead).",
+                obj(
+                    &["type", "topic", "title", "content"],
+                    json!({
+                        "type": {"type": "string", "description": "bugfix | decision | architecture | discovery | pattern | config | preference"},
+                        "topic": {"type": "string", "description": "Stable topic key, e.g. 'usuario:gustos'"},
+                        "title": {"type": "string", "description": "Short verb+what, e.g. 'Cafe sin azucar'"},
+                        "content": {"type": "string", "description": "What/Why/Learned in plain prose"},
+                        "tags": {"type": "string", "description": "Optional comma-separated tags"},
+                    }),
+                ),
+            ),
+            f(
+                "recall",
+                "Search the user's persistent memory for relevant past entries.",
+                obj(&["query"], json!({"query": {"type": "string"}})),
+            ),
+            f(
+                "reminder_add",
+                "Schedule a one-shot reminder. Call this whenever the user asks to be \
+                 reminded, alerted, or pinged about something at a future moment. NEVER \
+                 reply 'I'll remind you' without invoking this — that is hallucination.",
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "in_minutes": {"type": "integer", "description": "Relative offset, e.g. 15 = 15 min from now"},
+                        "when": {"type": "string", "description": "Absolute time, e.g. '17:00' or '2026-04-30T09:00'"},
+                        "message": {"type": "string", "description": "What the reminder text should say"},
+                    },
+                    "required": ["message"],
+                }),
+            ),
+            f(
+                "health_fact_add",
+                "Save a permanent health fact (allergy, chronic condition, blood type, \
+                 emergency contact, donor status, insurance). Call this when the user \
+                 states something like 'I'm allergic to X', 'my blood type is X', or \
+                 explicitly asks to record/save a fact. AMBIGUITY RULE: if the user \
+                 reports a symptom or worry (e.g. 'I felt a lump in my neck'), do NOT \
+                 auto-invoke — ask first whether to register it as a medical antecedent.",
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "fact_type": {"type": "string", "description": "allergy|condition|blood_type|emergency_contact|donor|insurance|other"},
+                        "label": {"type": "string", "description": "Short label, e.g. 'Penicilina', 'O+'"},
+                        "severity": {"type": "string", "description": "Optional: mild|moderate|severe|life_threatening"},
+                        "notes": {"type": "string"},
+                    },
+                    "required": ["fact_type", "label"],
+                }),
+            ),
+            f(
+                "health_fact_list",
+                "List the user's saved permanent health facts, optionally filtered by type.",
+                json!({
+                    "type": "object",
+                    "properties": {"fact_type": {"type": "string"}},
+                }),
+            ),
+            f(
+                "vital_record",
+                "Record a single vital-sign reading. Fire this whenever the user sends \
+                 a measurement that fits a known vital type — including bare numbers \
+                 in conventional formats like '116/78 59 pulses' (= systolic 116, \
+                 diastolic 78, heart_rate_resting 59). For blood pressure, emit two \
+                 separate calls (systolic + diastolic) with the same measured_at.",
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "vital_type": {"type": "string", "description": "glucose|weight|blood_pressure_systolic|blood_pressure_diastolic|heart_rate_resting|temperature|oxygen_saturation|sleep_hours|mood|pain_intensity|migraine_intensity"},
+                        "value_numeric": {"type": "number"},
+                        "unit": {"type": "string"},
+                        "context": {"type": "string", "description": "Optional, e.g. 'en ayunas'"},
+                        "measured_at": {"type": "string", "description": "Optional ISO timestamp; defaults to now"},
+                    },
+                    "required": ["vital_type", "value_numeric"],
+                }),
+            ),
+            f(
+                "vital_history",
+                "Return time-series of a vital, most recent first.",
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "vital_type": {"type": "string"},
+                        "limit": {"type": "integer", "description": "Default 30"},
+                    },
+                    "required": ["vital_type"],
+                }),
+            ),
+            f(
+                "medication_start",
+                "Record the user starting a medication. If they were already on a \
+                 different dose of the same drug, call medication_stop on the old \
+                 entry first.",
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "dosage": {"type": "string"},
+                        "frequency": {"type": "string"},
+                        "condition": {"type": "string"},
+                        "prescribed_by": {"type": "string"},
+                        "notes": {"type": "string"},
+                    },
+                    "required": ["name", "dosage", "frequency"],
+                }),
+            ),
+            f(
+                "medication_stop",
+                "Mark the user as having stopped a medication. Needs the med_id from medication_active.",
+                json!({
+                    "type": "object",
+                    "properties": {"med_id": {"type": "string"}},
+                    "required": ["med_id"],
+                }),
+            ),
+            f(
+                "medication_active",
+                "List medications the user is currently taking.",
+                json!({"type": "object", "properties": {}}),
+            ),
+            f(
+                "lab_add",
+                "Record a lab result.",
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "test_name": {"type": "string"},
+                        "value_numeric": {"type": "number"},
+                        "unit": {"type": "string"},
+                        "reference_low": {"type": "number"},
+                        "reference_high": {"type": "number"},
+                        "lab_name": {"type": "string"},
+                        "notes": {"type": "string"},
+                    },
+                    "required": ["test_name"],
+                }),
+            ),
+            f(
+                "health_summary",
+                "Return the full health snapshot: permanent facts + active meds + \
+                 recent vitals + recent labs. Use it for medical-visit prep or full \
+                 history reviews.",
+                json!({"type": "object", "properties": {}}),
+            ),
+        ]
     }
 
     /// Parse tool calls from LLM response text.
@@ -3477,6 +3674,12 @@ Listo!"#;
                 preferred_provider: None,
                 max_tokens: Some(2048),
                 task_type: None,
+                // OpenAI tool specs forwarded to llama-server (`--jinja` renders
+                // them via the model's chat template). Qwen3.5 emits structured
+                // tool_calls back instead of markdown JSON in `content`. Falls
+                // back to inline `<tool>...</tool>` text parsing if the model
+                // declined to use the structured channel.
+                tools: Some(build_axi_tool_specs()),
             };
 
             let router = ctx.router.read().await;
@@ -3492,8 +3695,23 @@ Listo!"#;
             let response_text = response.text.clone();
             let provider = response.provider.clone();
 
-            // Parse tool calls from LLM response
-            let (tool_calls, text_before_tools) = parse_tool_calls(&response_text);
+            // Prefer the structured `tool_calls` returned by the OpenAI API;
+            // fall back to scanning the raw text for inline `<tool>` markup
+            // if the model emitted text-only (older paths or providers that
+            // don't surface tool_calls).
+            let (tool_calls, text_before_tools) = if !response.tool_calls.is_empty() {
+                let calls: Vec<ToolCall> = response
+                    .tool_calls
+                    .iter()
+                    .map(|tc| ToolCall {
+                        name: tc.name.clone(),
+                        args: tc.args.clone(),
+                    })
+                    .collect();
+                (calls, response_text.trim().to_string())
+            } else {
+                parse_tool_calls(&response_text)
+            };
 
             if tool_calls.is_empty() {
                 // No tool calls — this is the final response
@@ -3874,6 +4092,7 @@ Listo!"#;
             preferred_provider: None,
             max_tokens: Some(1024),
             task_type: None,
+        tools: None,
         };
 
         let router = ctx.router.read().await;
@@ -9952,6 +10171,7 @@ Listo!"#;
             preferred_provider: None,
             max_tokens: Some(1024),
         task_type: None,
+        tools: None,
         };
 
         let router = ctx.router.read().await;
@@ -10453,6 +10673,7 @@ Listo!"#;
             preferred_provider: model.map(|m| m.to_string()),
             max_tokens: Some(2048),
             task_type: None,
+        tools: None,
         };
 
         let router = ctx.router.read().await;
@@ -11025,6 +11246,7 @@ Listo!"#;
                 preferred_provider: Some(model.to_string()),
                 max_tokens: Some(2048),
             task_type: None,
+            tools: None,
             };
 
             let router = ctx.router.read().await;
@@ -11228,6 +11450,7 @@ Listo!"#;
             preferred_provider: None,
             max_tokens: Some(512),
             task_type: None,
+        tools: None,
         };
 
         let router = ctx.router.read().await;

--- a/daemon/src/llm_debate.rs
+++ b/daemon/src/llm_debate.rs
@@ -458,7 +458,7 @@ async fn query_single_provider(
         preferred_provider: Some(provider.name.clone()),
         max_tokens: Some(1024),
         task_type: None,
-    tools: None,
+        tools: None,
     };
 
     let resp = router.chat(&router_req).await?;
@@ -660,7 +660,7 @@ async fn synthesize_with_judge(
         preferred_provider: local_provider,
         max_tokens: Some(2048),
         task_type: None,
-    tools: None,
+        tools: None,
     };
 
     let resp = router.chat(&req).await?;

--- a/daemon/src/llm_debate.rs
+++ b/daemon/src/llm_debate.rs
@@ -458,6 +458,7 @@ async fn query_single_provider(
         preferred_provider: Some(provider.name.clone()),
         max_tokens: Some(1024),
         task_type: None,
+    tools: None,
     };
 
     let resp = router.chat(&router_req).await?;
@@ -659,6 +660,7 @@ async fn synthesize_with_judge(
         preferred_provider: local_provider,
         max_tokens: Some(2048),
         task_type: None,
+    tools: None,
     };
 
     let resp = router.chat(&req).await?;

--- a/daemon/src/llm_router.rs
+++ b/daemon/src/llm_router.rs
@@ -70,6 +70,26 @@ pub struct RouterRequest {
     /// Optional task type hint. If `None`, the router auto-classifies from messages.
     #[serde(default)]
     pub task_type: Option<TaskType>,
+    /// OpenAI-format tool specs. When present, the OpenAI-compatible providers
+    /// forward them in the `tools` field of the request body, and the response
+    /// is mined for `choices[0].message.tool_calls` instead of inline text
+    /// markup. Pass `None` for plain chat (no tool use available).
+    #[serde(default)]
+    pub tools: Option<Vec<serde_json::Value>>,
+}
+
+/// One tool invocation extracted from the model response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LlmToolCall {
+    /// Provider-supplied id (passed back as `tool_call_id` on the next turn).
+    /// May be empty when the provider does not surface one.
+    #[serde(default)]
+    pub id: String,
+    /// Tool name as registered in `axi_tools` (e.g. `health_fact_add`).
+    pub name: String,
+    /// Parsed arguments object. Always a JSON object; empty `{}` if the model
+    /// emitted nothing parseable.
+    pub args: serde_json::Value,
 }
 
 /// Response returned by the router.
@@ -81,6 +101,12 @@ pub struct RouterResponse {
     pub tokens_used: Option<u32>,
     pub latency_ms: u64,
     pub cached: bool,
+    /// Tool calls emitted by the model via the OpenAI `tool_calls` channel.
+    /// Empty when the model produced plain text (or when the provider does
+    /// not support structured tool use). Callers should prefer this over
+    /// scanning `text` for inline `<tool>` markup.
+    #[serde(default)]
+    pub tool_calls: Vec<LlmToolCall>,
 }
 
 /// Cost tracking for a provider.
@@ -786,12 +812,23 @@ impl LlmRouter {
             .unwrap_or("/v1/chat/completions");
         let url = format!("{}{}", provider.api_base, path);
 
-        let payload = serde_json::json!({
+        let mut payload = serde_json::json!({
             "model": provider.model,
             "messages": request.messages,
             "max_tokens": request.max_tokens.unwrap_or(2048),
             "stream": false,
         });
+        // Forward OpenAI-format tool specs when the caller provided them.
+        // llama-server with `--jinja` uses the model's native chat template
+        // to render these (Qwen3.5 emits structured tool_calls back), so the
+        // response stops returning markdown JSON in `content` and starts
+        // populating `choices[0].message.tool_calls` properly.
+        if let Some(tools) = &request.tools {
+            if !tools.is_empty() {
+                payload["tools"] = serde_json::Value::Array(tools.clone());
+                payload["tool_choice"] = serde_json::Value::String("auto".into());
+            }
+        }
 
         let mut req = self.http.post(&url).json(&payload);
 
@@ -843,6 +880,7 @@ impl LlmRouter {
                             .to_string();
                         let text = strip_think_tags(&raw_text);
                         let text = strip_reasoning_loop(&text);
+                        let tool_calls = extract_openai_tool_calls(msg);
                         let tokens_used = retry_body["usage"]["total_tokens"]
                             .as_u64()
                             .and_then(|t| u32::try_from(t).ok());
@@ -853,6 +891,7 @@ impl LlmRouter {
                             tokens_used,
                             latency_ms: 0,
                             cached: false,
+                            tool_calls,
                         });
                     }
                 }
@@ -881,6 +920,12 @@ impl LlmRouter {
         let text = strip_think_tags(&raw_text);
         let text = strip_reasoning_loop(&text);
 
+        // Pull structured tool_calls from the OpenAI response shape. With
+        // `--jinja` this is what Qwen3.5 emits when the caller passes a
+        // `tools` array; without `tools` the field is empty and the caller
+        // can fall back to scanning `text` for inline markup.
+        let tool_calls = extract_openai_tool_calls(msg);
+
         let tokens_used = body["usage"]["total_tokens"]
             .as_u64()
             .and_then(|t| u32::try_from(t).ok());
@@ -892,6 +937,7 @@ impl LlmRouter {
             tokens_used,
             latency_ms: 0,
             cached: false,
+            tool_calls,
         })
     }
 
@@ -980,6 +1026,7 @@ impl LlmRouter {
             tokens_used,
             latency_ms: 0,
             cached: false,
+            tool_calls: Vec::new(),
         })
     }
 
@@ -1698,6 +1745,75 @@ fn starts_with_terminal_hedge(normalized: &str, hedge: &str) -> bool {
     false
 }
 
+/// Pull tool calls out of the OpenAI-format `choices[0].message` object.
+///
+/// Two shapes are normalised:
+/// - Modern OpenAI / llama.cpp `--jinja`: `message.tool_calls` is an array of
+///   `{id, type:"function", function:{name, arguments:"<json string>"}}`.
+/// - Older / partial implementations: `message.function_call` (singular) with
+///   `{name, arguments:"<json string>"}`.
+///
+/// `arguments` is parsed from string to `serde_json::Value::Object`. Empty or
+/// malformed argument blobs degrade to `{}` rather than an error — the caller
+/// already validates per-tool args downstream.
+pub fn extract_openai_tool_calls(message: &serde_json::Value) -> Vec<LlmToolCall> {
+    let mut out: Vec<LlmToolCall> = Vec::new();
+
+    let parse_args = |raw: &serde_json::Value| -> serde_json::Value {
+        match raw {
+            serde_json::Value::String(s) => serde_json::from_str(s.trim())
+                .unwrap_or_else(|_| serde_json::json!({})),
+            serde_json::Value::Object(_) => raw.clone(),
+            _ => serde_json::json!({}),
+        }
+    };
+
+    if let Some(arr) = message.get("tool_calls").and_then(|v| v.as_array()) {
+        for tc in arr {
+            let id = tc
+                .get("id")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string();
+            let function = tc.get("function").unwrap_or(&serde_json::Value::Null);
+            let name = function
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .trim()
+                .to_string();
+            if name.is_empty() {
+                continue;
+            }
+            let args = function
+                .get("arguments")
+                .map(parse_args)
+                .unwrap_or_else(|| serde_json::json!({}));
+            out.push(LlmToolCall { id, name, args });
+        }
+    } else if let Some(fc) = message.get("function_call") {
+        let name = fc
+            .get("name")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .trim()
+            .to_string();
+        if !name.is_empty() {
+            let args = fc
+                .get("arguments")
+                .map(parse_args)
+                .unwrap_or_else(|| serde_json::json!({}));
+            out.push(LlmToolCall {
+                id: String::new(),
+                name,
+                args,
+            });
+        }
+    }
+
+    out
+}
+
 /// Strip `<think>...</think>` blocks from LLM responses (Qwen3, DeepSeek, etc.).
 /// These models include chain-of-thought reasoning that shouldn't be shown to users.
 pub fn strip_think_tags(text: &str) -> String {
@@ -1775,6 +1891,100 @@ pub fn strip_reasoning_loop(text: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn extract_openai_tool_calls_modern_array_shape() {
+        // Modern OpenAI / llama.cpp `--jinja` shape: tool_calls is an array of
+        // {id, type, function:{name, arguments}}. arguments is a JSON STRING
+        // that the parser must JSON.parse before handing to the executor.
+        let msg = serde_json::json!({
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_abc",
+                    "type": "function",
+                    "function": {
+                        "name": "vital_record",
+                        "arguments": "{\"vital_type\":\"blood_pressure_systolic\",\"value_numeric\":116}"
+                    }
+                },
+                {
+                    "id": "call_def",
+                    "type": "function",
+                    "function": {
+                        "name": "vital_record",
+                        "arguments": "{\"vital_type\":\"blood_pressure_diastolic\",\"value_numeric\":78}"
+                    }
+                }
+            ]
+        });
+        let calls = extract_openai_tool_calls(&msg);
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].id, "call_abc");
+        assert_eq!(calls[0].name, "vital_record");
+        assert_eq!(calls[0].args["value_numeric"], 116);
+        assert_eq!(calls[1].args["vital_type"], "blood_pressure_diastolic");
+    }
+
+    #[test]
+    fn extract_openai_tool_calls_legacy_function_call_shape() {
+        // Some providers still ship the old `function_call` singular shape.
+        let msg = serde_json::json!({
+            "role": "assistant",
+            "function_call": {
+                "name": "health_fact_add",
+                "arguments": "{\"fact_type\":\"blood_type\",\"label\":\"O+\"}"
+            }
+        });
+        let calls = extract_openai_tool_calls(&msg);
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "health_fact_add");
+        assert_eq!(calls[0].args["label"], "O+");
+    }
+
+    #[test]
+    fn extract_openai_tool_calls_handles_object_arguments() {
+        // Some implementations skip the JSON.stringify step and put the args
+        // as a raw object. Accept both.
+        let msg = serde_json::json!({
+            "role": "assistant",
+            "tool_calls": [{
+                "id": "call_1",
+                "type": "function",
+                "function": {
+                    "name": "remember",
+                    "arguments": {"type": "preference", "topic": "x", "title": "y", "content": "z"}
+                }
+            }]
+        });
+        let calls = extract_openai_tool_calls(&msg);
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].args["type"], "preference");
+    }
+
+    #[test]
+    fn extract_openai_tool_calls_skips_empty_or_malformed() {
+        // Blank name → drop. Malformed args → degrade to {} not error.
+        let msg = serde_json::json!({
+            "role": "assistant",
+            "tool_calls": [
+                {"id": "x", "type": "function", "function": {"name": "", "arguments": "{}"}},
+                {"id": "y", "type": "function", "function": {"name": "remember", "arguments": "not-json"}}
+            ]
+        });
+        let calls = extract_openai_tool_calls(&msg);
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "remember");
+        assert_eq!(calls[0].args, serde_json::json!({}));
+    }
+
+    #[test]
+    fn extract_openai_tool_calls_plain_text_response_is_empty() {
+        // No tool_calls field → empty vec, caller falls back to text scanner.
+        let msg = serde_json::json!({"role": "assistant", "content": "just a chat reply"});
+        assert!(extract_openai_tool_calls(&msg).is_empty());
+    }
 
     #[test]
     fn test_bug_reasoning_loop_qwen35_repeats_same_sentence() {
@@ -2006,6 +2216,7 @@ mod tests {
             tokens_used: None,
             latency_ms: 0,
             cached: false,
+            tool_calls: Vec::new(),
         }
     }
 
@@ -2167,6 +2378,7 @@ mod tests {
             complexity: Some(TaskComplexity::Simple),
             sensitivity: Some(SensitivityLevel::Low),
             task_type: None,
+        tools: None,
             max_tokens: None,
         };
 
@@ -2239,6 +2451,7 @@ mod tests {
             complexity: Some(TaskComplexity::Simple),
             sensitivity: Some(SensitivityLevel::Low),
             task_type: None,
+        tools: None,
             max_tokens: None,
         };
 

--- a/daemon/src/llm_router.rs
+++ b/daemon/src/llm_router.rs
@@ -1761,8 +1761,9 @@ pub fn extract_openai_tool_calls(message: &serde_json::Value) -> Vec<LlmToolCall
 
     let parse_args = |raw: &serde_json::Value| -> serde_json::Value {
         match raw {
-            serde_json::Value::String(s) => serde_json::from_str(s.trim())
-                .unwrap_or_else(|_| serde_json::json!({})),
+            serde_json::Value::String(s) => {
+                serde_json::from_str(s.trim()).unwrap_or_else(|_| serde_json::json!({}))
+            }
             serde_json::Value::Object(_) => raw.clone(),
             _ => serde_json::json!({}),
         }
@@ -2378,7 +2379,7 @@ mod tests {
             complexity: Some(TaskComplexity::Simple),
             sensitivity: Some(SensitivityLevel::Low),
             task_type: None,
-        tools: None,
+            tools: None,
             max_tokens: None,
         };
 
@@ -2451,7 +2452,7 @@ mod tests {
             complexity: Some(TaskComplexity::Simple),
             sensitivity: Some(SensitivityLevel::Low),
             task_type: None,
-        tools: None,
+            tools: None,
             max_tokens: None,
         };
 

--- a/daemon/src/meeting_assistant.rs
+++ b/daemon/src/meeting_assistant.rs
@@ -1203,6 +1203,7 @@ Usá EXACTAMENTE este formato para cada tarea:
             preferred_provider: None,
             max_tokens: Some(4096),
             task_type: None,
+        tools: None,
         };
 
         let router_guard = router.read().await;

--- a/daemon/src/meeting_assistant.rs
+++ b/daemon/src/meeting_assistant.rs
@@ -1203,7 +1203,7 @@ Usá EXACTAMENTE este formato para cada tarea:
             preferred_provider: None,
             max_tokens: Some(4096),
             task_type: None,
-        tools: None,
+            tools: None,
         };
 
         let router_guard = router.read().await;

--- a/daemon/src/memory_plane.rs
+++ b/daemon/src/memory_plane.rs
@@ -4716,6 +4716,7 @@ impl MemoryPlaneManager {
                 preferred_provider: None,
                 max_tokens: Some(400),
                 task_type: None,
+            tools: None,
             };
 
             let summary_text = match router.chat(&req).await {

--- a/daemon/src/memory_plane.rs
+++ b/daemon/src/memory_plane.rs
@@ -4716,7 +4716,7 @@ impl MemoryPlaneManager {
                 preferred_provider: None,
                 max_tokens: Some(400),
                 task_type: None,
-            tools: None,
+                tools: None,
             };
 
             let summary_text = match router.chat(&req).await {

--- a/daemon/src/session_store.rs
+++ b/daemon/src/session_store.rs
@@ -707,7 +707,7 @@ impl SessionStore {
             preferred_provider: None,
             max_tokens: Some(1024),
             task_type: None,
-        tools: None,
+            tools: None,
         };
 
         let router_guard = router.read().await;

--- a/daemon/src/session_store.rs
+++ b/daemon/src/session_store.rs
@@ -707,6 +707,7 @@ impl SessionStore {
             preferred_provider: None,
             max_tokens: Some(1024),
             task_type: None,
+        tools: None,
         };
 
         let router_guard = router.read().await;

--- a/daemon/src/supervisor.rs
+++ b/daemon/src/supervisor.rs
@@ -974,7 +974,7 @@ impl Supervisor {
                     preferred_provider: None,
                     max_tokens: Some(2048),
                     task_type: None,
-                tools: None,
+                    tools: None,
                 };
 
                 let plan_result = {
@@ -1393,7 +1393,7 @@ impl Supervisor {
             preferred_provider: None,
             max_tokens: Some(256),
             task_type: None,
-        tools: None,
+            tools: None,
         };
 
         let router = self.router.read().await;
@@ -2025,7 +2025,7 @@ Always end with a "respond" step summarizing what was done."#,
             preferred_provider: None,
             max_tokens: Some(2048),
             task_type: None,
-        tools: None,
+            tools: None,
         };
 
         let router = self.router.read().await;
@@ -2433,7 +2433,7 @@ Respond ONLY with a JSON object (no markdown):
             preferred_provider: None,
             max_tokens: Some(512),
             task_type: None,
-        tools: None,
+            tools: None,
         };
 
         let router = self.router.read().await;
@@ -2539,7 +2539,7 @@ Respond ONLY with a JSON object (no markdown):
             preferred_provider: None,
             max_tokens: Some(1024),
             task_type: None,
-        tools: None,
+            tools: None,
         };
 
         let router = self.router.read().await;

--- a/daemon/src/supervisor.rs
+++ b/daemon/src/supervisor.rs
@@ -974,6 +974,7 @@ impl Supervisor {
                     preferred_provider: None,
                     max_tokens: Some(2048),
                     task_type: None,
+                tools: None,
                 };
 
                 let plan_result = {
@@ -1392,6 +1393,7 @@ impl Supervisor {
             preferred_provider: None,
             max_tokens: Some(256),
             task_type: None,
+        tools: None,
         };
 
         let router = self.router.read().await;
@@ -1570,6 +1572,7 @@ impl Supervisor {
             preferred_provider: None,
             max_tokens: Some(512),
         task_type: None,
+        tools: None,
         };
 
         let router = self.router.read().await;
@@ -2022,6 +2025,7 @@ Always end with a "respond" step summarizing what was done."#,
             preferred_provider: None,
             max_tokens: Some(2048),
             task_type: None,
+        tools: None,
         };
 
         let router = self.router.read().await;
@@ -2429,6 +2433,7 @@ Respond ONLY with a JSON object (no markdown):
             preferred_provider: None,
             max_tokens: Some(512),
             task_type: None,
+        tools: None,
         };
 
         let router = self.router.read().await;
@@ -2534,6 +2539,7 @@ Respond ONLY with a JSON object (no markdown):
             preferred_provider: None,
             max_tokens: Some(1024),
             task_type: None,
+        tools: None,
         };
 
         let router = self.router.read().await;

--- a/daemon/src/translation.rs
+++ b/daemon/src/translation.rs
@@ -72,6 +72,7 @@ pub async fn detect_language(text: &str, router: Option<&LlmRouter>) -> Result<S
             preferred_provider: None,
             max_tokens: Some(4),
             task_type: None,
+        tools: None,
         };
         match router.chat(&req).await {
             Ok(resp) => {
@@ -285,6 +286,7 @@ impl TranslationEngine {
             preferred_provider: None,
             max_tokens: Some(2048),
             task_type: None,
+        tools: None,
         };
         let resp = router
             .chat(&req)

--- a/daemon/src/translation.rs
+++ b/daemon/src/translation.rs
@@ -72,7 +72,7 @@ pub async fn detect_language(text: &str, router: Option<&LlmRouter>) -> Result<S
             preferred_provider: None,
             max_tokens: Some(4),
             task_type: None,
-        tools: None,
+            tools: None,
         };
         match router.chat(&req).await {
             Ok(resp) => {
@@ -286,7 +286,7 @@ impl TranslationEngine {
             preferred_provider: None,
             max_tokens: Some(2048),
             task_type: None,
-        tools: None,
+            tools: None,
         };
         let resp = router
             .chat(&req)


### PR DESCRIPTION
## Why

Silent forgetting **persists** even after PR #59. Empirical proof: queried llama-server directly with my own prompt teaching the canonical \`<tool>X</tool>\` format. Qwen3.5 (with --jinja) ignored the instruction and emitted markdown JSON in \`content\`. The parser scanned for \`<tool>\` tags, found none, dropped the call. Axi then confidently narrated "ya guardé X" without saving anything.

The bug is architectural: --jinja routes Qwen3.5 through its native chat template, which uses structured \`tool_calls\` in the API response, not inline text markup. We were on the wrong channel.

## What this changes

### 1. Router types

- \`RouterRequest.tools: Option<Vec<Value>>\` — OpenAI function specs forwarded in the request payload.
- \`RouterResponse.tool_calls: Vec<LlmToolCall>\` — structured calls extracted from \`choices[0].message.tool_calls\` (and the legacy \`function_call\` shape, for older providers).

### 2. Agentic loop

\`axi_tools.rs::build_axi_tool_specs()\` returns OpenAI specs for the priority write tools:

| Tool | Coverage |
|---|---|
| \`remember\`, \`recall\` | Persistent memory |
| \`reminder_add\` | One-shot reminders |
| \`health_fact_add\`, \`health_fact_list\` | Allergies, blood type, conditions |
| \`vital_record\`, \`vital_history\` | Blood pressure, glucose, weight, etc. |
| \`medication_start\`, \`_stop\`, \`_active\` | Med history |
| \`lab_add\` | Lab results |
| \`health_summary\` | Full snapshot |

Other tools still use the legacy text-parsing path; they can be migrated incrementally.

The loop now prefers \`response.tool_calls\` and only falls back to \`parse_tool_calls(text)\` if the model declined the structured channel.

### 3. System prompt rewrite

Two big behavioural shifts the user explicitly requested:

**No keyword triggers.** The model used to demand "guardá / registrá / anotá" before saving. That's wrong — a smart agent infers from data shape:

- \`"116/78 59 pulsos"\` → \`vital_record\` ×3 automatically
- \`"mi tipo de sangre es O+"\` → \`health_fact_add\` automatically
- \`"recuérdame en 30 min"\` → \`reminder_add\` automatically

**Ambiguity → ask.** If a message could be a record OR a question/concern, Axi must ask before invoking a tool. Examples in the prompt:

- \`"sentí una bola en el cuello"\` — symptom OR antecedent? Recommend doctor + ask "¿lo registro como antecedente?"
- \`"me duele la cabeza"\` — chat OR pain log? Ask first.

Plus an explicit **anti-mentira rule**: if your text says "ya guardé" without emitting a tool_call, you're lying — reformulate.

## Tests

5 new in \`llm_router.rs::tests\`:
- \`extract_openai_tool_calls_modern_array_shape\`
- \`extract_openai_tool_calls_legacy_function_call_shape\`
- \`extract_openai_tool_calls_handles_object_arguments\` (object vs JSON-string args)
- \`extract_openai_tool_calls_skips_empty_or_malformed\`
- \`extract_openai_tool_calls_plain_text_response_is_empty\` (fallback path)

## Test plan post-deploy

- [ ] Send to Axi: \`"mi tipo de sangre es O+"\` (no keyword trigger). Verify \`memory/stats.by_kind.health_fact >= 1\`.
- [ ] Send to Axi: \`"116/78 59 pulsos"\`. Verify 3 \`vital_record\` entries (sys/dia/heart_rate) within seconds.
- [ ] Send ambiguous message: \`"sentí una bola en el cuello"\`. Axi should ASK before saving (not auto-record, not silently ignore).

Bumps version to 0.8.21.