### PR TITLE
fix(quadlet): move ExecStartPre to [Service] section

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "life"
-version = "0.8.26"
+version = "0.8.27"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2626,7 +2626,7 @@ dependencies = [
 
 [[package]]
 name = "lifeos-integration-tests"
-version = "0.8.26"
+version = "0.8.27"
 dependencies = [
  "life",
  "serde_json",
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "lifeosd"
-version = "0.8.26"
+version = "0.8.27"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.26"
+version = "0.8.27"
 
 [workspace.metadata.lifeos]
 codename = "Axolotl"

--- a/containers/lifeos-lifeosd/lifeos-lifeosd.container
+++ b/containers/lifeos-lifeosd/lifeos-lifeosd.container
@@ -55,9 +55,6 @@ Volume=/etc/lifeos:/etc/lifeos:ro,z
 # host service.
 Volume=/etc/pki/ca-trust/extracted:/etc/pki/ca-trust/extracted:ro,z
 
-# Defense-in-depth Capa 4.
-ExecStartPre=/usr/local/bin/lifeos-ensure-images
-
 # === Critical environment variables ===
 # Same set the host service passes today.
 Environment=LIFEOS_DASHBOARD_DIR=/usr/share/lifeos/dashboard
@@ -66,6 +63,10 @@ Environment=RUST_LOG=info,lifeosd=debug
 EnvironmentFile=-/etc/lifeos/llm-providers.env
 
 [Service]
+# Defense-in-depth Capa 4: ensure image is present locally before starting.
+# Quadlet requires ExecStartPre in [Service], not [Container].
+ExecStartPre=/usr/local/bin/lifeos-ensure-images
+
 # Capa 3 of defense-in-depth — auto-restart with watchdog.
 Restart=always
 RestartSec=5s

--- a/containers/lifeos-llama-embeddings/lifeos-llama-embeddings.container
+++ b/containers/lifeos-llama-embeddings/lifeos-llama-embeddings.container
@@ -55,10 +55,11 @@ Exec=/usr/sbin/llama-server \
     --embeddings \
     --pooling mean
 
-# Defense-in-depth Capa 4.
+[Service]
+# Defense-in-depth Capa 4: ensure image is present locally before starting.
+# Quadlet requires ExecStartPre in [Service], not [Container].
 ExecStartPre=/usr/local/bin/lifeos-ensure-images
 
-[Service]
 EnvironmentFile=-/etc/lifeos/llama-embeddings.env
 
 # Capa 3 of defense-in-depth — auto-restart with sane backoff. Embeddings

--- a/containers/lifeos-llama-server/lifeos-llama-server.container
+++ b/containers/lifeos-llama-server/lifeos-llama-server.container
@@ -93,9 +93,6 @@ Volume=/var/lib/lifeos/models:/var/lib/lifeos/models:ro,z
 # A separate bind mount would be redundant — llama-server reads vars
 # from its environment, not from a file path.
 
-# Defense-in-depth Capa 4.
-ExecStartPre=/usr/local/bin/lifeos-ensure-images
-
 # === The exec line — same args the host service uses ===
 #
 # Reads model + tuning from the runtime-profile env file. The benchmarker
@@ -125,6 +122,10 @@ Exec=/usr/sbin/llama-server \
     --jinja
 
 [Service]
+# Defense-in-depth Capa 4: ensure image is present locally before starting.
+# Quadlet requires ExecStartPre in [Service], not [Container].
+ExecStartPre=/usr/local/bin/lifeos-ensure-images
+
 # CRITICAL: these paths are HOST paths (systemd evaluates EnvironmentFile=
 # on the host before the container is created). The benchmarker writes
 # to /var/lib/lifeos/llama-server-runtime-profile.env on the host —

--- a/containers/lifeos-simplex-bridge/lifeos-simplex-bridge.container
+++ b/containers/lifeos-simplex-bridge/lifeos-simplex-bridge.container
@@ -36,10 +36,11 @@ Volume=/var/lib/lifeos/simplex:/var/lib/lifeos/simplex:z
 # would relabel it and break TLS for every other host service.
 Volume=/etc/pki/ca-trust/extracted:/etc/pki/ca-trust/extracted:ro,z
 
-# Defense-in-depth Capa 4.
+[Service]
+# Defense-in-depth Capa 4: ensure image is present locally before starting.
+# Quadlet requires ExecStartPre in [Service], not [Container].
 ExecStartPre=/usr/local/bin/lifeos-ensure-images
 
-[Service]
 # Capa 3 — SimpleX is touchy about graceful shutdown (DB locks). RestartSec
 # matches the host service's 10s, giving SimpleX time to flush WAL on SIGTERM.
 Restart=always

--- a/containers/lifeos-tts/lifeos-tts.container
+++ b/containers/lifeos-tts/lifeos-tts.container
@@ -77,11 +77,11 @@ Volume=/opt/lifeos/kokoro-env/voices-manifest.json:/opt/lifeos/kokoro-env/voices
 # `:z` shares the label across consumers — safe for read-only configs.
 Volume=/etc/lifeos/tts-server.env:/etc/lifeos/tts-server.env:ro,z
 
-# Defense-in-depth Capa 4: re-pull the image from the registry if it was
-# deleted from local storage. Cheap if image is present (skopeo no-op).
+[Service]
+# Defense-in-depth Capa 4: ensure image is present locally before starting.
+# Quadlet requires ExecStartPre in [Service], not [Container].
 ExecStartPre=/usr/local/bin/lifeos-ensure-images
 
-[Service]
 # Load the env file BOTH ways: as systemd EnvironmentFile= so podman
 # inherits the vars and exports them into the container ENV (the Python
 # script reads via os.environ). The Volume= bind mount in [Container]


### PR DESCRIPTION
## Summary

Phase 1 TTS flip in #70 booted on the laptop with `lifeos-tts.service could not be found` because Quadlet rejected `ExecStartPre=` in the `[Container]` section. The same idiom is in all five `.container` scaffolds, so this PR fixes the lot.

```
quadlet-generator: converting "lifeos-tts.container":
  unsupported key 'ExecStartPre' in group 'Container' in /etc/containers/systemd/lifeos-tts.container
quadlet-generator: processing encountered some errors
```

`ExecStartPre=` is a `[Service]` directive in systemd. Quadlet does not forward it from `[Container]`. The local rootless `podman run` path used during validation never exercised the Quadlet generator, so the bug surfaced only at boot.

## Changes

- `containers/lifeos-tts/lifeos-tts.container`
- `containers/lifeos-llama-embeddings/lifeos-llama-embeddings.container`
- `containers/lifeos-lifeosd/lifeos-lifeosd.container`
- `containers/lifeos-llama-server/lifeos-llama-server.container`
- `containers/lifeos-simplex-bridge/lifeos-simplex-bridge.container`

Each file moves `ExecStartPre=/usr/local/bin/lifeos-ensure-images` from the trailing `[Container]` block into a fresh `[Service]` block (with a clarifying comment so the placement constraint is documented inline).

Version bumped 0.8.26 → 0.8.27.

## Test plan

- [ ] `release-channels.yml` and `side-images.yml` build green.
- [ ] After deploy + reboot on the laptop:
  - `systemctl is-active lifeos-tts.service` → `active`
  - `journalctl -u lifeos-tts.service` shows the Quadlet pulling `ghcr.io/hectormr206/lifeos-tts:stable` cleanly
  - `curl -s http://127.0.0.1:8084/health` → `voices_loaded: 53`
  - `lifeosd` voice synthesis (Axi answers) works end-to-end.