### PR TITLE
ci(release): build-and-push on VPS self-hosted runner

### DIFF
--- a/.github/workflows/release-channels.yml
+++ b/.github/workflows/release-channels.yml
@@ -115,7 +115,7 @@ jobs:
   build-and-push:
     needs: determine-channel
     if: needs.determine-channel.outputs.channel != 'skip'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, vps]
     permissions:
       contents: read
       packages: write

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "life"
-version = "0.8.23"
+version = "0.8.24"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2626,7 +2626,7 @@ dependencies = [
 
 [[package]]
 name = "lifeos-integration-tests"
-version = "0.8.23"
+version = "0.8.24"
 dependencies = [
  "life",
  "serde_json",
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "lifeosd"
-version = "0.8.23"
+version = "0.8.24"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.23"
+version = "0.8.24"
 
 [workspace.metadata.lifeos]
 codename = "Axolotl"


### PR DESCRIPTION
## Summary
- Move `build-and-push` job from `ubuntu-latest` to `[self-hosted, vps]`
- Other 5 jobs (Truth Alignment, determine-channel, generate-sbom, update-channel-manifest, notify-release) stay on `ubuntu-latest`
- Version bump 0.8.23 → 0.8.24

## Why
GitHub-hosted `ubuntu-latest` (4 vCPU, 16GB RAM) runs out of memory during `vulkan-shaders-gen` fork phase:
```
Error executing command for matmul_id_subgroup_*: Failed to fork process / Cannot allocate memory
```
Three sequential builds failed with the same OOM. The shader-gen tool internally forks parallel `glslangValidator` children, each duplicating parent memory.

## Solution
VPS self-hosted runner `vps-builder` (12 CPUs / 23GB RAM / 415GB disk) registered with label `vps`. Resource limits via systemd drop-in (`limits.conf`):
- `CPUQuota=600%` — max 6 of 12 CPUs (Coolify, n8n stay responsive)
- `MemoryMax=12G` — max 12GB of 23GB
- `IOWeight=50` — low I/O priority
- `Nice=10` — low CPU priority

## Test plan
- [ ] CI passes on this branch
- [ ] Merge → main release-channels triggers VPS build
- [ ] VPS build succeeds, image pushed to GHCR
- [ ] Coolify and n8n unaffected during build