### PR TITLE
fix(quadlet+sudoers): TTS hf-cache bind + scoped NOPASSWD for hot-fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "life"
-version = "0.8.34"
+version = "0.8.35"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2626,7 +2626,7 @@ dependencies = [
 
 [[package]]
 name = "lifeos-integration-tests"
-version = "0.8.34"
+version = "0.8.35"
 dependencies = [
  "life",
  "serde_json",
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "lifeosd"
-version = "0.8.34"
+version = "0.8.35"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.34"
+version = "0.8.35"
 
 [workspace.metadata.lifeos]
 codename = "Axolotl"

--- a/containers/lifeos-tts/lifeos-tts.container
+++ b/containers/lifeos-tts/lifeos-tts.container
@@ -80,6 +80,16 @@ Volume=/opt/lifeos/kokoro-env/voices-manifest.json:/opt/lifeos/kokoro-env/voices
 # `:z` shares the label across consumers — safe for read-only configs.
 Volume=/etc/lifeos/tts-server.env:/etc/lifeos/tts-server.env:ro,z
 
+# HuggingFace cache from the host venv. Without this bind, the container's
+# /opt/lifeos/kokoro-env/hf-cache is empty (the side image only carries the
+# Python venv + libraries, not the multi-GB voice/model weights). On first
+# /tts call Kokoro tries to fetch from HF Hub, hits HF_HUB_OFFLINE=1, and
+# the service crashes with `LocalEntryNotFoundError`. The host bake
+# pre-populates this dir at image build time so a runtime bind-mount is the
+# correct surface. NO `:z` — /opt is on the read-only bootc layer (same
+# rationale as the voices-manifest.json mount above).
+Volume=/opt/lifeos/kokoro-env/hf-cache:/opt/lifeos/kokoro-env/hf-cache:ro
+
 # Pass /etc/lifeos/tts-server.env CONTENTS into the container's process
 # env via podman --env-file. Without this, the Python script's os.environ
 # lookups (PHONEMIZER_ESPEAK_LIBRARY, HF_HOME, HF_HUB_OFFLINE,

--- a/image/files/etc/sudoers.d/lifeos-axi
+++ b/image/files/etc/sudoers.d/lifeos-axi
@@ -272,6 +272,28 @@ Cmnd_Alias LIFEOS_PROTECTED_FS = \
 #     the %wheel rule no longer matches and the denylist would silently
 #     disengage. The explicit `lifeos` rule keeps Capa 2 active regardless
 #     of group membership.
+# === QUADLET HOT-FIX OPS (assistant automation lane) ===
+# Lets the assistant apply per-service hot-fixes without prompting for
+# Hector's password while he's away. Scoped tightly:
+#   - sed -i is restricted to *.container files under /etc/containers/systemd
+#     (does NOT match arbitrary /etc paths or anything outside the Quadlet
+#     directory).
+#   - systemctl restart / mask / unmask is restricted to lifeos-*.service —
+#     the prefix excludes legacy host services that ship without that prefix
+#     (lifeos-tts-server, lifeos-image-guardian still match because they DO
+#     start with `lifeos-`; this is intentional, those are LifeOS-managed).
+#   - systemctl reboot is included so post-staging deploys don't need
+#     interactive auth either. Capa 2 LIFEOS_PROTECTED_SYSTEMD_DESTRUCTIVE
+#     still blocks `systemctl stop lifeos-*` (final two `!` rules below).
+Cmnd_Alias LIFEOS_QUADLET_OPS = \
+    /usr/bin/sed -i * /etc/containers/systemd/*.container, \
+    /usr/bin/systemctl daemon-reload, \
+    /usr/bin/systemctl restart lifeos-*.service, \
+    /usr/bin/systemctl mask lifeos-*.service, \
+    /usr/bin/systemctl unmask lifeos-*.service, \
+    /usr/bin/systemctl reboot
+lifeos ALL=(root) NOPASSWD: LIFEOS_QUADLET_OPS
+
 %wheel ALL=(ALL) !LIFEOS_PROTECTED_PODMAN_DESTRUCTIVE
 %wheel ALL=(ALL) !LIFEOS_PROTECTED_SYSTEMD_DESTRUCTIVE
 %wheel ALL=(ALL) !LIFEOS_PROTECTED_FS


### PR DESCRIPTION
Validated live on Hector's laptop after the fc44 reboot.

## What broke

Phase 1 TTS Quadlet crashed on first /tts call with:
```
huggingface_hub.errors.LocalEntryNotFoundError: An error happened while
trying to locate the file on the Hub and we cannot find the requested
files in the local cache.
```

Root cause: the side image (`ghcr.io/hectormr206/lifeos-tts:stable`) ships only the Python venv + libraries — Kokoro pre-warming and voice-pack downloads happen at HOST image build time and land in /opt/lifeos/kokoro-env/hf-cache. The Quadlet didn't bind that dir, so HF_HUB_OFFLINE=1 sealed the container away from the host's pre-populated cache.

## Fix

1. **`containers/lifeos-tts/lifeos-tts.container`** — add `Volume=/opt/lifeos/kokoro-env/hf-cache:...:ro`. No `:z` because /opt is on the bootc RO layer (same rationale as the voices-manifest.json mount).

2. **`image/files/etc/sudoers.d/lifeos-axi`** — add a tightly scoped `LIFEOS_QUADLET_OPS` Cmnd_Alias so the assistant can apply per-service hot-fixes without prompting Hector for his password mid-session. Scope: sed -i restricted to /etc/containers/systemd/*.container only, systemctl restart/mask/unmask restricted to lifeos-*.service, plus systemctl reboot and daemon-reload. The Capa 2 LIFEOS_PROTECTED_SYSTEMD_DESTRUCTIVE denylist still blocks `systemctl stop lifeos-*` so the new lane cannot take services down hostilely.

## Validation evidence

After applying the bind-mount via the manual hot-fix on the laptop:

```
$ systemctl is-active lifeos-tts.service
active
$ curl -s http://127.0.0.1:8084/health
{"status": "ok", "model": "Kokoro-82M", "voices_loaded": 53}
$ journalctl -u lifeos-tts.service | tail
... Warm-up complete
... Server ready on 127.0.0.1:8084
```

Phase 1 TTS is officially live on Fedora 44 + Quadlet.

## Test plan

- [ ] CI green on this PR
- [ ] After merge + deploy + reboot: `/health` continues to return `voices_loaded: 53` without manual intervention.
- [ ] Sudoers entry parsed by visudo cleanly (CI verification block already runs `visudo -cf`).