### PR TITLE
fix(quadlet): JD audit follow-up — install Capa 4, fix TTS env, revert 2/5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "life"
-version = "0.8.28"
+version = "0.8.29"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2626,7 +2626,7 @@ dependencies = [
 
 [[package]]
 name = "lifeos-integration-tests"
-version = "0.8.28"
+version = "0.8.29"
 dependencies = [
  "life",
  "serde_json",
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "lifeosd"
-version = "0.8.28"
+version = "0.8.29"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.28"
+version = "0.8.29"
 
 [workspace.metadata.lifeos]
 codename = "Axolotl"

--- a/README.md
+++ b/README.md
@@ -113,10 +113,13 @@ All documentation is organized in [`docs/`](docs/README.md):
 ## Tech Stack
 
 - **Language:** Rust 2021 (daemon + CLI)
-- **OS Base:** Fedora bootc (immutable, OCI-based)
+- **OS Base:** Fedora bootc (immutable, OCI-based) + per-service podman Quadlets
 - **Desktop:** COSMIC (System76) on Wayland
 - **AI Runtime:** llama.cpp / llama-server
-- **TTS:** Kokoro-82M (Apache 2.0) via `lifeos-tts-server.service` on `127.0.0.1:8084`
+- **TTS:** Kokoro-82M (Apache 2.0) — runs as a podman Quadlet (`lifeos-tts.service`) pulling `ghcr.io/hectormr206/lifeos-tts:stable`, exposes `127.0.0.1:8084`
+- **Service architecture:** lean bootc host + ghcr.io side images per service
+  (`lifeos-tts`, `lifeos-llama-embeddings`, `lifeos-lifeosd`, `lifeos-simplex-bridge`).
+  See `docs/strategy/prd-architecture-pivot-lean-bootc-quadlet.md`.
 - **Database:** SQLite with WAL + sqlite-vec for embeddings
 - **API:** Axum REST + WebSocket on localhost:8081
 - **Protocols:** MCP (Model Context Protocol), AT-SPI2, D-Bus, CDP

--- a/containers/lifeos-tts/lifeos-tts.container
+++ b/containers/lifeos-tts/lifeos-tts.container
@@ -77,19 +77,20 @@ Volume=/opt/lifeos/kokoro-env/voices-manifest.json:/opt/lifeos/kokoro-env/voices
 # `:z` shares the label across consumers — safe for read-only configs.
 Volume=/etc/lifeos/tts-server.env:/etc/lifeos/tts-server.env:ro,z
 
+# Pass /etc/lifeos/tts-server.env CONTENTS into the container's process
+# env via podman --env-file. Without this, the Python script's os.environ
+# lookups (PHONEMIZER_ESPEAK_LIBRARY, HF_HOME, HF_HUB_OFFLINE,
+# LIFEOS_TTS_*) are undefined → phonemizer falls back to grapheme output
+# and Kokoro tries to fetch models online (which fails offline). [Service]
+# EnvironmentFile= only loads vars into systemd's exec env for substitution
+# in ExecStart=; podman does NOT inherit them into the container without
+# this [Container] directive.
+EnvironmentFile=/etc/lifeos/tts-server.env
+
 [Service]
 # Defense-in-depth Capa 4: ensure image is present locally before starting.
 # Quadlet requires ExecStartPre in [Service], not [Container].
 ExecStartPre=/usr/local/bin/lifeos-ensure-images
-
-# Load the env file BOTH ways: as systemd EnvironmentFile= so podman
-# inherits the vars and exports them into the container ENV (the Python
-# script reads via os.environ). The Volume= bind mount in [Container]
-# is REDUNDANT for the script's needs but kept for parity with the host
-# service (some operators may grep the file inside the container for
-# debugging). The `-` prefix tolerates the file being absent on a fresh
-# laptop where /etc/lifeos hasn't been provisioned yet.
-EnvironmentFile=-/etc/lifeos/tts-server.env
 
 # Capa 3 of defense-in-depth — auto-restart with watchdog.
 Restart=always

--- a/docs/operations/simplex-features.md
+++ b/docs/operations/simplex-features.md
@@ -12,14 +12,12 @@ the network. The connection is end-to-end encrypted and routed through
 SimpleX relay servers that never learn who is talking to whom.
 
 Axi connects to a local `simplex-chat` process running in headless/WebSocket
-mode on `ws://127.0.0.1:5226`. As of 0.8.28 the process runs as a podman
-Quadlet (`lifeos-simplex-bridge.service` generated from
-`/etc/containers/systemd/lifeos-simplex-bridge.container`) pulling
-`ghcr.io/hectormr206/lifeos-simplex-bridge:stable`. The legacy
-`simplex-chat.service` remains in `/usr/lib/systemd/system/` as a manual
-rollback target. All messages are dispatched through the shared agentic
-tool system in `daemon/src/axi_tools.rs` — same LLM, same tools, same
-conversation memory across SimpleX and the dashboard.
+mode on `ws://127.0.0.1:5226`. The host service `simplex-chat.service`
+runs the bot directly (Phase 5 Quadlet flip is staged but reverted in
+0.8.29 pending bootstrap-script integration). All messages are dispatched
+through the shared agentic tool system in `daemon/src/axi_tools.rs` —
+same LLM, same tools, same conversation memory across SimpleX and the
+dashboard.
 
 On first connect, the SimpleX profile is auto-configured (name: **Axi**,
 avatar, description) so Axi appears with the correct identity out of the box.

--- a/image/Containerfile
+++ b/image/Containerfile
@@ -791,6 +791,16 @@ COPY image/files/etc/systemd/system/lifeos-tts-server.service /usr/lib/systemd/s
 COPY image/files/etc/lifeos/tts-server.env /etc/lifeos/tts-server.env
 RUN chmod +x /usr/local/bin/lifeos-tts-server.py
 
+# --- Capa 4 — image guardian (PRD §5e) ---
+# Best-effort script + systemd unit that re-pulls system Quadlet images if
+# they were deleted from rootful containers-storage. Also wired as
+# ExecStartPre of every Quadlet, so the same code path runs before each
+# container start (defense-in-depth — works even if guardian.service is
+# masked).
+COPY image/files/usr/local/bin/lifeos-ensure-images /usr/local/bin/lifeos-ensure-images
+COPY image/files/etc/systemd/system/lifeos-image-guardian.service /usr/lib/systemd/system/lifeos-image-guardian.service
+RUN chmod +x /usr/local/bin/lifeos-ensure-images
+
 # --- Phase 1: TTS Quadlet (architecture pivot) ---
 # Drop the systemd Quadlet definition. systemd-generator picks it up at boot
 # and synthesizes lifeos-tts.service automatically — no symlink needed.
@@ -1137,10 +1147,13 @@ COPY image/files/etc/systemd/system/lifeos-refresh-bls-titles.service /usr/lib/s
 COPY image/files/etc/systemd/system/llama-server.service       /usr/lib/systemd/system/llama-server.service
 COPY image/files/etc/systemd/system/llama-server.service.d/10-fast-kill.conf /etc/systemd/system/llama-server.service.d/10-fast-kill.conf
 COPY image/files/etc/systemd/system/llama-embeddings.service   /usr/lib/systemd/system/llama-embeddings.service
-# Phase 2: nomic-embed-text → Quadlet. Generator turns this into
-# lifeos-llama-embeddings.service. Image is built by side-images.yml,
-# pulled at first boot via lifeos-ensure-images.
-COPY containers/lifeos-llama-embeddings/lifeos-llama-embeddings.container /etc/containers/systemd/lifeos-llama-embeddings.container
+# Phase 2 (embeddings) flip is REVERTED — the Quadlet relies on the host
+# setup script `lifeos-embeddings-setup.sh` to populate
+# /etc/lifeos/llama-embeddings.env (LIFEOS_EMBED_MODEL=...) and download
+# the GGUF, but the Quadlet doesn't invoke it. Re-flipping requires either
+# baking that bootstrap into the .container's ExecStartPre OR keeping the
+# legacy llama-embeddings.service auto-enabled with ExecCondition skipping
+# llama-server. Tracked for a follow-up PR.
 COPY image/files/etc/systemd/system/whisper-stt.service       /usr/lib/systemd/system/whisper-stt.service
 COPY image/files/etc/systemd/system/lifeos-btrfs-snapshot.service /usr/lib/systemd/system/lifeos-btrfs-snapshot.service
 COPY image/files/etc/systemd/system/lifeos-btrfs-snapshot.timer   /usr/lib/systemd/system/lifeos-btrfs-snapshot.timer
@@ -1150,9 +1163,12 @@ COPY image/files/etc/systemd/system/lifeos-security-baseline.service /usr/lib/sy
 COPY image/files/etc/systemd/system/lifeos-sentinel.service /usr/lib/systemd/system/lifeos-sentinel.service
 COPY image/files/etc/systemd/system/simplex-chat.service /usr/lib/systemd/system/simplex-chat.service
 COPY image/files/etc/systemd/system/simplex-chat.service.d/10-bootstrap-profile.conf /usr/lib/systemd/system/simplex-chat.service.d/10-bootstrap-profile.conf
-# Phase 5: simplex-chat → Quadlet. Generator produces
-# lifeos-simplex-bridge.service. Image is built by side-images.yml.
-COPY containers/lifeos-simplex-bridge/lifeos-simplex-bridge.container /etc/containers/systemd/lifeos-simplex-bridge.container
+# Phase 5 (simplex) flip is REVERTED — the Quadlet relies on
+# /var/lib/lifeos/simplex pre-existing with correct mode/owner AND on
+# `lifeos-simplex-setup.sh` having run to bootstrap the Axi profile.
+# Both came from the legacy host service which #73 removed from
+# multi-user.target.wants/. Re-flipping requires moving those into the
+# Quadlet's ExecStartPre or shipping a one-shot setup unit. Follow-up.
 COPY image/files/usr/local/bin/lifeos-simplex-setup.sh /usr/local/bin/lifeos-simplex-setup.sh
 RUN chmod +x /usr/local/bin/lifeos-simplex-setup.sh
 COPY image/files/etc/systemd/system/nvidia-persistenced.service.d/10-lifeos-conditions.conf /etc/systemd/system/nvidia-persistenced.service.d/10-lifeos-conditions.conf
@@ -1219,6 +1235,7 @@ RUN mkdir -p /usr/lib/systemd/system/multi-user.target.wants \
     ln -sf /usr/lib/systemd/system/lifeos-security-baseline.service /usr/lib/systemd/system/multi-user.target.wants/lifeos-security-baseline.service && \
     ln -sf /usr/lib/systemd/system/lifeos-sentinel.service /usr/lib/systemd/system/multi-user.target.wants/lifeos-sentinel.service && \
     ln -sf /usr/lib/systemd/system/lifeos-refresh-bls-titles.service /usr/lib/systemd/system/multi-user.target.wants/lifeos-refresh-bls-titles.service && \
+    ln -sf /usr/lib/systemd/system/simplex-chat.service /usr/lib/systemd/system/multi-user.target.wants/simplex-chat.service && \
     # Canonical enablement: lifeosd starts from the graphical session target
     # so it waits for the display server to be ready (fixes the tray-icon
     # race where lifeosd gave up after its 30s wait before COSMIC was up).
@@ -1233,6 +1250,7 @@ RUN mkdir -p /usr/lib/systemd/system/multi-user.target.wants \
         ln -sf /usr/lib/systemd/system/nvidia-persistenced.service /usr/lib/systemd/system/multi-user.target.wants/nvidia-persistenced.service; \
     fi && \
     ln -sf /usr/lib/systemd/system/llama-server.service   /usr/lib/systemd/system/multi-user.target.wants/llama-server.service && \
+    ln -sf /usr/lib/systemd/system/llama-embeddings.service /usr/lib/systemd/system/multi-user.target.wants/llama-embeddings.service && \
     ln -sf /usr/lib/systemd/system/whisper-stt.service    /usr/lib/systemd/system/multi-user.target.wants/whisper-stt.service && \
     ln -sf /usr/lib/systemd/system/fstrim.timer /usr/lib/systemd/system/timers.target.wants/fstrim.timer && \
     ln -sf /usr/lib/systemd/system/lifeos-btrfs-snapshot.timer /usr/lib/systemd/system/timers.target.wants/lifeos-btrfs-snapshot.timer && \
@@ -1240,6 +1258,7 @@ RUN mkdir -p /usr/lib/systemd/system/multi-user.target.wants \
     ln -sf /usr/lib/systemd/system/lifeos-flatpak-update.timer /usr/lib/systemd/system/timers.target.wants/lifeos-flatpak-update.timer && \
     ln -sf /usr/lib/systemd/system/lifeos-flatpak-nvidia-sync.service /usr/lib/systemd/system/multi-user.target.wants/lifeos-flatpak-nvidia-sync.service && \
     ln -sf /usr/lib/systemd/system/lifeos-aide-check.timer /usr/lib/systemd/system/timers.target.wants/lifeos-aide-check.timer && \
+    ln -sf /usr/lib/systemd/system/lifeos-image-guardian.service /usr/lib/systemd/system/multi-user.target.wants/lifeos-image-guardian.service && \
     ln -sf /usr/lib/systemd/system/lifeos-update-check.timer /usr/lib/systemd/system/timers.target.wants/lifeos-update-check.timer && \
     ln -sf /usr/lib/systemd/system/lifeos-update-stage.timer /usr/lib/systemd/system/timers.target.wants/lifeos-update-stage.timer && \
     ln -sf /usr/lib/systemd/system/lifeos-first-boot.service /usr/lib/systemd/system/graphical.target.wants/lifeos-first-boot.service && \

--- a/image/Containerfile
+++ b/image/Containerfile
@@ -1461,6 +1461,10 @@ RUN set -e; fail() { echo "VERIFY FAILED: $1"; exit 1; }; \
     test -x /usr/local/bin/lifeos-tts-server.py || fail "/usr/local/bin/lifeos-tts-server.py"; \
     test -f /usr/lib/systemd/system/lifeos-tts-server.service || fail "lifeos-tts-server.service"; \
     test -f /etc/lifeos/tts-server.env    || fail "/etc/lifeos/tts-server.env"; \
+    test -x /usr/local/bin/lifeos-ensure-images || fail "/usr/local/bin/lifeos-ensure-images"; \
+    test -f /usr/lib/systemd/system/lifeos-image-guardian.service || fail "lifeos-image-guardian.service"; \
+    test -L /usr/lib/systemd/system/multi-user.target.wants/lifeos-image-guardian.service || fail "guardian wants symlink"; \
+    test -f /etc/containers/systemd/lifeos-tts.container || fail "lifeos-tts.container"; \
     test -d /opt/lifeos/kokoro-env        || fail "/opt/lifeos/kokoro-env"; \
     test -f /opt/lifeos/kokoro-env/voices-manifest.json || fail "kokoro voices-manifest.json"; \
     test -x /usr/bin/spice-vdagent        || fail "/usr/bin/spice-vdagent"; \


### PR DESCRIPTION
## Summary

Adversarial review of #70/#71/#73 surfaced production-fatal bugs the local `podman run` validation never exercised because that path skips the systemd Quadlet generator entirely.

The current staged image (post #73) **would NOT work** on next reboot:
- 203/EXEC on every Quadlet (missing \`lifeos-ensure-images\` script)
- Robotic voice + offline-fetch failures on TTS (env vars not propagated to container)
- Empty model name → llama-server crash (Phase 2 embeddings)
- SimpleX bot with no profile + missing state dir (Phase 5)

## Production-fatal fixes

1. **\`lifeos-ensure-images\` and \`lifeos-image-guardian.service\` were never copied into the bootc image** — only the source files lived in \`image/files/\`. ExecStartPre would 203/EXEC, blocking every Quadlet. Now installed + guardian wired into \`multi-user.target.wants/\`.

2. **TTS \`EnvironmentFile=\` was in [Service]** instead of [Container]. systemd loads those vars into the unit's exec env for ExecStart= substitution but does NOT pass them through podman into the container ENV. Moved into [Container] (Quadlet maps it to podman \`--env-file\`).

3. **Phase 2 (embeddings) flip REVERTED.** The Quadlet relies on \`/etc/lifeos/llama-embeddings.env\` existing with \`LIFEOS_EMBED_MODEL=...\` — created by \`lifeos-embeddings-setup.sh\` in the legacy host service. With the legacy service removed from \`multi-user.target.wants/\`, that script never runs and the env var substitutes empty → \`llama-server --model /models/\` fails. Re-enabled the legacy service; flip will land once the bootstrap is folded into the Quadlet.

4. **Phase 5 (simplex-bridge) flip REVERTED.** Same shape: \`/var/lib/lifeos/simplex\` provisioning + profile bootstrap came from the legacy service. Re-enabled.

Phase 1 (TTS) stays flipped with fixes #1 and #2.

## Test plan

- [ ] CI green
- [ ] After deploy + reboot: \`systemctl is-active lifeos-tts.service\` → active, \`/health\` returns \`voices_loaded: 53\`, audio bubbles work via lifeosd
- [ ] \`systemctl is-active lifeos-image-guardian.service\` → active (oneshot, terminates after re-pull check)
- [ ] \`systemctl is-active llama-embeddings.service simplex-chat.service\` → both active (legacy services restored)