### PR TITLE
chore(deps): bump base Fedora 43 → 44

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "life"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2626,7 +2626,7 @@ dependencies = [
 
 [[package]]
 name = "lifeos-integration-tests"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "life",
  "serde_json",
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "lifeosd"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.33"
+version = "0.8.34"
 
 [workspace.metadata.lifeos]
 codename = "Axolotl"

--- a/containers/lifeos-lifeosd/Containerfile
+++ b/containers/lifeos-lifeosd/Containerfile
@@ -39,7 +39,7 @@
 # ---------------------------------------------------------------------------
 # Heavy: Rust toolchain, native deps for SQLite/openssl/dbus, full cargo cache.
 # Kept entirely separate from runtime so we don't ship gcc, headers, or .cargo/.
-FROM fedora:43 AS builder
+FROM fedora:44 AS builder
 
 RUN dnf -y install \
         rust cargo \
@@ -96,10 +96,10 @@ RUN /src/target/release/lifeosd --version || \
 # ---------------------------------------------------------------------------
 # Stage 2 — runtime
 # ---------------------------------------------------------------------------
-# fedora-minimal:43 because we need libsqlite3 + libdbus + libssl runtime libs
+# fedora-minimal:44 because we need libsqlite3 + libdbus + libssl runtime libs
 # and it's smaller than full fedora:43 (~80 MB vs ~250 MB). distroless is
 # tempting but lacks D-Bus libs we need for the SimpleX bridge IPC.
-FROM fedora-minimal:43 AS runtime
+FROM fedora-minimal:44 AS runtime
 
 RUN microdnf install -y \
         ca-certificates \

--- a/containers/lifeos-lifeosd/Containerfile
+++ b/containers/lifeos-lifeosd/Containerfile
@@ -97,7 +97,7 @@ RUN /src/target/release/lifeosd --version || \
 # Stage 2 — runtime
 # ---------------------------------------------------------------------------
 # fedora-minimal:44 because we need libsqlite3 + libdbus + libssl runtime libs
-# and it's smaller than full fedora:43 (~80 MB vs ~250 MB). distroless is
+# and it's smaller than full fedora:44 (~80 MB vs ~250 MB). distroless is
 # tempting but lacks D-Bus libs we need for the SimpleX bridge IPC.
 FROM fedora-minimal:44 AS runtime
 

--- a/containers/lifeos-llama-embeddings/Containerfile
+++ b/containers/lifeos-llama-embeddings/Containerfile
@@ -19,7 +19,7 @@
 # ---------------------------------------------------------------------------
 # Build llama-server CPU-only (no Vulkan, no CUDA, no GPU). Embeddings is
 # CPU-bound on a 84 MB model — GPU would add complexity for ~zero speedup.
-FROM fedora:43 AS builder
+FROM fedora:44 AS builder
 
 RUN dnf -y install \
         cmake \
@@ -63,7 +63,7 @@ RUN /tmp/llama.cpp/build/bin/llama-server --version
 # ---------------------------------------------------------------------------
 # Minimal runtime — just the binary, libcurl (for model URL fetching if ever
 # needed), and tini for clean signal forwarding.
-FROM fedora-minimal:43 AS runtime
+FROM fedora-minimal:44 AS runtime
 
 RUN microdnf install -y \
         ca-certificates \

--- a/containers/lifeos-llama-embeddings/README.md
+++ b/containers/lifeos-llama-embeddings/README.md
@@ -28,7 +28,7 @@ podman build -t 10.66.66.1:5001/lifeos-llama-embeddings:dev \
   containers/lifeos-llama-embeddings/
 ```
 
-Expected size: ~50-80 MB (fedora-minimal:43 + the static llama-server binary). The build takes 5-10 minutes for the cmake compile.
+Expected size: ~50-80 MB (fedora-minimal:44 + the static llama-server binary). The build takes 5-10 minutes for the cmake compile.
 
 ## Test on laptop (manual, until Phase 2 flips)
 

--- a/containers/lifeos-llama-server/Containerfile
+++ b/containers/lifeos-llama-server/Containerfile
@@ -32,7 +32,7 @@
 # Heavy: shader-gen tool needs Vulkan headers + glslang. Build is slower
 # than embeddings (~20-30 min) because shader compilation alone is heavy.
 # Same image base as the host bootc llama-server build for parity.
-FROM fedora:43 AS builder
+FROM fedora:44 AS builder
 
 RUN dnf -y install \
         cmake \
@@ -85,7 +85,7 @@ RUN /tmp/llama.cpp/build/bin/llama-server --version
 # Critically does NOT need NVIDIA driver libraries — those come from the
 # HOST via CDI passthrough at container start time. The container only
 # needs vulkan-loader to find them.
-FROM fedora-minimal:43 AS runtime
+FROM fedora-minimal:44 AS runtime
 
 RUN microdnf install -y \
         ca-certificates \

--- a/docs/architecture/ai-runtime.md
+++ b/docs/architecture/ai-runtime.md
@@ -2253,7 +2253,7 @@ RUN dnf -y install cosmic-desktop cosmic-files cosmic-terminal \
 # --- Nvidia Optimus (GPU hibrida) ---
 # NVIDIA driver RPMs provienen de hectormr206/lifeos-nvidia-drivers
 # (Production Branch, Blackwell-ready, actualizado semanalmente).
-FROM ghcr.io/hectormr206/lifeos-nvidia-drivers:latest-f43-x86_64 AS nvidia-rpms
+FROM ghcr.io/hectormr206/lifeos-nvidia-drivers:latest-f44-x86_64 AS nvidia-rpms
 # (en stage final)
 RUN --mount=type=bind,from=nvidia-rpms,source=/,target=/mnt/nvidia-rpms,ro \
     dnf -y install /mnt/nvidia-rpms/*.rpm supergfxctl && dnf clean all

--- a/docs/operations/system-admin.md
+++ b/docs/operations/system-admin.md
@@ -197,6 +197,7 @@ not the primary runtime model.
 
 | Component | Pinned tag | Notes |
 |---|---|---|
+| Base distro | `Fedora 44` (`FEDORA_MAJOR=44`) | bumped from Fedora 43 — kernel + glibc + every RPM rebuilt |
 | llama.cpp | `b8999` (2026-05) | b8925 → b8999: ~74 commits, Vulkan opts + llama-server security patches |
 | simplex-chat | `v6.5.0` (2026-04) | bumped from v6.4.11; minor release line |
 | whisper.cpp | `v1.8.4` (2026-03) | Reproducible build (was unpinned HEAD) |

--- a/docs/strategy/prd-architecture-pivot-lean-bootc-quadlet.md
+++ b/docs/strategy/prd-architecture-pivot-lean-bootc-quadlet.md
@@ -189,7 +189,7 @@ TOTAL: 3-5 minutos por iteración
 
 ```bash
 # 1. Crear distrobox dev (una sola vez)
-distrobox create --name lifeos-dev --image fedora:43 --nvidia
+distrobox create --name lifeos-dev --image fedora:44 --nvidia
 distrobox enter lifeos-dev
 # adentro: rustup default stable, cargo, etc.
 
@@ -361,7 +361,7 @@ image prune`. Los argumentos son idénticos.
 
 ```dockerfile
 # Build stage — Fedora con cargo
-FROM fedora:43 AS builder
+FROM fedora:44 AS builder
 RUN dnf install -y rust cargo openssl-devel sqlite-devel
 WORKDIR /build
 COPY . .
@@ -380,7 +380,7 @@ Resultado esperado: ~30-50 MB vs ~500 MB con full Fedora runtime.
 
 ```dockerfile
 # Build stage con todas las deps
-FROM fedora:43 AS builder
+FROM fedora:44 AS builder
 RUN dnf install -y cmake gcc-c++ vulkan-headers glslang glslc \
     pkgconf-pkg-config curl-devel
 WORKDIR /build
@@ -390,7 +390,7 @@ RUN git clone https://github.com/ggml-org/llama.cpp /tmp/llama.cpp \
     && cmake --build build -j1
 
 # Runtime stage — solo lo mínimo para correr
-FROM fedora:43-minimal
+FROM fedora-minimal:44
 RUN microdnf install -y vulkan-loader libcurl --setopt=tsflags=nodocs && microdnf clean all
 COPY --from=builder /build/build/bin/llama-server /usr/sbin/llama-server
 ENTRYPOINT ["/usr/sbin/llama-server"]
@@ -404,7 +404,7 @@ Definir un `lifeos-base` mínimo común:
 
 ```dockerfile
 # containers/lifeos-base/Containerfile
-FROM fedora:43-minimal
+FROM fedora-minimal:44
 RUN microdnf install -y ca-certificates tzdata libcurl --setopt=tsflags=nodocs \
     && microdnf clean all
 ```

--- a/docs/strategy/prd-memory-simplification.md
+++ b/docs/strategy/prd-memory-simplification.md
@@ -1,0 +1,171 @@
+# PRD — Memory Simplification (Lexical-First)
+
+**Status:** Draft · 2026-04-26
+**Author:** Hector + Claude
+**Inspiration:** [Gentleman's Engram](https://github.com/) (SQLite + FTS5 only)
+**Predecessor:** Memory audit (Sprint 1-4 ya shipped)
+
+---
+
+## 1. Motivación
+
+LifeOS tiene actualmente 4 capas de búsqueda de memoria:
+
+| Capa | Estado | Costo |
+|------|--------|-------|
+| SQLite (relacional) | OK | bajo |
+| sqlite-vec (embeddings 768-dim) | OK | alto (modelo 250MB + servicio embeddings + ~80ms/query) |
+| AES-256-GCM-SIV (encripción por fila) | OK | medio (CPU por cada read/write) |
+| FTS5 (lexical) | **roto** desde audit | bajo |
+
+**Hallazgo del audit:** la capa lexical (FTS5) estaba rota mientras la vectorial "funcionaba". Eso indica que **la lexical no era crítica en el flujo real** — si lo fuera, lo habríamos detectado mucho antes.
+
+**Hipótesis a validar:** el 80-90% de las queries reales que hace Axi (y Hector) se resuelven igual o mejor con FTS5 que con embeddings semánticos. Las embeddings agregan latencia, dependencia de servicio externo (`llama-embeddings.service`), y RAM/VRAM, sin beneficio proporcional.
+
+**Costo del status quo:**
+- 250MB modelo nomic-embed-text-v1.5 en disco
+- ~80ms latencia por query (embed → vec search → re-rank)
+- Servicio extra que puede fallar (`llama-embeddings.service`)
+- Complejidad: 2 caminos de búsqueda en código → más superficie de bug
+
+---
+
+## 2. Decisión propuesta
+
+**Hacer FTS5 la búsqueda PRIMARIA. Demover sqlite-vec a fallback opcional.**
+
+### Arquitectura objetivo
+
+```
+┌─ Query entra ─┐
+│               │
+▼               ▼
+FTS5 lexical    (timeout 5ms)
+│
+├─ Si retorna >= N resultados relevantes → DONE
+│
+└─ Si vacío o muy pocos
+   │
+   ├─ ¿Embeddings disponibles? (servicio up + modelo cargado)
+   │  ├─ SÍ → vector search como fallback
+   │  └─ NO → retornar resultados FTS5 aunque sean pocos
+   │
+   └─ Combinar y deduplicar
+```
+
+### Reglas
+
+1. **FTS5 SIEMPRE corre primero.** Sin excepciones.
+2. **Vector solo si:** (a) FTS5 retorna < 3 resultados Y (b) servicio embeddings está OK
+3. **Vector es OPCIONAL** a nivel imagen: feature flag `embeddings`. Imagen base no lo incluye. Usuario opt-in.
+4. **Reformulación de queries:** antes de ir a vector, el LLM puede reformular la query 2-3 veces y reintenter FTS5 (más barato que embed)
+
+---
+
+## 3. Plan de validación (NO implementar antes de medir)
+
+### Sprint pre-implementación: **Telemetría de uso**
+
+1. Logear toda query a `MemoryPlane::search` con:
+   - query string original
+   - origin (LLM tool / UI / API)
+   - resultados FTS5 (count, top relevance)
+   - resultados vector (count, top similarity)
+   - cuál se usó finalmente
+2. Correr 2 semanas en uso real
+3. Análisis:
+   - **% queries donde FTS5 solo bastó** (>= 1 resultado relevante)
+   - **% queries donde vector aportó algo único** (resultado que FTS5 no encontró)
+   - **% queries donde ninguno encontró nada**
+4. **Decisión gate:**
+   - FTS5 solo basta >= 85% → ir adelante con migración
+   - 70-85% → mantener híbrido, FTS5 primero (versión "soft" del cambio)
+   - < 70% → no migrar, vector justifica su costo
+
+---
+
+## 4. Implementación (después del gate)
+
+### Fase 1: Arreglar FTS5 (sprint memoria pendiente)
+- FTS5 virtual table sobre `memory_entries.content` y `memory_entries.title`
+- Tokenizer: `unicode61 remove_diacritics 2`
+- Triggers para mantener FTS5 sincronizado
+- Tests: queries en español con acentos, números, fechas
+
+### Fase 2: Reordenar prioridad
+- `MemoryPlane::search()` → llama FTS5 primero
+- Solo si necesario, llama vector
+- Métrica nueva: `search_path` ("fts5_only" | "fts5_then_vector" | "vector_fallback")
+
+### Fase 3: Demover sqlite-vec
+- Feature flag `embeddings` en `daemon/Cargo.toml`
+- `llama-embeddings.service` se vuelve opt-in (no arranca por default)
+- Documentar en `docs/operations/memory.md` cómo activar para usuarios con GPU
+
+### Fase 4: Limpieza
+- Eliminar tools LLM que dependen exclusivamente de embeddings
+- Migrar tools que usaban embeddings → versión que primero intenta FTS5
+
+---
+
+## 5. Lo que NO se cambia
+
+- **Encripción AES-256-GCM-SIV** se mantiene — Hector lo quiere por privacidad
+- **Knowledge graph (entities + relations)** se mantiene — es relacional puro, no compite con búsqueda
+- **Sqlite-vec NO se elimina del código** — solo deja de ser default
+- **Ningún dato existente se pierde** — embeddings ya generadas siguen consultables si user activa feature
+
+---
+
+## 6. Riesgos
+
+| Riesgo | Mitigación |
+|--------|------------|
+| FTS5 español no maneja bien acentos | Tokenizer `unicode61 remove_diacritics 2` + tests específicos |
+| LLM no reformula queries bien | Prompt template + ejemplos few-shot |
+| Usuario nota peor recall | Telemetría detecta antes; vector queda como fallback automático |
+| Romper tools existentes que llaman vector directo | Feature flag + tests de regresión |
+
+---
+
+## 7. Métricas de éxito
+
+- **Latencia p50 query:** baja de ~80ms a < 5ms
+- **RAM daemon:** baja ~300MB (modelo nomic) si usuario opta out
+- **Servicios systemd activos:** -1 (`llama-embeddings.service` opt-in)
+- **Líneas de código memoria:** -20-30% (eliminar branches embed-first)
+- **Bugs en memoria:** menos superficie → menos bugs
+
+---
+
+## 8. Estimación
+
+| Fase | Esfuerzo |
+|------|----------|
+| Telemetría (pre-gate) | 4-6h |
+| 2 semanas observación | wall-clock, 0h trabajo |
+| Análisis + decisión gate | 1-2h |
+| Fase 1 (arreglar FTS5) | 6-8h |
+| Fase 2 (reordenar prioridad) | 4-6h |
+| Fase 3 (demover sqlite-vec) | 3-4h |
+| Fase 4 (cleanup) | 2-3h |
+
+**Total: 20-30h** + 2 semanas wall-clock para validación.
+
+---
+
+## 9. Decisiones pendientes
+
+- [ ] ¿Telemetría tiene que ser opt-in del usuario? (sí — privacidad)
+- [ ] ¿Métricas se guardan localmente o se exportan? (local-only por default)
+- [ ] ¿Cuál es el threshold "resultado relevante" en FTS5? (rank score > X)
+- [ ] ¿Mantenemos sqlite-vec para nuevas instalaciones o solo legacy? (decidir post-gate)
+
+---
+
+## 10. Próximos pasos
+
+1. Aprobar este PRD (Hector ✅ — 2026-04-26)
+2. **NO empezar hasta** que termine el deploy actual (Life Areas v1)
+3. Crear change vía `/sdd-new memory-simplification` cuando esté listo
+4. Sprint telemetría primero, **datos antes que opiniones**

--- a/docs/strategy/prd-tinyagent-swarm.md
+++ b/docs/strategy/prd-tinyagent-swarm.md
@@ -1,0 +1,453 @@
+# PRD — TinyAgent Swarm (Enjambre de Nanoagentes Especializados)
+
+**Status:** Draft · 2026-04-26
+**Author:** Hector + Claude
+**Inspiración:** [NVIDIA "Small Language Models are the Future of Agentic AI" (2026)](https://arxiv.org/pdf/2506.02153), [Hybrid AI Routers (arXiv 2504.10519)](https://arxiv.org/html/2504.10519v1), Google Gemma 3 270M
+**Predecesor:** Plan original LifeOS de "1 modelo grande Qwen3.5-9B con 128K"
+
+---
+
+## 1. Visión
+
+LifeOS debe correr en **cualquier laptop de 8-12GB RAM**, sin GPU obligatoria, manteniendo **privacidad 100% local**. Para lograrlo:
+
+> **Reemplazar (donde sea posible) el modelo monolítico grande por un enjambre de tinyagentes especializados (<512MB cada uno) corriendo en CPU+RAM, donde cada uno hace UNA tarea muy bien y muy rápido.**
+
+El modelo grande (Qwen3.5-9B) **NO desaparece** — se reserva para razonamiento profundo y queries complejas verdaderamente novedosas. Se vuelve un **co-procesador** que se invoca solo cuando ningún tinyagent puede resolver la query.
+
+### Por qué esta dirección
+
+1. **Privacidad real para cualquier hardware:** no requiere VRAM, todo en RAM
+2. **Paralelismo verdadero:** cada tinyagent es un proceso independiente, no comparten contexto ni KV cache
+3. **Sin degradación por concurrencia:** 5 tinyagents trabajando simultáneamente = 5x throughput, no division de recursos
+4. **Costo bajo de inferencia:** un 270M Q4 en CPU corre a 50-100 tok/s, latencia <100ms
+5. **Industria validada:** Gartner predice 3x más adopción de SLMs vs LLMs generalistas para 2027
+
+---
+
+## 2. Restricciones duras (no negociables)
+
+| Restricción | Razón |
+|-------------|-------|
+| **Cada tinyagent ≤ 512MB en disco/RAM (Q4_K_M)** | Caben varios en 8GB RAM con margen para sistema |
+| **CPU-only inference por default** | LifeOS para todos, no asume GPU |
+| **Latencia de invocación < 200ms** | Para que UI/Axi se sientan instantáneos |
+| **Tinyagent solo necesita su prompt + input → output** | No requiere context histórico (ese lo da el orchestrator) |
+| **Apache 2.0 / MIT solamente** | Comercial sin trabas |
+| **Funciona offline** | Privacidad 100% |
+
+**Tope total RAM del enjambre completo:** 4GB (deja margen en laptop de 8GB para sistema + dashboard + memoria + browser).
+
+---
+
+## 3. Catálogo de modelos candidatos (validados)
+
+### Tier 1: Ultra-tiny (<300MB Q4) — para tareas mecánicas
+
+| Modelo | Tamaño Q4 | Velocidad CPU | Especialidad ideal |
+|--------|-----------|---------------|---------------------|
+| **Gemma-3-270M** | ~180MB | 80-150 tok/s | Clasificación, routing, NER, extracción estructurada (Google lo diseñó EXACTAMENTE para esto) |
+| **SmolLM2-135M** | ~90MB | 150-250 tok/s | Triage muy rápido, intent detection |
+| **SmolLM2-360M** | ~250MB | 60-100 tok/s | Resumen corto, reescritura |
+
+### Tier 2: Tiny (300-700MB Q4) — para tareas con algo de razonamiento
+
+| Modelo | Tamaño Q4 | Velocidad CPU | Especialidad ideal |
+|--------|-----------|---------------|---------------------|
+| **Qwen2.5-0.5B** | ~350MB | 50-80 tok/s | Function-calling, multilingual ES |
+| **TinyLlama-1.1B** | ~600MB | 30-50 tok/s | Conversación corta general |
+| **Llama-3.2-1B** | ~700MB | 25-40 tok/s | Resumen estructurado, instrucciones |
+
+### Tier 3: Small (700MB-1GB Q4) — para tareas complejas pero acotadas
+
+| Modelo | Tamaño Q4 | Velocidad CPU | Especialidad ideal |
+|--------|-----------|---------------|---------------------|
+| **Qwen2.5-1.5B** | ~900MB | 20-35 tok/s | Razonamiento simple, JSON estructurado, multilingual |
+
+### Tier 4 (escape hatch): Modelo grande on-demand
+
+- **Qwen3.5-9B Q4** (5.5GB, GPU si disponible, sino offload) — solo invocado cuando **ningún tinyagent puede manejar la query**
+
+---
+
+## 4. Casos de uso priorizados — por dónde empezar
+
+### Sprint 1 (alto valor, bajo riesgo): **Router tinyagent**
+
+**Tarea:** clasificar cada query entrante en una de N categorías → decide qué procesador usar.
+
+- **Modelo:** Gemma-3-270M fine-tuneado (o zero-shot inicialmente)
+- **Input:** texto del usuario + metadata (origen: chat / Telegram / dashboard / tool)
+- **Output:** JSON `{"category": "summarization|email|coding|chat|memory_query|…", "confidence": 0.95}`
+- **Latencia objetivo:** <50ms
+- **Reemplaza:** lógica hardcoded actual en `llm_router.rs`
+
+### Sprint 2: **Resumen de reuniones (background)**
+
+**Tarea:** mientras Whisper transcribe en tiempo real, un tinyagent resume cada chunk de 5min.
+
+- **Modelo:** Gemma-3-270M fine-tuneado en summarization (o Llama-3.2-1B sin fine-tune)
+- **Input:** transcript de los últimos 5min
+- **Output:** 3-5 bullet points + temas emergentes
+- **Latencia objetivo:** <2s por chunk
+- **Beneficio crítico:** **libera al Qwen-9B para que vos puedas chatear con Axi en paralelo mientras grabás reunión** — hoy esto NO es posible
+
+### Sprint 3: **Categorizador de correos**
+
+**Tarea:** clasificar correo entrante en (urgente / importante / spam / newsletter / personal / trabajo).
+
+- **Modelo:** Gemma-3-270M fine-tuneado con tus correos históricos (privacy-preserving)
+- **Input:** subject + primeros 500 chars del body + sender
+- **Output:** `{"category": "...", "priority": 1-5, "needs_response": bool}`
+- **Latencia:** <100ms
+- **Reemplaza:** workflow n8n actual con Ollama+Gemma 4 (más rápido, local)
+
+### Sprint 4: **Extractor de entidades para memoria**
+
+**Tarea:** cuando Axi recibe un mensaje, extraer entidades (personas, fechas, lugares, montos) para alimentar el knowledge graph.
+
+- **Modelo:** Gemma-3-270M fine-tuneado en NER multilingual ES/EN
+- **Input:** texto natural
+- **Output:** JSON estructurado con entidades + relaciones
+- **Latencia:** <100ms
+- **Reemplaza:** prompts complejos al Qwen-9B que hoy hacen esto
+
+### Sprint 5: **Function-call selector**
+
+**Tarea:** dado que Axi tiene ~150 tools, elegir las 3-5 más relevantes para esta query (reduce contexto que se manda al LLM principal).
+
+- **Modelo:** Qwen2.5-0.5B (mejor en JSON estructurado)
+- **Input:** query + lista de tools disponibles (resumen 1-line cada uno)
+- **Output:** JSON `{"selected_tools": ["mem_search", "freelance_cliente_get", ...]}`
+- **Latencia:** <150ms
+- **Beneficio:** menos tokens al LLM grande → más rápido + más barato
+
+### Sprint 6+: **Tareas adicionales (lista abierta)**
+
+- Traductor ES↔EN (Llama-3.2-1B)
+- Reescritor de mensajes para diferentes tonos (formal / casual / corto)
+- Extractor de TODOs en notas
+- Detector de urgencia en SimpleX
+- Generador de títulos para conversaciones
+- Rewriter de queries para FTS5 (genera 3 reformulaciones)
+
+---
+
+## 5. Arquitectura técnica propuesta
+
+### 5.1 Componentes
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Orchestrator (parte de lifeosd)                        │
+│  - Decide qué tinyagent invocar para qué                │
+│  - Gestiona pool de procesos                            │
+│  - Mide latencia + tasa de error                        │
+└────────────────┬────────────────────────────────────────┘
+                 │
+       ┌─────────┼─────────┬─────────┬─────────┐
+       ▼         ▼         ▼         ▼         ▼
+   ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐
+   │Router  │ │Resumer │ │Mailer  │ │NER     │ │Tool-   │
+   │270M    │ │270M FT │ │270M FT │ │270M FT │ │Picker  │
+   │CPU     │ │CPU     │ │CPU     │ │CPU     │ │0.5B CPU│
+   │180MB   │ │180MB   │ │180MB   │ │180MB   │ │350MB   │
+   └────────┘ └────────┘ └────────┘ └────────┘ └────────┘
+
+Total RAM: ~1.1GB para los 5 tinyagents principales
+                 │
+                 ▼ (escape hatch para queries complejas)
+   ┌──────────────────────────────────────────┐
+   │  Qwen3.5-9B (GPU si disponible, sino    │
+   │  offload). Solo invocado cuando router   │
+   │  decide "esto requiere razonamiento     │
+   │  profundo".                              │
+   └──────────────────────────────────────────┘
+```
+
+### 5.2 Cómo se ejecutan los tinyagents
+
+**Opción A — Pool de procesos llama-server (recomendado):**
+- Cada tinyagent = una instancia llama-server en puerto distinto (8090, 8091, 8092, …)
+- Carga en boot del daemon, queda residente
+- HTTP API simple para invocar
+- Pro: aislado, robusto, no comparte estado, ya tenés llama-server
+- Con: 5 procesos = ~50MB overhead de runtime
+
+**Opción B — Llama embedded (vía `llama-cpp-rs` u `ort`):**
+- Modelos cargados dentro del proceso lifeosd
+- Inferencia directa, sin HTTP
+- Pro: latencia mínima, menos overhead
+- Con: si un modelo crashea el daemon entero cae
+
+**Decisión:** **Opción A** para MVP (más estable, debug fácil), evaluar Opción B post-validación.
+
+### 5.3 systemd
+
+Una unidad por tinyagent:
+```
+lifeos-tinyagent-router.service       (puerto 8090)
+lifeos-tinyagent-summarizer.service   (puerto 8091)
+lifeos-tinyagent-mailer.service       (puerto 8092)
+lifeos-tinyagent-ner.service          (puerto 8093)
+lifeos-tinyagent-tool-picker.service  (puerto 8094)
+```
+
+Permite habilitar/deshabilitar individualmente. Usuario en laptop chico desactiva los que no usa.
+
+### 5.4 Invocación desde el daemon
+
+Nuevo módulo `daemon/src/tinyagent/`:
+```rust
+pub struct TinyAgentClient {
+    name: String,
+    endpoint: String,
+    timeout_ms: u64,
+}
+
+impl TinyAgentClient {
+    pub async fn invoke(&self, input: TinyAgentInput) -> Result<TinyAgentOutput>;
+}
+
+pub struct TinyAgentRegistry {
+    router: TinyAgentClient,
+    summarizer: TinyAgentClient,
+    // ...
+}
+```
+
+`llm_router.rs` se simplifica: primero pregunta al `router` tinyagent, después dispatch.
+
+---
+
+## 6. Fine-tuning — pipeline local + comunidad
+
+### 6.1 Buena noticia: la laptop estándar SÍ aguanta (con QLoRA + Unsloth)
+
+Hardware referencia (Hector): 12GB VRAM + 32GB RAM. Validado:
+
+| Modelo | Método | VRAM | Tiempo (1500 ejemplos) | Viable |
+|--------|--------|------|------------------------|--------|
+| **Gemma-3-270M** | QLoRA + Unsloth | ~2-3GB | **30-60 min** | ✅ trivial |
+| **SmolLM2-360M** | QLoRA + Unsloth | ~3GB | 45-90 min | ✅ trivial |
+| **Qwen2.5-0.5B** | QLoRA + Unsloth | ~3-4GB | 1-2 hrs | ✅ trivial |
+| **Llama-3.2-1B** | QLoRA + Unsloth | ~5-6GB | 2-4 hrs | ✅ overnight |
+| **Qwen2.5-1.5B** | QLoRA + Unsloth | ~7-9GB | 4-8 hrs | ⚠️ overnight, enchufada |
+| Modelos > 3B | cualquier método | >12GB | — | ❌ no en laptop |
+
+**Claves técnicas:**
+- **QLoRA** = base cuantizado a 4-bit congelado + adapters de ~1% del modelo entrenables → VRAM baja 5-8x
+- **Unsloth** (open-source) = optimización extra, otro 50-70% menos VRAM y 2x más rápido
+- **Output:** archivo `.safetensors` de 10-50MB que se carga sobre el modelo base (no duplica el peso)
+
+### 6.2 Restricción para el PRD
+
+Tinyagent swarm asume fine-tuning local **solo para Tier 1 + Tier 2 (≤700MB)**. Si una tarea requiere un 1.5B fine-tuneado, ese modelo se entrena UNA vez (en laptop de Hector u otro contributor) y se publica para que el resto descargue.
+
+### 6.3 Estrategia escalonada
+
+**Etapa A — Zero-shot inicial (sprint 1-2):**
+- Empezar usando modelos sin fine-tune (Gemma-3-270M instruction-tuned ya viene con buen following)
+- Funcionalidad inmediata, validar arquitectura
+- Logear todas las queries + respuestas del usuario (consentido, local-only)
+
+**Etapa B — Fine-tune con datos sintéticos (sprint 3+):**
+- Generar dataset usando Qwen-9B local (NO sale del laptop)
+- Ejemplo: "Genera 500 ejemplos de clasificación de correos con estos labels: …"
+- Entrenar Gemma-3-270M con ese dataset → tinyagent v1
+
+**Etapa C — Fine-tune con datos reales del usuario (continua):**
+- Después de N semanas de uso, hay queries reales con outcomes validados
+- Re-fine-tune el tinyagent con datos reales → tinyagent v2 (mejor)
+- **Knowledge distillation pasiva:** queries que se escalaron a Qwen-9B + sus respuestas → entrenan al tinyagent para no escalar la próxima vez
+- **Mejora continua sin intervención manual**
+
+**Etapa D — Compartir modelos comunitarios (opt-in):**
+- Si Hector entrena un tinyagent que es genéricamente útil (ej: categorizador de correos en español), opcionalmente publicarlo en HuggingFace
+- LifeOS descarga modelos comunitarios al instalarse → usuario nuevo arranca con tinyagents pre-entrenados, no en zero-shot
+
+### 6.4 Pipeline técnico
+
+**CLI nuevo:**
+```bash
+# Generar dataset (sintético, local)
+life tinyagent dataset generate \
+  --task email-categorizer \
+  --source ~/.local/lifeos/email_history.db \
+  --size 1500 \
+  --teacher qwen-9b
+
+# Entrenar (local, QLoRA, Unsloth)
+life tinyagent train \
+  --model gemma-3-270m \
+  --task email-categorizer \
+  --dataset ~/datasets/email-cat.jsonl \
+  --epochs 3
+# → libera Qwen-9B durante el entrenamiento
+# → al terminar reactiva Qwen-9B
+
+# Validar
+life tinyagent test email-categorizer --against test-set.jsonl
+
+# Deploy
+life tinyagent deploy email-categorizer
+# → reemplaza el modelo en producción + reinicia el systemd unit
+
+# Compartir (opcional)
+life tinyagent publish email-categorizer --to huggingface
+```
+
+**Módulo nuevo:** `daemon/src/tinyagent/training/` envuelve Unsloth (Python) vía subprocess (Rust no tiene buen training stack).
+
+### 6.5 Privacidad
+
+| Caso | Garantía |
+|------|----------|
+| Generación de dataset sintético | 100% local — Qwen-9B genera, datos nunca salen |
+| Entrenamiento | 100% local — Unsloth corre en GPU del usuario |
+| Datos reales del usuario para re-fine-tune | 100% local — base SQLite cifrada, jamás se exporta |
+| Modelo entrenado | LOCAL por default. Publicación a HuggingFace es **explícita opt-in** con confirmación + diff de qué datos influyeron |
+| Modelos descargados de HuggingFace | Verificación de checksum + Apache 2.0/MIT only |
+
+### 6.6 Lo que NO hacemos
+
+- ❌ Mandar datos del usuario a APIs cloud para fine-tune (rompe privacy)
+- ❌ Pre-training desde cero (ridículo en laptop)
+- ❌ Full fine-tune de modelos >500M (no entra en VRAM consumer)
+- ❌ Auto-publicar modelos sin consentimiento explícito del usuario
+
+---
+
+## 7. Métricas de éxito
+
+| Métrica | Baseline (hoy) | Target post-implementación |
+|---------|----------------|----------------------------|
+| RAM ocupada por inferencia idle | 5.5GB (Qwen-9B residente) | <1.5GB (5 tinyagents) |
+| Latencia media de query simple | 800-1500ms (Qwen-9B) | <200ms (tinyagent directo) |
+| Throughput Axi en paralelo (queries simultáneas) | 1 (bloquea Qwen) | 5+ (cada tinyagent independiente) |
+| Hardware mínimo requerido | 12GB RAM + 8GB VRAM ideal | 8GB RAM, sin GPU |
+| % de queries resueltas por tinyagent (sin invocar Qwen-9B) | 0% | >70% objetivo |
+| Tiempo cold-start del daemon | ~15s | <8s (modelos chicos cargan rápido) |
+
+---
+
+## 8. Plan de migración por fases
+
+### Fase 0 (pre-trabajo, ~2 semanas wall-clock)
+- Telemetría: logear todas las queries actuales a Qwen-9B con su tipo
+- Análisis: clasificar manualmente 500 queries → cuántas son "simples" (candidatas a tinyagent)
+- **Decision gate:** si >60% son simples → seguir. Si <40% → repensar.
+
+### Fase 1 (~10-15h): Infraestructura
+- Módulo `daemon/src/tinyagent/` (cliente + registry)
+- Systemd template para tinyagents
+- 1 tinyagent piloto: el **Router** (Gemma-3-270M zero-shot)
+- Métricas: latencia, accuracy del router
+
+### Fase 2 (~8-10h): Resumer de reuniones
+- Tinyagent summarizer (Gemma-3-270M zero-shot inicial)
+- Integración con whisper-server para chunks
+- UI: mostrar resumen incremental en dashboard
+- Validar: **podés chatear con Axi mientras Whisper+Summarizer corren**
+
+### Fase 3 (~10h): Categorizador correos
+- Reemplaza workflow n8n actual
+- Fine-tune con tus correos históricos en VPS
+- Backfill de correos pasados re-categorizados
+
+### Fase 4 (~8h): NER + Tool-picker
+- Acelera memoria + reduce tokens al LLM grande
+
+### Fase 5 (~ongoing): Más tinyagents según demanda
+- Cada tarea repetitiva = candidato
+
+### Fase 6 (~6h): Knowledge distillation pasiva
+- Pipeline para mejorar tinyagents con uso real
+
+---
+
+## 9. Riesgos honestos
+
+| Riesgo | Probabilidad | Mitigación |
+|--------|--------------|------------|
+| Fine-tuning local resulta inviable sin GPU | Alta | Empezar zero-shot; fine-tune en VPS (CPU lento pero gratis) |
+| Tinyagents tienen accuracy insuficiente para producción | Media | Decision gate por tarea: si <85% → no migrar esa tarea |
+| Orchestrator se vuelve cuello de botella | Baja | Latencia HTTP local <5ms, despreciable |
+| Mantenimiento de N modelos = N veces más bugs | Media | Cada tinyagent es trivial (1 prompt + 1 task), bug surface chica |
+| Usuarios se confunden con tantos servicios systemd | Baja | Dashboard les muestra como "AI workers", no como servicios |
+| Modelos pre-fine-tuneados no existen para tareas en español | Media | Fine-tune local con datasets sintéticos generados por Qwen-9B |
+| 270M no entiende español rioplatense bien | Media | Validar con casos reales antes de comprometerse |
+
+---
+
+## 10. Lo que NO se cambia
+
+- **Qwen3.5-9B sigue como modelo principal** — solo se reduce la frecuencia de invocación
+- **Modo Privacidad** sigue funcionando — todo es local
+- **APIs cloud (Claude, GPT-4)** siguen disponibles para usuarios que opten — el enjambre no las reemplaza, las complementa
+- **Dashboard, SimpleX, n8n** no se tocan — solo cambia qué consume detrás
+- **Memoria, encripción, knowledge graph** intactos
+
+---
+
+## 11. Estimación total
+
+| Fase | Esfuerzo |
+|------|----------|
+| Fase 0 (telemetría + análisis) | 4h código + 2 semanas wall-clock |
+| Fase 1 (infra + router piloto) | 10-15h |
+| Fase 2 (summarizer reuniones) | 8-10h |
+| Fase 3 (categorizador correos) | 10h |
+| Fase 4 (NER + tool-picker) | 8h |
+| Fase 5+ (más tinyagents) | 4-6h por tinyagent adicional |
+| Fase 6 (distillation passive) | 6h |
+| **Fase 7 (training pipeline local)** | **15-20h** (CLI `life tinyagent train`, módulo Unsloth wrapper, validación) |
+| **Fase 8 (model sharing comunitario)** | **8-10h** (publish/download flow, checksum, verificación licencia) |
+
+**Total Fases 0-4: ~40-50h** + 2 semanas validación. Fases 5-8 incrementales (~30-40h adicionales para el pipeline completo de fine-tuning).
+
+---
+
+## 12. Decisiones pendientes (para charlar antes de empezar)
+
+- [ ] ¿Empezamos zero-shot o invertimos en fine-tuning desde el día 1?
+- [ ] ¿Aceptamos correr fine-tunes en el VPS (CPU lento pero privacy-safe) o usamos un servicio cloud para entrenar UNA vez los modelos base?
+- [ ] ¿Cuántos tinyagents máximo en la imagen base de LifeOS? (5 default + opt-in para más?)
+- [ ] ¿Usuarios pueden agregar tinyagents propios? (UX para "instalar tinyagent")
+- [ ] ¿Métricas de fine-tune son privadas (local) o se exportan opcionalmente?
+
+---
+
+## 13. Próximos pasos
+
+1. **Aprobar este PRD** (Hector ✅ — pending)
+2. **NO empezar antes de:**
+   - Terminar deploy actual (Life Areas v1)
+   - Ejecutar PRD Memory Simplification (FTS5 first) — son pre-requisito para algunos tinyagents
+3. **Crear change** vía `/sdd-new tinyagent-swarm` cuando esté listo
+4. **Sprint Fase 0 primero** — datos antes que opiniones
+
+---
+
+## Apéndice A — Referencias
+
+- [NVIDIA: Small Language Models are the Future of Agentic AI (2026)](https://arxiv.org/pdf/2506.02153)
+- [Survey: SLMs for Agentic Systems (arXiv 2510.03847)](https://arxiv.org/abs/2510.03847)
+- [Hybrid AI Routers — Super Agent System (arXiv 2504.10519)](https://arxiv.org/html/2504.10519v1)
+- [Google: Introducing Gemma 3 270M](https://developers.googleblog.com/en/introducing-gemma-3-270m/)
+- [Own your AI: Fine-tune Gemma 3 270M on-device](https://developers.googleblog.com/own-your-ai-fine-tune-gemma-3-270m-for-on-device/)
+- [Best Small AI Models 2026 — Local AI Master](https://localaimaster.com/blog/small-language-models-guide-2026)
+- [SmolLM2 model family (HuggingFace)](https://huggingface.co/HuggingFaceTB)
+- [Qwen2.5-0.5B specifications](https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct)
+
+---
+
+## Apéndice B — Hardware target validado
+
+| Hardware | RAM disponible para AI | Tinyagents que caben |
+|----------|------------------------|----------------------|
+| Laptop 8GB RAM | ~3GB | 5 tinyagents (Router 180MB + Summarizer 180MB + Mailer 180MB + NER 180MB + Tool-picker 350MB = 1.1GB, queda margen) |
+| Laptop 12GB RAM (estándar 2026) | ~5GB | 8-10 tinyagents + Qwen3.5-9B compartido CPU/GPU |
+| Workstation 32GB RAM | ~20GB | enjambre completo + Qwen-9B + Qwen3.6-35B-A3B opt-in |
+
+**LifeOS funciona en TODO el rango sin cambios de arquitectura.**

--- a/image/Containerfile
+++ b/image/Containerfile
@@ -14,6 +14,13 @@
 # Build against the latest supported Fedora major release.
 ARG FEDORA_MAJOR=44
 
+# Pre-compiled NVIDIA RPM image — must match FEDORA_MAJOR's kernel ABI.
+# Declared at global scope so the `FROM ...:${NVIDIA_DRIVERS_TAG}` in the
+# nvidia-rpms stage can reference it (Dockerfile rule: ARGs used in FROM
+# must be declared before any FROM, not inside a previous stage). Built
+# and published by lifeos-nvidia-drivers CI per Fedora major.
+ARG NVIDIA_DRIVERS_TAG=latest-f44-x86_64
+
 # ============================================================================
 # Stage 1: Build CLI + Daemon (Rust)
 # ============================================================================
@@ -313,14 +320,13 @@ RUN set -eux && \
 # kernel), nvidia-kmod-common, nvidia-modprobe, nvidia-settings,
 # nvidia-persistenced, nvidia-driver-selinux, nvidia-container-toolkit,
 # libnvidia-container.
-# BLOCKER on Fedora bumps: this image must be rebuilt + republished with a
-# matching `f${FEDORA_MAJOR}` tag in the lifeos-nvidia-drivers repo BEFORE
-# this Containerfile bumps. The pre-compiled kmod-nvidia in this image is
-# linked against fc${X}'s kernel ABI; mixing fc43 kmod into an fc44 base
-# fails modprobe at first boot. CI should fail at the FROM line if the tag
-# does not exist, surfacing the blocker explicitly rather than silently
-# shipping a broken image.
-ARG NVIDIA_DRIVERS_TAG=latest-f44-x86_64
+# BLOCKER on Fedora bumps: lifeos-nvidia-drivers must publish a matching
+# `f${FEDORA_MAJOR}` tag BEFORE this Containerfile bumps — the pre-compiled
+# kmod-nvidia is linked against the kernel ABI of its build distro and
+# crossing majors fails modprobe at first boot. NVIDIA_DRIVERS_TAG is
+# declared at global scope at the top of the file (Dockerfile requires
+# ARGs used in FROM to be declared before any FROM line, not inside a
+# prior stage).
 FROM ghcr.io/hectormr206/lifeos-nvidia-drivers:${NVIDIA_DRIVERS_TAG} AS nvidia-rpms
 
 # ============================================================================

--- a/image/Containerfile
+++ b/image/Containerfile
@@ -313,7 +313,15 @@ RUN set -eux && \
 # kernel), nvidia-kmod-common, nvidia-modprobe, nvidia-settings,
 # nvidia-persistenced, nvidia-driver-selinux, nvidia-container-toolkit,
 # libnvidia-container.
-FROM ghcr.io/hectormr206/lifeos-nvidia-drivers:latest-f43-x86_64 AS nvidia-rpms
+# BLOCKER on Fedora bumps: this image must be rebuilt + republished with a
+# matching `f${FEDORA_MAJOR}` tag in the lifeos-nvidia-drivers repo BEFORE
+# this Containerfile bumps. The pre-compiled kmod-nvidia in this image is
+# linked against fc${X}'s kernel ABI; mixing fc43 kmod into an fc44 base
+# fails modprobe at first boot. CI should fail at the FROM line if the tag
+# does not exist, surfacing the blocker explicitly rather than silently
+# shipping a broken image.
+ARG NVIDIA_DRIVERS_TAG=latest-f44-x86_64
+FROM ghcr.io/hectormr206/lifeos-nvidia-drivers:${NVIDIA_DRIVERS_TAG} AS nvidia-rpms
 
 # ============================================================================
 # Stage 6: Sistema Final
@@ -363,12 +371,16 @@ RUN dnf -y install dnf5-plugins && \
     # when the repoid is missing, which made the previous attempt
     # non-portable across rpmfusion package versions; sed on the actual
     # .repo files is robust to that.
-    for repo in /etc/yum.repos.d/rpmfusion-free-rawhide.repo \
-                /etc/yum.repos.d/rpmfusion-free-updates-testing.repo \
-                /etc/yum.repos.d/rpmfusion-nonfree-rawhide.repo \
-                /etc/yum.repos.d/rpmfusion-nonfree-updates-testing.repo; do \
-        [ -f "$repo" ] && sed -i 's/^enabled *= *1/enabled=0/' "$repo" || true; \
-    done && \
+    # Use find so the loop self-adapts if rpmfusion renames or adds repo
+    # files in future package versions. Empirically on rpmfusion-44:
+    # only `rpmfusion-free-rawhide.repo` ships with `enabled=1`; the
+    # updates-testing repos already ship `enabled=0`, and there is no
+    # `rpmfusion-nonfree-rawhide.repo` at all. The find pattern catches
+    # any matching file regardless of which entries the future package
+    # actually ships.
+    find /etc/yum.repos.d -maxdepth 1 -type f \
+        \( -name 'rpmfusion-*-rawhide*.repo' -o -name 'rpmfusion-*-updates-testing*.repo' \) \
+        -exec sed -i 's/^enabled *= *1/enabled=0/' {} + && \
     dnf clean all
 
 # --- Escritorio COSMIC y Base ---

--- a/image/Containerfile
+++ b/image/Containerfile
@@ -12,7 +12,7 @@
 #   podman build --build-arg LIFEOS_CHANNEL=edge -t lifeos:edge -f image/Containerfile .
 
 # Build against the latest supported Fedora major release.
-ARG FEDORA_MAJOR=43
+ARG FEDORA_MAJOR=44
 
 # ============================================================================
 # Stage 1: Build CLI + Daemon (Rust)
@@ -321,7 +321,7 @@ FROM ghcr.io/hectormr206/lifeos-nvidia-drivers:latest-f43-x86_64 AS nvidia-rpms
 FROM quay.io/fedora/fedora-bootc:${FEDORA_MAJOR}
 
 ARG LIFEOS_PRELOAD_MODEL=false
-ARG FEDORA_MAJOR=43
+ARG FEDORA_MAJOR=44
 
 ARG LIFEOS_CHANNEL=edge
 # Runtime booted version for bootc/channel manifests.

--- a/image/Containerfile
+++ b/image/Containerfile
@@ -354,6 +354,15 @@ RUN dnf -y install dnf5-plugins && \
     dnf -y --setopt=localpkg_gpgcheck=1 install \
       "https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm" \
       "https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm" && \
+    # The rpmfusion release RPM ships rawhide + updates-testing repo files
+    # ENABLED by default. On Fedora 44 that pulls ffmpeg from fc45 rawhide
+    # which needs glibc 2.44 (not on fc44). Disable both leaving only the
+    # release-stable channel for both free and nonfree.
+    dnf config-manager setopt \
+      rpmfusion-free-rawhide.enabled=0 \
+      rpmfusion-free-updates-testing.enabled=0 \
+      rpmfusion-nonfree-rawhide.enabled=0 \
+      rpmfusion-nonfree-updates-testing.enabled=0 && \
     dnf clean all
 
 # --- Escritorio COSMIC y Base ---

--- a/image/Containerfile
+++ b/image/Containerfile
@@ -355,14 +355,20 @@ RUN dnf -y install dnf5-plugins && \
       "https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm" \
       "https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm" && \
     # The rpmfusion release RPM ships rawhide + updates-testing repo files
-    # ENABLED by default. On Fedora 44 that pulls ffmpeg from fc45 rawhide
-    # which needs glibc 2.44 (not on fc44). Disable both leaving only the
-    # release-stable channel for both free and nonfree.
-    dnf config-manager setopt \
-      rpmfusion-free-rawhide.enabled=0 \
-      rpmfusion-free-updates-testing.enabled=0 \
-      rpmfusion-nonfree-rawhide.enabled=0 \
-      rpmfusion-nonfree-updates-testing.enabled=0 && \
+    # in /etc/yum.repos.d/. On Fedora 44 the rawhide repo points at
+    # ffmpeg-libs-8.0.1-9.fc45 which needs glibc 2.44 (not on fc44),
+    # breaking the ffmpeg install later. Force-disable both rawhide and
+    # updates-testing for free + nonfree by rewriting `enabled=1` to
+    # `enabled=0` directly. The dnf5 `config-manager setopt` errors out
+    # when the repoid is missing, which made the previous attempt
+    # non-portable across rpmfusion package versions; sed on the actual
+    # .repo files is robust to that.
+    for repo in /etc/yum.repos.d/rpmfusion-free-rawhide.repo \
+                /etc/yum.repos.d/rpmfusion-free-updates-testing.repo \
+                /etc/yum.repos.d/rpmfusion-nonfree-rawhide.repo \
+                /etc/yum.repos.d/rpmfusion-nonfree-updates-testing.repo; do \
+        [ -f "$repo" ] && sed -i 's/^enabled *= *1/enabled=0/' "$repo" || true; \
+    done && \
     dnf clean all
 
 # --- Escritorio COSMIC y Base ---

--- a/image/Containerfile
+++ b/image/Containerfile
@@ -655,7 +655,7 @@ RUN set -eux && \
 # --- Firefox Hardened (Privacy-first browser) ---
 RUN dnf -y install \
     firefox \
-    intel-media-driver \
+    libva-intel-media-driver \
     libva-utils \
     && dnf clean all
 

--- a/scripts/distrobox-dev-setup.sh
+++ b/scripts/distrobox-dev-setup.sh
@@ -2,7 +2,7 @@
 #
 # distrobox-dev-setup.sh — Provision the LifeOS developer distrobox.
 #
-# Phase 0 of the architecture pivot. Creates a Fedora 43 distrobox named
+# Phase 0 of the architecture pivot. Creates a Fedora 44 distrobox named
 # `lifeos-dev` with everything you need to:
 #   - cargo build the daemon + cli WITHOUT touching the host bootc rootfs
 #   - podman build any of the lifeos-* containers
@@ -24,7 +24,7 @@
 set -euo pipefail
 
 DISTROBOX_NAME="lifeos-dev"
-BASE_IMAGE="quay.io/fedora/fedora:43"
+BASE_IMAGE="quay.io/fedora/fedora:44"
 
 log() { printf "[distrobox-dev-setup] %s\n" "$*"; }
 


### PR DESCRIPTION
Successor of closed #79 (got auto-closed when #78 merged and squashed the base branch). Bumps the bootc base + 4 side-image scaffolds to Fedora 44. Tags verified upstream. Risks: kmod-nvidia availability, package renames, toolchain drift. Watch CI carefully — if fc44 RPMs break the build, iterate from there.