### PR TITLE
fix(quadlet): drop EnvironmentFile=- prefix on lifeos-lifeosd Quadlet

### DIFF
--- a/containers/lifeos-lifeosd/lifeos-lifeosd.container
+++ b/containers/lifeos-lifeosd/lifeos-lifeosd.container
@@ -70,7 +70,15 @@ Volume=/etc/pki/ca-trust/extracted:/etc/pki/ca-trust/extracted:ro,z
 Environment=LIFEOS_DASHBOARD_DIR=/usr/share/lifeos/dashboard
 Environment=LIFEOS_RUNTIME_DIR=/run/lifeos
 Environment=RUST_LOG=info,lifeosd=debug
-EnvironmentFile=-/etc/lifeos/llm-providers.env
+# Quadlet does NOT honor the systemd `-` prefix as "optional" the way
+# regular .service units do — it interprets the dash as a leading path
+# segment relative to the Quadlet directory, so
+# `EnvironmentFile=-/etc/lifeos/llm-providers.env` blew up at runtime
+# trying to open `/usr/share/containers/systemd/-/etc/lifeos/...`. The
+# host bootc image always ships `/etc/lifeos/llm-providers.env` (mode
+# 0600 root, lifeos-secrets.conf enforces it) so the file is always
+# present — drop the dash.
+EnvironmentFile=/etc/lifeos/llm-providers.env
 
 # Memory DB encryption key derives from /etc/machine-id + /etc/hostname
 # (see daemon/src/memory_plane.rs::derive_machine_key). Without these


### PR DESCRIPTION
## Summary

One-line fix for a regression caught at first boot of edge-20260504-df2c733 (PR #84 cutover).

`lifeos-lifeosd.service` failed to start with:

\`\`\`
Error: parsing file "/usr/share/containers/systemd/-/etc/lifeos/llm-providers.env":
open /usr/share/containers/systemd/-/etc/lifeos/llm-providers.env:
no such file or directory
\`\`\`

Quadlet's [Container] section does NOT honor systemd's \`-\` "optional" prefix on \`EnvironmentFile=\` — it interprets the leading dash as a relative path segment. The host bootc image always ships \`/etc/lifeos/llm-providers.env\` (lifeos-secrets.conf enforces 0600 root), so the prefix was load-bearing on no host. Drop it.

The other Quadlets that still use \`EnvironmentFile=-\` (lifeos-llama-server, lifeos-llama-embeddings) have the directive in the [Service] section where systemd parses it directly, so they're fine.

## Hotfix already applied on production laptop

Operator hot-fixed via:
\`\`\`
sudo cp /usr/share/containers/systemd/lifeos-lifeosd.container /etc/containers/systemd/lifeos-lifeosd.container
sudo sed -i 's|EnvironmentFile=-/etc/lifeos/llm-providers.env|EnvironmentFile=/etc/lifeos/llm-providers.env|' /etc/containers/systemd/lifeos-lifeosd.container
sudo systemctl daemon-reload && sudo systemctl restart lifeos-lifeosd.service
\`\`\`

The /etc overlay survives bootc upgrade. This source fix lands so the next image deploy doesn't need the workaround.

## Test plan

- [x] Manual: hotfix on laptop confirmed daemon starts cleanly, dashboard returns HTTP 200, memory.db loads (6 sessions)
- [ ] CI: bootc image build + side-images pipeline
- [ ] Manual: next \`bootc upgrade\` no longer needs the /etc overlay

## Out of scope

- \`lifeos-llama-server.service\` failing with "compiled without GPU offload" — separate issue, GHCR \`:stable\` image doesn't have Vulkan despite the Containerfile's \`-DGGML_VULKAN=ON\`. Will investigate with a forced workflow_dispatch rebuild in a follow-up.