### PR TITLE
fix(ai-runtime): defer benchmark + detect stale env on boot (#793)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "life"
-version = "0.8.21"
+version = "0.8.22"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2626,7 +2626,7 @@ dependencies = [
 
 [[package]]
 name = "lifeos-integration-tests"
-version = "0.8.21"
+version = "0.8.22"
 dependencies = [
  "life",
  "serde_json",
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "lifeosd"
-version = "0.8.21"
+version = "0.8.22"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.21"
+version = "0.8.22"
 
 [workspace.metadata.lifeos]
 codename = "Axolotl"

--- a/daemon/src/ai_runtime_profile.rs
+++ b/daemon/src/ai_runtime_profile.rs
@@ -11,7 +11,25 @@ use std::time::Duration;
 const PROFILE_SCHEMA_VERSION: u32 = 1;
 const PROFILE_CHECK_INTERVAL_SECS: u64 = 15 * 60;
 const PROFILE_RETRY_INTERVAL_SECS: u64 = 5 * 60;
-const INITIAL_BENCHMARK_DELAY_SECS: u64 = 45;
+/// How long after lifeosd boots before the auto-benchmark fires.
+///
+/// Engram bug #793: each benchmark candidate calls `apply_runtime_env` +
+/// `restart_llama_server_sync` to measure latency, which means
+/// `/var/lib/lifeos/llama-server-runtime-profile.env` and the actually-running
+/// llama-server process flip between cpu_ram, normal_gpu, and
+/// game_guard_cpu_fallback candidates over the benchmark window. If the user
+/// chats with Axi during that window, their turn lands on whichever candidate
+/// happens to be loaded — which can be Qwen3.5-4B in CPU at full ctx, painfully
+/// slow for prefill (~50 tok/s), and prone to router timeouts.
+///
+/// The proper fix is sidecar benchmarks (run candidates as child processes on
+/// a separate port, never touch the main llama-server). That is tracked as a
+/// follow-up. For now we mitigate by deferring the auto-benchmark long enough
+/// that a user who just booted the laptop is overwhelmingly unlikely to be
+/// actively chatting when it fires. 30 minutes is a balance: the benchmark
+/// still runs unattended on most laptops, but the most common
+/// "boot → log into COSMIC → ping Axi" flow finishes long before.
+const INITIAL_BENCHMARK_DELAY_SECS: u64 = 30 * 60;
 const DEFAULT_MODEL: &str = "Qwen3.5-4B-Q4_K_M.gguf";
 const DEFAULT_ALIAS: &str = "lifeos";
 const DEFAULT_PORT: u16 = 8082;
@@ -292,6 +310,20 @@ pub fn bootstrap_runtime_profile(data_dir: &Path) -> Result<BootstrapOutcome> {
         save_runtime_profile(&profile_path, &profile)?;
     }
 
+    // Defensive recovery for engram bug #793: if a previous lifeosd instance
+    // died mid-benchmark, the on-disk runtime-profile.env can be left holding
+    // a candidate's settings (e.g. game_guard_cpu_fallback shape — gpu_layers=0,
+    // 4B model, threads=12). The unconditional write below already overwrites
+    // it with `active_settings()` (= normal_gpu when GPU is available), so
+    // boot is self-healing. But we ALSO log when we detect that drift, so the
+    // bug is observable in journals if it happens again under new code paths.
+    if let Some(found_drift) = detect_stale_candidate_in_runtime_env(&profile) {
+        warn!(
+            "[ai_runtime] runtime-profile.env had stale {found_drift} candidate state at boot — \
+             overwriting with active_settings (engram #793 recovery)"
+        );
+    }
+
     let env_changed = apply_runtime_env(&profile.active_settings())?;
     Ok(BootstrapOutcome {
         benchmark_pending: !profile.benchmark_completed,
@@ -299,6 +331,35 @@ pub fn bootstrap_runtime_profile(data_dir: &Path) -> Result<BootstrapOutcome> {
         profile_changed,
         env_changed,
     })
+}
+
+/// Inspect the on-disk runtime env file and report which (if any) candidate
+/// shape it currently holds, instead of the active profile. Returns the
+/// candidate-name string (e.g. "game_guard_cpu_fallback", "cpu_ram") when the
+/// file diverges from active_settings, or `None` when the file is already
+/// aligned (or missing). Used purely for the boot-time observability log
+/// added for engram bug #793; the unconditional `apply_runtime_env` that
+/// follows it heals the file regardless.
+fn detect_stale_candidate_in_runtime_env(profile: &RuntimeProfile) -> Option<&'static str> {
+    let path = runtime_override_env_path();
+    let content = std::fs::read_to_string(&path).ok()?;
+    let active = profile.active_settings();
+    let active_lines = active.to_env_lines();
+    // If the file already matches active settings byte-for-byte, no drift.
+    if active_lines.iter().all(|line| content.contains(line)) {
+        return None;
+    }
+    // Otherwise, see which candidate it most closely resembles.
+    if let Some(g) = profile.profiles.game_guard_cpu_fallback.as_ref() {
+        if g.to_env_lines().iter().all(|line| content.contains(line)) {
+            return Some("game_guard_cpu_fallback");
+        }
+    }
+    let cpu_lines = profile.profiles.cpu_ram.to_env_lines();
+    if cpu_lines.iter().all(|line| content.contains(line)) {
+        return Some("cpu_ram");
+    }
+    Some("unknown candidate")
 }
 
 pub async fn run_runtime_profile_manager(


### PR DESCRIPTION
## Why

Engram bug #793. When a user boots their laptop, lifeosd's auto-benchmark fires 45 seconds later. Each candidate calls \`apply_runtime_env\` + \`restart_llama_server_sync\` to measure latency, which means \`runtime-profile.env\` AND the actually-running llama-server flip between \`cpu_ram\`, \`normal_gpu\`, and \`game_guard_cpu_fallback\` candidates over the benchmark window (~3-5 min for 5 candidates).

If the user chats with Axi during that window, their turn lands on whichever candidate happens to be loaded. Empirical evidence (engram #793): Hector hit Qwen3.5-4B in CPU with full ctx, prefill at ~50 tok/s, router timeout, "Error conectando con el LLM".

## The proper fix is sidecar benchmarks

Run candidates as child processes on a separate port, never mutate the main llama-server's env file or restart it. That is a 6-10h refactor and is tracked as a separate follow-up (engram #793 still open for that).

## What this PR ships

Two pragmatic mitigations for the common case:

1. **Bump INITIAL_BENCHMARK_DELAY_SECS from 45 to 1800 (30 min).** The "boot → log into COSMIC → ping Axi" user flow finishes in minutes; the benchmark window now lands well after that. Once the benchmark completes once, \`profile.benchmark_completed = true\` and subsequent boots skip it entirely — so this is only a first-boot-per-profile concern anyway.

2. **\`detect_stale_candidate_in_runtime_env\`**: at bootstrap, peek at \`runtime-profile.env\` BEFORE \`apply_runtime_env\` overwrites it. If it holds a candidate shape (\`game_guard_cpu_fallback\`, \`cpu_ram\`, or anything that diverges from \`active_settings\`), log a \`warn!\` with the candidate name. The unconditional \`apply_runtime_env\` that follows already heals the file — this is purely observability, so the bug is detectable in journals if a future code path re-introduces it.

## Test plan post-deploy

- [ ] Boot freshly. Within the first 30 min, journal should NOT show any benchmark candidate writes.
- [ ] After 30 min, benchmark fires (\`[ai_runtime] benchmark completed\` in journal).
- [ ] If journal ever shows \`runtime-profile.env had stale ... candidate state at boot\`, that is the new observability hook firing — file a follow-up for the responsible code path.

Bumps version to 0.8.22.