### PR TITLE
chore(deps): bump llama.cpp + simplex-chat in side container scaffolds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "life"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2626,7 +2626,7 @@ dependencies = [
 
 [[package]]
 name = "lifeos-integration-tests"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "life",
  "serde_json",
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "lifeosd"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.29"
+version = "0.8.30"
 
 [workspace.metadata.lifeos]
 codename = "Axolotl"

--- a/containers/lifeos-llama-embeddings/Containerfile
+++ b/containers/lifeos-llama-embeddings/Containerfile
@@ -35,7 +35,7 @@ RUN dnf -y install \
 # Pin to the same tag the bootc image llama-server uses, so embedding format
 # semantics match across the host (currently using --jinja for chat) and the
 # container (using --embeddings here). Bump in lockstep.
-ARG LLAMA_CPP_TAG=b8925
+ARG LLAMA_CPP_TAG=b8999
 
 RUN git clone https://github.com/ggml-org/llama.cpp /tmp/llama.cpp && \
     cd /tmp/llama.cpp && \

--- a/containers/lifeos-llama-server/Containerfile
+++ b/containers/lifeos-llama-server/Containerfile
@@ -53,7 +53,7 @@ RUN dnf -y install \
 
 # MUST match the host bootc llama-server's pinned tag for chat-template
 # compatibility. Bump in lockstep across both Containerfiles.
-ARG LLAMA_CPP_TAG=b8925
+ARG LLAMA_CPP_TAG=b8999
 
 RUN git clone https://github.com/ggml-org/llama.cpp /tmp/llama.cpp && \
     cd /tmp/llama.cpp && \

--- a/containers/lifeos-simplex-bridge/Containerfile
+++ b/containers/lifeos-simplex-bridge/Containerfile
@@ -19,7 +19,7 @@
 # carry just the binary into the runtime stage.
 FROM ubuntu:22.04 AS extract
 
-ARG SIMPLEX_CLI_VERSION=v6.4.11
+ARG SIMPLEX_CLI_VERSION=v6.5.0
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Container scaffolds only — host bootc image keeps current pins so this can land without touching the production chat path. llama.cpp b8925→b8999 (~74 upstream commits incl. Vulkan optimizations + security patches), simplex-chat v6.4.11→v6.5.0. Side-images.yml CI rebuilds these automatically; once they soak via the :stable images, the host bootc Containerfile can follow in a separate PR.