### PR TITLE
fix(quadlet): remove NoNewPrivileges= from TTS service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "life"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2626,7 +2626,7 @@ dependencies = [
 
 [[package]]
 name = "lifeos-integration-tests"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "life",
  "serde_json",
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "lifeosd"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.30"
+version = "0.8.31"
 
 [workspace.metadata.lifeos]
 codename = "Axolotl"

--- a/containers/lifeos-tts/lifeos-tts.container
+++ b/containers/lifeos-tts/lifeos-tts.container
@@ -106,13 +106,19 @@ TimeoutStartSec=60s
 # WatchdogSec=60s
 
 # Resource limits — same as the legacy systemd unit.
+# NOTE: applied to the systemd cgroup that wraps the podman process. With
+# Quadlet's `--cgroups=split` the container gets its own sub-cgroup; these
+# limits cap the parent so the WHOLE service envelope stays bounded.
 MemoryMax=1536M
 CPUQuota=200%
 
-# Security hardening that doesn't conflict with podman containerization.
-# Several hardenings (ProtectSystem=strict, PrivateDevices=true) are
-# implicit when running inside a container.
-NoNewPrivileges=true
+# DO NOT add `NoNewPrivileges=true` here. On Fedora 43 + podman 5.x +
+# Quadlet, NNP combined with `--cgroups=split` blocks podman's runtime
+# init lock acquisition (`/run/libpod/alive.lck` returns EACCES even
+# though the unit runs as root). The container-level hardening that
+# matters is set INSIDE [Container] (DropCapability=, ReadOnly=,
+# SecurityLabel=*) which Quadlet translates to podman flags directly.
+# Re-enable only after proving it works on a current Fedora image.
 
 [Install]
 WantedBy=multi-user.target default.target


### PR DESCRIPTION
Phase 1 TTS Quadlet crash-looped 800+ times post-reboot with: `Error: acquiring runtime init lock: open /run/libpod/alive.lck: permission denied`. NoNewPrivileges=true in [Service] interacts badly with podman's --cgroups=split. Removing it lets the container start cleanly. Container-level hardening via [Container] directives is unaffected. Manual workaround: revert to lifeos-tts-server.service. Test: after deploy + reboot, systemctl is-active lifeos-tts.service → active and /health returns voices_loaded:53.