### PR TITLE
feat(quadlet): Phase 2 embeddings + Phase 5 simplex-bridge flips

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "life"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2626,7 +2626,7 @@ dependencies = [
 
 [[package]]
 name = "lifeos-integration-tests"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "life",
  "serde_json",
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "lifeosd"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.27"
+version = "0.8.28"
 
 [workspace.metadata.lifeos]
 codename = "Axolotl"

--- a/docs/operations/simplex-features.md
+++ b/docs/operations/simplex-features.md
@@ -1,7 +1,7 @@
 # Axi on SimpleX
 
 > Documentation for all Axi interaction features via SimpleX Chat.
-> Updated: 2026-04-13
+> Updated: 2026-05-01
 
 ## Overview
 
@@ -12,8 +12,13 @@ the network. The connection is end-to-end encrypted and routed through
 SimpleX relay servers that never learn who is talking to whom.
 
 Axi connects to a local `simplex-chat` process running in headless/WebSocket
-mode on `ws://127.0.0.1:5226`. All messages are dispatched through the shared
-agentic tool system in `daemon/src/axi_tools.rs` — same LLM, same tools, same
+mode on `ws://127.0.0.1:5226`. As of 0.8.28 the process runs as a podman
+Quadlet (`lifeos-simplex-bridge.service` generated from
+`/etc/containers/systemd/lifeos-simplex-bridge.container`) pulling
+`ghcr.io/hectormr206/lifeos-simplex-bridge:stable`. The legacy
+`simplex-chat.service` remains in `/usr/lib/systemd/system/` as a manual
+rollback target. All messages are dispatched through the shared agentic
+tool system in `daemon/src/axi_tools.rs` — same LLM, same tools, same
 conversation memory across SimpleX and the dashboard.
 
 On first connect, the SimpleX profile is auto-configured (name: **Axi**,

--- a/image/Containerfile
+++ b/image/Containerfile
@@ -1137,6 +1137,10 @@ COPY image/files/etc/systemd/system/lifeos-refresh-bls-titles.service /usr/lib/s
 COPY image/files/etc/systemd/system/llama-server.service       /usr/lib/systemd/system/llama-server.service
 COPY image/files/etc/systemd/system/llama-server.service.d/10-fast-kill.conf /etc/systemd/system/llama-server.service.d/10-fast-kill.conf
 COPY image/files/etc/systemd/system/llama-embeddings.service   /usr/lib/systemd/system/llama-embeddings.service
+# Phase 2: nomic-embed-text → Quadlet. Generator turns this into
+# lifeos-llama-embeddings.service. Image is built by side-images.yml,
+# pulled at first boot via lifeos-ensure-images.
+COPY containers/lifeos-llama-embeddings/lifeos-llama-embeddings.container /etc/containers/systemd/lifeos-llama-embeddings.container
 COPY image/files/etc/systemd/system/whisper-stt.service       /usr/lib/systemd/system/whisper-stt.service
 COPY image/files/etc/systemd/system/lifeos-btrfs-snapshot.service /usr/lib/systemd/system/lifeos-btrfs-snapshot.service
 COPY image/files/etc/systemd/system/lifeos-btrfs-snapshot.timer   /usr/lib/systemd/system/lifeos-btrfs-snapshot.timer
@@ -1146,6 +1150,9 @@ COPY image/files/etc/systemd/system/lifeos-security-baseline.service /usr/lib/sy
 COPY image/files/etc/systemd/system/lifeos-sentinel.service /usr/lib/systemd/system/lifeos-sentinel.service
 COPY image/files/etc/systemd/system/simplex-chat.service /usr/lib/systemd/system/simplex-chat.service
 COPY image/files/etc/systemd/system/simplex-chat.service.d/10-bootstrap-profile.conf /usr/lib/systemd/system/simplex-chat.service.d/10-bootstrap-profile.conf
+# Phase 5: simplex-chat → Quadlet. Generator produces
+# lifeos-simplex-bridge.service. Image is built by side-images.yml.
+COPY containers/lifeos-simplex-bridge/lifeos-simplex-bridge.container /etc/containers/systemd/lifeos-simplex-bridge.container
 COPY image/files/usr/local/bin/lifeos-simplex-setup.sh /usr/local/bin/lifeos-simplex-setup.sh
 RUN chmod +x /usr/local/bin/lifeos-simplex-setup.sh
 COPY image/files/etc/systemd/system/nvidia-persistenced.service.d/10-lifeos-conditions.conf /etc/systemd/system/nvidia-persistenced.service.d/10-lifeos-conditions.conf
@@ -1212,7 +1219,6 @@ RUN mkdir -p /usr/lib/systemd/system/multi-user.target.wants \
     ln -sf /usr/lib/systemd/system/lifeos-security-baseline.service /usr/lib/systemd/system/multi-user.target.wants/lifeos-security-baseline.service && \
     ln -sf /usr/lib/systemd/system/lifeos-sentinel.service /usr/lib/systemd/system/multi-user.target.wants/lifeos-sentinel.service && \
     ln -sf /usr/lib/systemd/system/lifeos-refresh-bls-titles.service /usr/lib/systemd/system/multi-user.target.wants/lifeos-refresh-bls-titles.service && \
-    ln -sf /usr/lib/systemd/system/simplex-chat.service /usr/lib/systemd/system/multi-user.target.wants/simplex-chat.service && \
     # Canonical enablement: lifeosd starts from the graphical session target
     # so it waits for the display server to be ready (fixes the tray-icon
     # race where lifeosd gave up after its 30s wait before COSMIC was up).
@@ -1227,7 +1233,6 @@ RUN mkdir -p /usr/lib/systemd/system/multi-user.target.wants \
         ln -sf /usr/lib/systemd/system/nvidia-persistenced.service /usr/lib/systemd/system/multi-user.target.wants/nvidia-persistenced.service; \
     fi && \
     ln -sf /usr/lib/systemd/system/llama-server.service   /usr/lib/systemd/system/multi-user.target.wants/llama-server.service && \
-    ln -sf /usr/lib/systemd/system/llama-embeddings.service /usr/lib/systemd/system/multi-user.target.wants/llama-embeddings.service && \
     ln -sf /usr/lib/systemd/system/whisper-stt.service    /usr/lib/systemd/system/multi-user.target.wants/whisper-stt.service && \
     ln -sf /usr/lib/systemd/system/fstrim.timer /usr/lib/systemd/system/timers.target.wants/fstrim.timer && \
     ln -sf /usr/lib/systemd/system/lifeos-btrfs-snapshot.timer /usr/lib/systemd/system/timers.target.wants/lifeos-btrfs-snapshot.timer && \


### PR DESCRIPTION
Stacks on #71 (which merged to main first). Drops `lifeos-llama-embeddings.container` and `lifeos-simplex-bridge.container` into `/etc/containers/systemd/`, removes the legacy `llama-embeddings.service` and `simplex-chat.service` from `multi-user.target.wants/`, leaves the legacy units installed for manual rollback.

Both side images already build, push, and pin via `side-images.yml`. ExecStartPre placement is correct from #71. Phase 3 (lifeosd) and Phase 4 (llama-server GPU) explicitly stay on host services per the architecture-pivot PRD.

## Test plan
- [ ] `release-channels.yml` builds the bootc image green.
- [ ] After deploy + reboot:
  - `systemctl is-active lifeos-llama-embeddings.service lifeos-simplex-bridge.service` → both `active`
  - `systemctl is-active llama-embeddings.service simplex-chat.service` → both `inactive`
  - `curl -s http://127.0.0.1:8083/v1/embeddings` returns a vector
  - SimpleX continues to receive Axi messages