### PR TITLE
chore(deps): bump base Fedora 43 → 44

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "life"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2626,7 +2626,7 @@ dependencies = [
 
 [[package]]
 name = "lifeos-integration-tests"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "life",
  "serde_json",
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "lifeosd"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.33"
+version = "0.8.34"
 
 [workspace.metadata.lifeos]
 codename = "Axolotl"

--- a/containers/lifeos-lifeosd/Containerfile
+++ b/containers/lifeos-lifeosd/Containerfile
@@ -39,7 +39,7 @@
 # ---------------------------------------------------------------------------
 # Heavy: Rust toolchain, native deps for SQLite/openssl/dbus, full cargo cache.
 # Kept entirely separate from runtime so we don't ship gcc, headers, or .cargo/.
-FROM fedora:43 AS builder
+FROM fedora:44 AS builder
 
 RUN dnf -y install \
         rust cargo \
@@ -96,10 +96,10 @@ RUN /src/target/release/lifeosd --version || \
 # ---------------------------------------------------------------------------
 # Stage 2 — runtime
 # ---------------------------------------------------------------------------
-# fedora-minimal:43 because we need libsqlite3 + libdbus + libssl runtime libs
+# fedora-minimal:44 because we need libsqlite3 + libdbus + libssl runtime libs
 # and it's smaller than full fedora:43 (~80 MB vs ~250 MB). distroless is
 # tempting but lacks D-Bus libs we need for the SimpleX bridge IPC.
-FROM fedora-minimal:43 AS runtime
+FROM fedora-minimal:44 AS runtime
 
 RUN microdnf install -y \
         ca-certificates \

--- a/containers/lifeos-llama-embeddings/Containerfile
+++ b/containers/lifeos-llama-embeddings/Containerfile
@@ -19,7 +19,7 @@
 # ---------------------------------------------------------------------------
 # Build llama-server CPU-only (no Vulkan, no CUDA, no GPU). Embeddings is
 # CPU-bound on a 84 MB model — GPU would add complexity for ~zero speedup.
-FROM fedora:43 AS builder
+FROM fedora:44 AS builder
 
 RUN dnf -y install \
         cmake \
@@ -63,7 +63,7 @@ RUN /tmp/llama.cpp/build/bin/llama-server --version
 # ---------------------------------------------------------------------------
 # Minimal runtime — just the binary, libcurl (for model URL fetching if ever
 # needed), and tini for clean signal forwarding.
-FROM fedora-minimal:43 AS runtime
+FROM fedora-minimal:44 AS runtime
 
 RUN microdnf install -y \
         ca-certificates \

--- a/containers/lifeos-llama-embeddings/README.md
+++ b/containers/lifeos-llama-embeddings/README.md
@@ -28,7 +28,7 @@ podman build -t 10.66.66.1:5001/lifeos-llama-embeddings:dev \
   containers/lifeos-llama-embeddings/
 ```
 
-Expected size: ~50-80 MB (fedora-minimal:43 + the static llama-server binary). The build takes 5-10 minutes for the cmake compile.
+Expected size: ~50-80 MB (fedora-minimal:44 + the static llama-server binary). The build takes 5-10 minutes for the cmake compile.
 
 ## Test on laptop (manual, until Phase 2 flips)
 

--- a/containers/lifeos-llama-server/Containerfile
+++ b/containers/lifeos-llama-server/Containerfile
@@ -32,7 +32,7 @@
 # Heavy: shader-gen tool needs Vulkan headers + glslang. Build is slower
 # than embeddings (~20-30 min) because shader compilation alone is heavy.
 # Same image base as the host bootc llama-server build for parity.
-FROM fedora:43 AS builder
+FROM fedora:44 AS builder
 
 RUN dnf -y install \
         cmake \
@@ -85,7 +85,7 @@ RUN /tmp/llama.cpp/build/bin/llama-server --version
 # Critically does NOT need NVIDIA driver libraries — those come from the
 # HOST via CDI passthrough at container start time. The container only
 # needs vulkan-loader to find them.
-FROM fedora-minimal:43 AS runtime
+FROM fedora-minimal:44 AS runtime
 
 RUN microdnf install -y \
         ca-certificates \

--- a/image/Containerfile
+++ b/image/Containerfile
@@ -12,7 +12,7 @@
 #   podman build --build-arg LIFEOS_CHANNEL=edge -t lifeos:edge -f image/Containerfile .
 
 # Build against the latest supported Fedora major release.
-ARG FEDORA_MAJOR=43
+ARG FEDORA_MAJOR=44
 
 # ============================================================================
 # Stage 1: Build CLI + Daemon (Rust)
@@ -321,7 +321,7 @@ FROM ghcr.io/hectormr206/lifeos-nvidia-drivers:latest-f43-x86_64 AS nvidia-rpms
 FROM quay.io/fedora/fedora-bootc:${FEDORA_MAJOR}
 
 ARG LIFEOS_PRELOAD_MODEL=false
-ARG FEDORA_MAJOR=43
+ARG FEDORA_MAJOR=44
 
 ARG LIFEOS_CHANNEL=edge
 # Runtime booted version for bootc/channel manifests.


### PR DESCRIPTION
Stacked on #78. Bumps the bootc base + 4 side-image scaffolds to Fedora 44. Verified tags exist on all 3 registries (fedora, fedora-minimal, fedora-bootc). Major risks tracked in commit message — kmod-nvidia availability, possible package renames, toolchain drift. Land #78 first, then this only after CI green AND laptop boot test.