### PR TITLE
fix(quadlet): drop :z from voices-manifest bind on bootc /opt RO layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "life"
-version = "0.8.32"
+version = "0.8.33"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2626,7 +2626,7 @@ dependencies = [
 
 [[package]]
 name = "lifeos-integration-tests"
-version = "0.8.32"
+version = "0.8.33"
 dependencies = [
  "life",
  "serde_json",
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "lifeosd"
-version = "0.8.32"
+version = "0.8.33"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "life"
-version = "0.8.31"
+version = "0.8.32"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2626,7 +2626,7 @@ dependencies = [
 
 [[package]]
 name = "lifeos-integration-tests"
-version = "0.8.31"
+version = "0.8.32"
 dependencies = [
  "life",
  "serde_json",
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "lifeosd"
-version = "0.8.31"
+version = "0.8.32"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.32"
+version = "0.8.33"
 
 [workspace.metadata.lifeos]
 codename = "Axolotl"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.31"
+version = "0.8.32"
 
 [workspace.metadata.lifeos]
 codename = "Axolotl"

--- a/containers/lifeos-tts/lifeos-tts.container
+++ b/containers/lifeos-tts/lifeos-tts.container
@@ -57,13 +57,16 @@ Network=host
 # which is already container-readable. Use plain `:ro`.
 Volume=/usr/local/bin/lifeos-tts-server.py:/usr/local/bin/lifeos-tts-server.py:ro
 
-# voices-manifest.json lives on the host inside the venv dir. Without this
-# bind-mount the script reports `voices_loaded: 0`, /voices returns [], and
-# /tts rejects valid voice names with HTTP 400. The manifest is curated
-# host-side (regenerated on Kokoro updates), so we keep it on the host and
-# mount read-only — same `:z` rationale as the env file (shared with rollback
-# host service and other readers).
-Volume=/opt/lifeos/kokoro-env/voices-manifest.json:/opt/lifeos/kokoro-env/voices-manifest.json:ro,z
+# voices-manifest.json lives in the bootc venv at /opt/lifeos/kokoro-env/.
+# Without this bind-mount the script reports `voices_loaded: 0`, /voices
+# returns [], and /tts rejects valid voice names with HTTP 400.
+#
+# IMPORTANT: NO `:z` here. /opt/ is part of the read-only bootc layer
+# (alongside /usr/) so podman's chcon-on-relabel via `:z` fails with
+# `lsetxattr ... read-only file system`. The file ships with the SELinux
+# label assigned at image build time (container-readable by default for
+# /opt/* on Fedora), so plain `:ro` is correct.
+Volume=/opt/lifeos/kokoro-env/voices-manifest.json:/opt/lifeos/kokoro-env/voices-manifest.json:ro
 
 # The legacy systemd unit reads /etc/lifeos/tts-server.env. Same here for
 # parity — the env file lives in the bootc image, no container rebuild

--- a/docs/operations/system-admin.md
+++ b/docs/operations/system-admin.md
@@ -197,7 +197,8 @@ not the primary runtime model.
 
 | Component | Pinned tag | Notes |
 |---|---|---|
-| llama.cpp | `b8925` (2026-04) | Vulkan FA DP4A, CUDA mem-leak fix, llama-server hardening |
+| llama.cpp | `b8999` (2026-05) | b8925 → b8999: ~74 commits, Vulkan opts + llama-server security patches |
+| simplex-chat | `v6.5.0` (2026-04) | bumped from v6.4.11; minor release line |
 | whisper.cpp | `v1.8.4` (2026-03) | Reproducible build (was unpinned HEAD) |
 | Bun runtime | `1.3.13` (2026-04) | Used by Claude Code Channels plugins |
 | Kokoro TTS | `kokoro==0.9.4` + `numpy==1.26.4` | numpy stays on 1.x for torch 2.4.1 ABI |

--- a/image/Containerfile
+++ b/image/Containerfile
@@ -125,7 +125,7 @@ RUN dnf install -y cmake make gcc-c++ git openssl-devel vulkan-loader-devel vulk
 # b8925 (2026-04) covers ~224 commits since b8701 incl. Vulkan FA DP4A perf
 # improvements, CUDA memory leak fix, and llama-server security patches.
 # https://github.com/ggml-org/llama.cpp/releases/tag/b8925
-ARG LLAMA_CPP_TAG=b8925
+ARG LLAMA_CPP_TAG=b8999
 RUN set -eux && \
     echo ">>> Building llama-server from source (Vulkan-enabled, pinned ${LLAMA_CPP_TAG})..." && \
     git clone https://github.com/ggml-org/llama.cpp /tmp/llama.cpp && \
@@ -286,7 +286,7 @@ RUN find /opt/lifeos/kokoro-env -type d -name '__pycache__' -exec rm -rf {} + 2>
 # We use bsdtar (libarchive) which natively handles .deb (ar) and .tar.zst
 # without needing dpkg or extra packages.
 FROM fedora:${FEDORA_MAJOR} AS simplex-extract
-ARG SIMPLEX_CLI_VERSION=v6.4.11
+ARG SIMPLEX_CLI_VERSION=v6.5.0
 RUN set -eux && \
     dnf -y install bsdtar curl && \
     curl -fSL -o /tmp/simplex-chat.deb \


### PR DESCRIPTION
Quadlet failed runtime after #77 with: `Error: lsetxattr ... /opt/lifeos/kokoro-env/voices-manifest.json: read-only file system`. The :z relabel can't write to /opt (bootc RO). Same fix as the .py script bind-mount (already uses :ro).