### PR TITLE
fix(daemon,cli): legacy unit names + STT model paths post-Quadlet pivot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "life"
-version = "0.8.39"
+version = "0.8.40"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2626,7 +2626,7 @@ dependencies = [
 
 [[package]]
 name = "lifeos-integration-tests"
-version = "0.8.39"
+version = "0.8.40"
 dependencies = [
  "life",
  "serde_json",
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "lifeosd"
-version = "0.8.39"
+version = "0.8.40"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.39"
+version = "0.8.40"
 
 [workspace.metadata.lifeos]
 codename = "Axolotl"

--- a/cli/src/commands/ai.rs
+++ b/cli/src/commands/ai.rs
@@ -8,6 +8,12 @@ use std::process::Command;
 
 use crate::daemon_client;
 
+/// Canonical chat-inference systemd unit (Quadlet-generated post-Phase-4).
+/// `life ai start` / `life ai stop` enable/stop this unit first; the legacy
+/// pre-pivot `llama-server.service` is the rollback fallback.
+const LLAMA_SERVICE_UNIT_QUADLET: &str = "lifeos-llama-server.service";
+const LLAMA_SERVICE_UNIT_LEGACY: &str = "llama-server.service";
+
 /// Default llama-server host
 const LLAMA_SERVER_HOST: &str = "http://localhost:8082";
 /// Default model directory
@@ -352,14 +358,14 @@ async fn start_ai(model: Option<String>, enable: bool) -> anyhow::Result<()> {
         print!("Enabling auto-start on boot... ");
         let canonical_ok = matches!(
             Command::new("sudo")
-                .args(["systemctl", "enable", "lifeos-llama-server.service"])
+                .args(["systemctl", "enable", LLAMA_SERVICE_UNIT_QUADLET])
                 .output(),
             Ok(out) if out.status.success()
         );
         let ok = canonical_ok
             || matches!(
                 Command::new("sudo")
-                    .args(["systemctl", "enable", "llama-server.service"])
+                    .args(["systemctl", "enable", LLAMA_SERVICE_UNIT_LEGACY])
                     .output(),
                 Ok(out) if out.status.success()
             );
@@ -400,12 +406,12 @@ async fn stop_ai() -> anyhow::Result<()> {
     // still respond to `life ai stop`.
     let stopped = matches!(
         Command::new("sudo")
-            .args(["systemctl", "stop", "lifeos-llama-server.service"])
+            .args(["systemctl", "stop", LLAMA_SERVICE_UNIT_QUADLET])
             .output(),
         Ok(out) if out.status.success()
     ) || matches!(
         Command::new("sudo")
-            .args(["systemctl", "stop", "llama-server.service"])
+            .args(["systemctl", "stop", LLAMA_SERVICE_UNIT_LEGACY])
             .output(),
         Ok(out) if out.status.success()
     );
@@ -2543,5 +2549,18 @@ mod tests {
         assert!(!is_selectable_model_asset("Qwen3.5-4B-mmproj-F16.gguf"));
         assert!(!is_selectable_model_asset("nomic-embed-text-v1.5.f16.gguf"));
         assert!(!is_selectable_model_asset("whisper-small.gguf"));
+    }
+
+    #[test]
+    fn llama_service_unit_constants_match_post_pivot_names() {
+        // Phase 4 of the architecture pivot: chat inference is the system
+        // Quadlet `lifeos-llama-server.service`; the legacy pre-pivot host
+        // unit is `llama-server.service`. Catches a regression where a
+        // future refactor renames either constant to a non-existent unit
+        // (silent `life ai start/stop` failure that reports success).
+        assert_eq!(super::LLAMA_SERVICE_UNIT_QUADLET, "lifeos-llama-server.service");
+        assert_eq!(super::LLAMA_SERVICE_UNIT_LEGACY, "llama-server.service");
+        assert!(super::LLAMA_SERVICE_UNIT_QUADLET.starts_with("lifeos-"));
+        assert_ne!(super::LLAMA_SERVICE_UNIT_QUADLET, super::LLAMA_SERVICE_UNIT_LEGACY);
     }
 }

--- a/cli/src/commands/ai.rs
+++ b/cli/src/commands/ai.rs
@@ -345,15 +345,28 @@ async fn start_ai(model: Option<String>, enable: bool) -> anyhow::Result<()> {
         }
     }
 
-    // Enable auto-start if requested
+    // Enable auto-start if requested.
+    // Phase 4: target the Quadlet unit (lifeos-llama-server.service); fall
+    // back to the legacy unit name for rolled-back hosts.
     if enable {
         print!("Enabling auto-start on boot... ");
-        match Command::new("sudo")
-            .args(["systemctl", "enable", "llama-server.service"])
-            .output()
-        {
-            Ok(output) if output.status.success() => println!("{}", "OK".green()),
-            _ => println!("{}", "FAILED".yellow()),
+        let canonical_ok = matches!(
+            Command::new("sudo")
+                .args(["systemctl", "enable", "lifeos-llama-server.service"])
+                .output(),
+            Ok(out) if out.status.success()
+        );
+        let ok = canonical_ok
+            || matches!(
+                Command::new("sudo")
+                    .args(["systemctl", "enable", "llama-server.service"])
+                    .output(),
+                Ok(out) if out.status.success()
+            );
+        if ok {
+            println!("{}", "OK".green());
+        } else {
+            println!("{}", "FAILED".yellow());
         }
     }
 
@@ -382,14 +395,25 @@ async fn start_ai(model: Option<String>, enable: bool) -> anyhow::Result<()> {
 async fn stop_ai() -> anyhow::Result<()> {
     println!("{}", "Stopping AI services...".bold().blue());
 
-    match Command::new("sudo")
-        .args(["systemctl", "stop", "llama-server.service"])
-        .output()
-    {
-        Ok(output) if output.status.success() => {
+    // Phase 4: stop the Quadlet unit; if it doesn't exist (rolled-back
+    // host) fall through to the legacy unit name so older deployments
+    // still respond to `life ai stop`.
+    let stopped = matches!(
+        Command::new("sudo")
+            .args(["systemctl", "stop", "lifeos-llama-server.service"])
+            .output(),
+        Ok(out) if out.status.success()
+    ) || matches!(
+        Command::new("sudo")
+            .args(["systemctl", "stop", "llama-server.service"])
+            .output(),
+        Ok(out) if out.status.success()
+    );
+    match stopped {
+        true => {
             println!("{}", "llama-server service stopped".green());
         }
-        _ => {
+        false => {
             println!("{}", "Service may not be running".yellow());
         }
     }

--- a/cli/src/commands/ai.rs
+++ b/cli/src/commands/ai.rs
@@ -2558,9 +2558,15 @@ mod tests {
         // unit is `llama-server.service`. Catches a regression where a
         // future refactor renames either constant to a non-existent unit
         // (silent `life ai start/stop` failure that reports success).
-        assert_eq!(super::LLAMA_SERVICE_UNIT_QUADLET, "lifeos-llama-server.service");
+        assert_eq!(
+            super::LLAMA_SERVICE_UNIT_QUADLET,
+            "lifeos-llama-server.service"
+        );
         assert_eq!(super::LLAMA_SERVICE_UNIT_LEGACY, "llama-server.service");
         assert!(super::LLAMA_SERVICE_UNIT_QUADLET.starts_with("lifeos-"));
-        assert_ne!(super::LLAMA_SERVICE_UNIT_QUADLET, super::LLAMA_SERVICE_UNIT_LEGACY);
+        assert_ne!(
+            super::LLAMA_SERVICE_UNIT_QUADLET,
+            super::LLAMA_SERVICE_UNIT_LEGACY
+        );
     }
 }

--- a/cli/src/commands/doctor.rs
+++ b/cli/src/commands/doctor.rs
@@ -84,7 +84,10 @@ pub async fn execute(args: DoctorArgs) -> anyhow::Result<()> {
                 println!("    Error: {}", format!("{e}").dimmed());
                 println!();
                 println!("  {} Is the daemon running?", "Hint:".dimmed());
-                println!("    {}", "sudo systemctl status lifeos-lifeosd.service".cyan());
+                println!(
+                    "    {}",
+                    "sudo systemctl status lifeos-lifeosd.service".cyan()
+                );
             }
         }
     }

--- a/cli/src/commands/doctor.rs
+++ b/cli/src/commands/doctor.rs
@@ -84,7 +84,7 @@ pub async fn execute(args: DoctorArgs) -> anyhow::Result<()> {
                 println!("    Error: {}", format!("{e}").dimmed());
                 println!();
                 println!("  {} Is the daemon running?", "Hint:".dimmed());
-                println!("    {}", "systemctl --user status lifeosd".cyan());
+                println!("    {}", "sudo systemctl status lifeos-lifeosd.service".cyan());
             }
         }
     }
@@ -136,12 +136,16 @@ impl StepResult {
     }
 }
 
-/// Run a systemctl --user command, returning Ok(true) on success.
-async fn systemctl_user(args: &[&str]) -> anyhow::Result<bool> {
-    let mut cmd = vec!["--user"];
-    cmd.extend_from_slice(args);
+/// Run a systemctl command in the system scope, returning Ok(true) on success.
+///
+/// Phase 3 of the architecture pivot moved lifeosd from a user-scope service
+/// (`systemctl --user lifeosd`) to a system Quadlet (`lifeos-lifeosd.service`).
+/// Repair operations now run against the system scope and require root;
+/// `life doctor --repair` is invoked via sudo or via the polkit rule that
+/// allowlists `lifeos-lifeosd.service` for wheel users.
+async fn systemctl_system(args: &[&str]) -> anyhow::Result<bool> {
     let output = tokio::process::Command::new("systemctl")
-        .args(&cmd)
+        .args(args)
         .output()
         .await?;
     Ok(output.status.success())
@@ -176,7 +180,7 @@ async fn run_repair(base: &str, json_mode: bool) -> anyhow::Result<()> {
     }
 
     // --- Step 1: Reset failed services ---
-    let step1 = match systemctl_user(&["reset-failed", "lifeosd"]).await {
+    let step1 = match systemctl_system(&["reset-failed", "lifeos-lifeosd.service"]).await {
         Ok(true) => StepResult::ok("Resetting failed services"),
         Ok(false) => StepResult::fail("Resetting failed services", "reset-failed exited non-zero"),
         Err(e) => StepResult::fail("Resetting failed services", &format!("{e}")),
@@ -187,7 +191,7 @@ async fn run_repair(base: &str, json_mode: bool) -> anyhow::Result<()> {
     results.push(step1);
 
     // --- Step 2: Restart the daemon ---
-    let step2 = match systemctl_user(&["restart", "lifeosd"]).await {
+    let step2 = match systemctl_system(&["restart", "lifeos-lifeosd.service"]).await {
         Ok(true) => StepResult::ok("Restarting lifeosd"),
         Ok(false) => StepResult::fail("Restarting lifeosd", "restart exited non-zero"),
         Err(e) => StepResult::fail("Restarting lifeosd", &format!("{e}")),
@@ -335,7 +339,7 @@ async fn run_repair(base: &str, json_mode: bool) -> anyhow::Result<()> {
                 println!(
                     "    {} Check daemon logs: {}",
                     "Hint:".dimmed(),
-                    "journalctl --user -u lifeosd -n 50".cyan()
+                    "sudo journalctl -u lifeos-lifeosd.service -n 50".cyan()
                 );
             }
         } else {

--- a/cli/src/system/mod.rs
+++ b/cli/src/system/mod.rs
@@ -713,11 +713,10 @@ pub async fn perform_recovery() -> anyhow::Result<RecoveryReport> {
     }
 
     if !daemon_running {
-        let restarted_lifeosd =
-            restart_unit(&["systemctl", "restart", "lifeos-lifeosd.service"])
-                || restart_unit(&["systemctl", "--user", "restart", "lifeosd.service"])
-                || restart_unit(&["systemctl", "--user", "start", "lifeosd.service"])
-                || restart_unit(&["systemctl", "restart", "lifeosd.service"]);
+        let restarted_lifeosd = restart_unit(&["systemctl", "restart", "lifeos-lifeosd.service"])
+            || restart_unit(&["systemctl", "--user", "restart", "lifeosd.service"])
+            || restart_unit(&["systemctl", "--user", "start", "lifeosd.service"])
+            || restart_unit(&["systemctl", "restart", "lifeosd.service"]);
 
         if restarted_lifeosd {
             report.repairs.push("Restarted lifeosd".to_string());

--- a/cli/src/system/mod.rs
+++ b/cli/src/system/mod.rs
@@ -528,7 +528,22 @@ fn check_ai_service_issue() -> Option<String> {
 }
 
 fn assess_llama_service() -> AiServiceAssessment {
-    assess_ai_service(
+    // Phase 4 of the architecture pivot: chat inference is the system
+    // Quadlet `lifeos-llama-server.service`. We probe the new name first,
+    // then fall back to the legacy `llama-server.service` so a host that
+    // rolled back keeps reporting accurate status.
+    let system_state = systemd_unit_state(
+        &[
+            "systemctl",
+            "show",
+            "lifeos-llama-server.service",
+            "--property=LoadState,ActiveState,SubState,Result",
+        ],
+        "system",
+    );
+    let system_state = if system_state.is_some() {
+        system_state
+    } else {
         systemd_unit_state(
             &[
                 "systemctl",
@@ -537,13 +552,16 @@ fn assess_llama_service() -> AiServiceAssessment {
                 "--property=LoadState,ActiveState,SubState,Result",
             ],
             "system",
-        ),
+        )
+    };
+    assess_ai_service(
+        system_state,
         systemd_unit_state(
             &[
                 "systemctl",
                 "--user",
                 "show",
-                "llama-server.service",
+                "lifeos-llama-server.service",
                 "--property=LoadState,ActiveState,SubState,Result",
             ],
             "user",
@@ -677,12 +695,18 @@ pub async fn perform_recovery() -> anyhow::Result<RecoveryReport> {
     });
 
     // --- Repair actions for failed services ---
+    // Phase 3/4 of the architecture pivot: lifeosd and llama-server are
+    // now system Quadlets (lifeos-lifeosd.service, lifeos-llama-server.service).
+    // Try the canonical names first, then the legacy host units for hosts
+    // that rolled back to a pre-Quadlet image.
     if ai_assessment.restart_recommended {
-        if restart_unit(&["systemctl", "restart", "llama-server.service"]) {
+        let restarted = restart_unit(&["systemctl", "restart", "lifeos-llama-server.service"])
+            || restart_unit(&["systemctl", "restart", "llama-server.service"]);
+        if restarted {
             report.repairs.push("Restarted ai-service".to_string());
         } else {
             report.repairs.push(
-                "Failed to restart ai-service (try: sudo systemctl restart llama-server.service)"
+                "Failed to restart ai-service (try: sudo systemctl restart lifeos-llama-server.service)"
                     .to_string(),
             );
         }
@@ -690,7 +714,8 @@ pub async fn perform_recovery() -> anyhow::Result<RecoveryReport> {
 
     if !daemon_running {
         let restarted_lifeosd =
-            restart_unit(&["systemctl", "--user", "restart", "lifeosd.service"])
+            restart_unit(&["systemctl", "restart", "lifeos-lifeosd.service"])
+                || restart_unit(&["systemctl", "--user", "restart", "lifeosd.service"])
                 || restart_unit(&["systemctl", "--user", "start", "lifeosd.service"])
                 || restart_unit(&["systemctl", "restart", "lifeosd.service"]);
 
@@ -698,7 +723,7 @@ pub async fn perform_recovery() -> anyhow::Result<RecoveryReport> {
             report.repairs.push("Restarted lifeosd".to_string());
         } else {
             report.repairs.push(
-                "Failed to restart lifeosd (try: systemctl --user restart lifeosd.service)"
+                "Failed to restart lifeosd (try: sudo systemctl restart lifeos-lifeosd.service)"
                     .to_string(),
             );
         }

--- a/daemon/src/agent_runtime.rs
+++ b/daemon/src/agent_runtime.rs
@@ -1561,7 +1561,12 @@ impl AgentRuntimeManager {
     }
 
     pub async fn self_defense_status(&self) -> SelfDefenseStatus {
-        let ai_service_running = is_service_active("llama-server.service").await;
+        // Phase 4 cutover: chat inference now runs as the
+        // `lifeos-llama-server.service` Quadlet. Probe both names so
+        // self-defense correctly observes the AI on any rolled-back host
+        // that still uses the legacy unit.
+        let ai_service_running = is_service_active("lifeos-llama-server.service").await
+            || is_service_active("llama-server.service").await;
         let network_online = has_default_network_route().await;
         let rollback_available = has_bootc_rollback_capability().await;
         let disk_usage_percent = read_disk_usage_percent("/var").await.unwrap_or(0.0);
@@ -1578,7 +1583,7 @@ impl AgentRuntimeManager {
         let degraded_offline = !network_online || !ai_service_running;
         let mut recommended_actions = Vec::new();
         if !ai_service_running {
-            recommended_actions.push("restart llama-server service".to_string());
+            recommended_actions.push("restart lifeos-llama-server service".to_string());
         }
         if !network_online {
             recommended_actions.push("switch to offline degraded operation mode".to_string());
@@ -1612,20 +1617,31 @@ impl AgentRuntimeManager {
         let mut actions_taken = Vec::new();
 
         if !status_before.ai_service_running {
-            let output = Command::new("systemctl")
-                .args(["restart", "llama-server.service"])
+            // Phase 4: target the Quadlet unit. Fall through to the legacy
+            // name only if the new unit doesn't exist on this host (rollback).
+            let canonical = "lifeos-llama-server.service";
+            let mut output = Command::new("systemctl")
+                .args(["restart", canonical])
                 .output()
                 .await;
+            let mut unit_used: &str = canonical;
+            if matches!(&output, Ok(out) if !out.status.success()) {
+                let legacy = "llama-server.service";
+                output = Command::new("systemctl")
+                    .args(["restart", legacy])
+                    .output()
+                    .await;
+                if matches!(&output, Ok(out) if out.status.success()) {
+                    unit_used = legacy;
+                }
+            }
             match output {
                 Ok(out) if out.status.success() => {
-                    actions_taken.push("restarted llama-server.service".to_string());
+                    actions_taken.push(format!("restarted {unit_used}"));
                 }
                 Ok(out) => {
                     let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
-                    actions_taken.push(format!(
-                        "failed to restart llama-server.service: {}",
-                        stderr
-                    ));
+                    actions_taken.push(format!("failed to restart {canonical}: {stderr}"));
                 }
                 Err(e) => {
                     actions_taken.push(format!("failed to execute restart command: {}", e));

--- a/daemon/src/ai_runtime_profile.rs
+++ b/daemon/src/ai_runtime_profile.rs
@@ -46,7 +46,13 @@ const CTX_SIZE_PROBE_LADDER: &[u32] = &[131_072, 65_536, 32_768, 16_384, 8_192];
 const DEFAULT_GPU_LAYERS: i32 = 99;
 const DEFAULT_GAME_GUARD_VRAM_THRESHOLD_MB: u64 = 500;
 const RUNTIME_ENV_DROPIN_NAME: &str = "99-lifeos-runtime-envs.conf";
-const USER_LLAMA_UNIT_NAME: &str = "llama-server.service";
+/// Canonical systemd unit name for chat inference. Phase 4 of the
+/// architecture pivot moved llama-server from the legacy host service
+/// `llama-server.service` to the `lifeos-llama-server.service` Quadlet.
+/// The constant name is kept for legacy reasons (it predates the rename
+/// and refers to the unit name regardless of scope, not the user-scope
+/// path which is a deprecated fallback handled separately below).
+const USER_LLAMA_UNIT_NAME: &str = "lifeos-llama-server.service";
 const LLAMA_PREFLIGHT_REASON_PATH: &str = "/var/lib/lifeos/llama-server-preflight.reason";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1004,7 +1010,7 @@ fn install_llama_runtime_dropin() -> Result<()> {
         .stdout(Stdio::null())
         .stderr(Stdio::piped())
         .spawn()
-        .context("failed to spawn systemctl edit for llama-server.service")?;
+        .with_context(|| format!("failed to spawn systemctl edit for {USER_LLAMA_UNIT_NAME}"))?;
 
     let mut stdin = child
         .stdin
@@ -1066,7 +1072,7 @@ fn llama_user_unit_path() -> Result<PathBuf> {
         return Ok(PathBuf::from(path));
     }
     let home = std::env::var_os("HOME").context("HOME is not set for user llama-server unit")?;
-    Ok(PathBuf::from(home).join(".config/systemd/user/llama-server.service"))
+    Ok(PathBuf::from(home).join(".config/systemd/user/lifeos-llama-server.service"))
 }
 
 fn ensure_user_llama_service() -> Result<()> {
@@ -1121,13 +1127,13 @@ fn llama_service_environment_files() -> Result<Vec<PathBuf>> {
     let output = Command::new("systemctl")
         .args([
             "show",
-            "llama-server.service",
+            USER_LLAMA_UNIT_NAME,
             "-p",
             "EnvironmentFiles",
             "--value",
         ])
         .output()
-        .context("failed to inspect llama-server.service environment files")?;
+        .with_context(|| format!("failed to inspect {USER_LLAMA_UNIT_NAME} environment files"))?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
         anyhow::bail!("systemctl show failed: {stderr}");

--- a/daemon/src/api/mod.rs
+++ b/daemon/src/api/mod.rs
@@ -2985,13 +2985,10 @@ fn resolve_existing_stt_model_path(candidate: &str) -> Option<String> {
     // Phase 6b/7 of the architecture pivot: STT models live exclusively
     // under /var/lib/lifeos/models/whisper now. The /usr/share/lifeos/models
     // paths were the pre-Phase-6b host location and are gone.
-    [
-        "/var/lib/lifeos/models/whisper",
-        "/var/lib/lifeos/models",
-    ]
-    .iter()
-    .map(|dir| format!("{dir}/{file_name}"))
-    .find(|path| std::path::Path::new(path).exists())
+    ["/var/lib/lifeos/models/whisper", "/var/lib/lifeos/models"]
+        .iter()
+        .map(|dir| format!("{dir}/{file_name}"))
+        .find(|path| std::path::Path::new(path).exists())
 }
 
 fn resolve_stt_model_path(model: Option<&str>) -> Option<String> {

--- a/daemon/src/api/mod.rs
+++ b/daemon/src/api/mod.rs
@@ -2569,23 +2569,36 @@ async fn detect_llama_service_status() -> LlamaServiceStatusSnapshot {
 }
 
 async fn systemctl_main_pid(user_scope: bool) -> Option<u32> {
-    let mut command = Command::new("systemctl");
-    if user_scope {
-        command.arg("--user");
+    // Phase 4: probe the Quadlet unit name first, fall through to the
+    // legacy name for rolled-back hosts.
+    for unit in ["lifeos-llama-server.service", "llama-server.service"] {
+        let mut command = Command::new("systemctl");
+        if user_scope {
+            command.arg("--user");
+        }
+        let Ok(output) = command
+            .args(["show", unit, "-p", "MainPID", "--value"])
+            .output()
+            .await
+        else {
+            continue;
+        };
+        if !output.status.success() {
+            continue;
+        }
+        if let Some(pid) = parse_systemctl_main_pid(&output.stdout) {
+            return Some(pid);
+        }
     }
-    let output = command
-        .args(["show", "llama-server.service", "-p", "MainPID", "--value"])
-        .output()
-        .await
-        .ok()?;
-    if !output.status.success() {
+    None
+}
+
+fn parse_systemctl_main_pid(stdout: &[u8]) -> Option<u32> {
+    let trimmed = std::str::from_utf8(stdout).ok()?.trim();
+    if trimmed.is_empty() || trimmed == "0" {
         return None;
     }
-    String::from_utf8_lossy(&output.stdout)
-        .trim()
-        .parse::<u32>()
-        .ok()
-        .filter(|pid| *pid > 0)
+    trimmed.parse::<u32>().ok().filter(|pid| *pid > 0)
 }
 
 async fn detect_llama_pid_via_pgrep() -> Option<u32> {
@@ -2969,11 +2982,12 @@ fn resolve_existing_stt_model_path(candidate: &str) -> Option<String> {
     let file_name = std::path::Path::new(candidate)
         .file_name()
         .and_then(|name| name.to_str())?;
+    // Phase 6b/7 of the architecture pivot: STT models live exclusively
+    // under /var/lib/lifeos/models/whisper now. The /usr/share/lifeos/models
+    // paths were the pre-Phase-6b host location and are gone.
     [
         "/var/lib/lifeos/models/whisper",
-        "/usr/share/lifeos/models/whisper",
         "/var/lib/lifeos/models",
-        "/usr/share/lifeos/models",
     ]
     .iter()
     .map(|dir| format!("{dir}/{file_name}"))
@@ -2991,13 +3005,11 @@ fn resolve_stt_model_path(model: Option<&str>) -> Option<String> {
         }
     }
 
+    // Phase 6b/7 of the architecture pivot: see resolve_existing_stt_model_path.
     [
         "/var/lib/lifeos/models/whisper/ggml-base.bin",
-        "/usr/share/lifeos/models/whisper/ggml-base.bin",
         "/var/lib/lifeos/models/whisper/ggml-base.en.bin",
-        "/usr/share/lifeos/models/whisper/ggml-base.en.bin",
         "/var/lib/lifeos/models/whisper/ggml-small.bin",
-        "/usr/share/lifeos/models/whisper/ggml-small.bin",
     ]
     .iter()
     .find(|candidate| std::path::Path::new(candidate).exists())

--- a/daemon/src/game_guard.rs
+++ b/daemon/src/game_guard.rs
@@ -1251,11 +1251,17 @@ mod tests {
 
     #[test]
     fn test_parse_nvidia_pmon_output() {
+        // Use PIDs far beyond `kernel.pid_max` (default 4194304 on Linux)
+        // so `parse_nvidia_pmon_output`'s call to `get_game_name_from_pid`
+        // returns None for our synthetic data and falls through to the
+        // pmon `command` column. Otherwise the CI runner's real /proc
+        // entries occasionally collide (we saw PID 5678 resolve to
+        // `lifeosd-db97203` and break this test).
         let sample = "\
 # gpu        pid  type    fb   command
-    0       1234     C   2816   llama-server
-    0       5678     G  10240   RERequiem
-    0       9999     G    128   gnome-shell
+    0   90001234     C   2816   llama-server
+    0   90005678     G  10240   RERequiem
+    0   90009999     G    128   gnome-shell
 ";
         let results = parse_nvidia_pmon_output(sample, 500, false);
         // llama-server excluded, gnome-shell excluded (below threshold), RERequiem included

--- a/daemon/src/health.rs
+++ b/daemon/src/health.rs
@@ -340,13 +340,18 @@ async fn check_disk_space() -> anyhow::Result<(bool, String)> {
 }
 
 async fn check_ai_service() -> anyhow::Result<(bool, String)> {
-    // Prefer systemd status when available.
-    if let Ok(output) = Command::new("systemctl")
-        .args(["is-active", "--quiet", "llama-server.service"])
-        .output()
-    {
-        if output.status.success() {
-            return Ok((true, "llama-server service is active".to_string()));
+    // Phase 4 of the architecture pivot moved chat inference to the
+    // `lifeos-llama-server.service` system Quadlet. Probe the new unit
+    // first; fall back to the legacy `llama-server.service` name only
+    // for hosts that haven't picked up the cutover yet (rollback).
+    for unit in ["lifeos-llama-server.service", "llama-server.service"] {
+        if let Ok(output) = Command::new("systemctl")
+            .args(["is-active", "--quiet", unit])
+            .output()
+        {
+            if output.status.success() {
+                return Ok((true, format!("{unit} is active")));
+            }
         }
     }
 

--- a/daemon/src/meeting_assistant.rs
+++ b/daemon/src/meeting_assistant.rs
@@ -2850,13 +2850,11 @@ async fn resolve_whisper_model() -> Result<String> {
     // (~142MB) on Spanish / accented speech at the cost of ~3× CPU
     // time, which is still well under the meeting duration itself.
     // Caption model (live) stays on `tiny` via `resolve_caption_model`.
+    // Phase 6b/7: STT models live exclusively under /var/lib/lifeos/models/whisper.
     let candidates = [
         "/var/lib/lifeos/models/whisper/ggml-medium.bin",
-        "/usr/share/lifeos/models/whisper/ggml-medium.bin",
         "/var/lib/lifeos/models/whisper/ggml-small.bin",
-        "/usr/share/lifeos/models/whisper/ggml-small.bin",
         "/var/lib/lifeos/models/whisper/ggml-base.bin",
-        "/usr/share/lifeos/models/whisper/ggml-base.bin",
     ];
     for path in &candidates {
         if tokio::fs::metadata(path).await.is_ok() {
@@ -2869,11 +2867,10 @@ async fn resolve_whisper_model() -> Result<String> {
 /// Resolve the whisper model for real-time captions (BB.8).
 /// Prefers the tiny model for minimal latency, falls back to base.
 async fn resolve_caption_model() -> Result<String> {
+    // Phase 6b/7: STT models live exclusively under /var/lib/lifeos/models/whisper.
     let candidates = [
         "/var/lib/lifeos/models/whisper/ggml-tiny.bin",
-        "/usr/share/lifeos/models/whisper/ggml-tiny.bin",
         "/var/lib/lifeos/models/whisper/ggml-base.bin",
-        "/usr/share/lifeos/models/whisper/ggml-base.bin",
     ];
     for path in &candidates {
         if tokio::fs::metadata(path).await.is_ok() {

--- a/daemon/src/sensory_pipeline.rs
+++ b/daemon/src/sensory_pipeline.rs
@@ -5958,13 +5958,10 @@ fn resolve_existing_stt_model(candidate: &str) -> Option<String> {
         .file_name()
         .and_then(|name| name.to_str())?;
     // Phase 6b/7: STT models live exclusively under /var/lib/lifeos/models.
-    [
-        "/var/lib/lifeos/models/whisper",
-        "/var/lib/lifeos/models",
-    ]
-    .iter()
-    .map(|dir| format!("{dir}/{file_name}"))
-    .find(|path| Path::new(path).exists())
+    ["/var/lib/lifeos/models/whisper", "/var/lib/lifeos/models"]
+        .iter()
+        .map(|dir| format!("{dir}/{file_name}"))
+        .find(|path| Path::new(path).exists())
 }
 
 fn espeak_voice_for_language(language: Option<&str>) -> &'static str {

--- a/daemon/src/sensory_pipeline.rs
+++ b/daemon/src/sensory_pipeline.rs
@@ -4001,11 +4001,15 @@ async fn maybe_apply_gpu_rebalance(
         }
 
         if llama_server_running {
-            Command::new("systemctl")
-                .args(["try-restart", "llama-server.service"])
-                .status()
-                .await
-                .ok();
+            // Phase 4: try-restart the Quadlet first; fall through to the
+            // legacy unit name for rolled-back hosts. try-restart is a no-op
+            // on units that don't exist, so trying both is safe.
+            for unit in ["lifeos-llama-server.service", "llama-server.service"] {
+                let _ = Command::new("systemctl")
+                    .args(["try-restart", unit])
+                    .status()
+                    .await;
+            }
         }
     }
 
@@ -4316,15 +4320,17 @@ async fn resolve_streaming_stt_model(override_model: Option<&str>) -> Option<Str
         }
     }
 
+    // Phase 6b/7 of the architecture pivot: STT models live exclusively
+    // under /var/lib/lifeos/models/whisper now (downloaded by lifeos-stt-
+    // setup.sh on host, bind-mounted into the daemon container). The
+    // /usr/share/lifeos/models/whisper paths were the pre-Phase-6b host
+    // location and are gone — keeping them in the candidate list only
+    // produced misleading filesystem probes in strace/auditd output.
     [
         "/var/lib/lifeos/models/whisper/ggml-tiny.bin",
-        "/usr/share/lifeos/models/whisper/ggml-tiny.bin",
         "/var/lib/lifeos/models/whisper/ggml-base.bin",
-        "/usr/share/lifeos/models/whisper/ggml-base.bin",
         "/var/lib/lifeos/models/whisper/ggml-base.en.bin",
-        "/usr/share/lifeos/models/whisper/ggml-base.en.bin",
         "/var/lib/lifeos/models/whisper/ggml-small.bin",
-        "/usr/share/lifeos/models/whisper/ggml-small.bin",
     ]
     .iter()
     .find(|candidate| Path::new(candidate).exists())
@@ -5883,42 +5889,35 @@ async fn resolve_stt_model(override_model: Option<&str>) -> Option<String> {
     // Auto-select whisper model based on available RAM
     let available_ram_gb = read_available_ram_gb();
 
-    // Tier the candidate list: prefer larger models when RAM allows
+    // Tier the candidate list: prefer larger models when RAM allows.
+    // Phase 6b/7 of the architecture pivot: STT models live exclusively
+    // under /var/lib/lifeos/models/whisper now (downloaded by lifeos-stt-
+    // setup.sh on host, bind-mounted into the daemon container). The
+    // /usr/share/lifeos/models/whisper paths were the pre-Phase-6b host
+    // location and have been removed.
     let candidates: &[&str] = if available_ram_gb > 8.0 {
         // >8 GB available — prefer medium for better accuracy on quiet speech
         &[
             "/var/lib/lifeos/models/whisper/ggml-medium.bin",
-            "/usr/share/lifeos/models/whisper/ggml-medium.bin",
             "/var/lib/lifeos/models/whisper/ggml-base.bin",
-            "/usr/share/lifeos/models/whisper/ggml-base.bin",
             "/var/lib/lifeos/models/whisper/ggml-base.en.bin",
-            "/usr/share/lifeos/models/whisper/ggml-base.en.bin",
             "/var/lib/lifeos/models/whisper/ggml-small.bin",
-            "/usr/share/lifeos/models/whisper/ggml-small.bin",
             "/var/lib/lifeos/models/whisper/ggml-tiny.bin",
-            "/usr/share/lifeos/models/whisper/ggml-tiny.bin",
         ]
     } else if available_ram_gb > 4.0 {
         // >4 GB — prefer base
         &[
             "/var/lib/lifeos/models/whisper/ggml-base.bin",
-            "/usr/share/lifeos/models/whisper/ggml-base.bin",
             "/var/lib/lifeos/models/whisper/ggml-base.en.bin",
-            "/usr/share/lifeos/models/whisper/ggml-base.en.bin",
             "/var/lib/lifeos/models/whisper/ggml-small.bin",
-            "/usr/share/lifeos/models/whisper/ggml-small.bin",
             "/var/lib/lifeos/models/whisper/ggml-tiny.bin",
-            "/usr/share/lifeos/models/whisper/ggml-tiny.bin",
         ]
     } else {
         // <4 GB — prefer tiny/small to conserve memory
         &[
             "/var/lib/lifeos/models/whisper/ggml-tiny.bin",
-            "/usr/share/lifeos/models/whisper/ggml-tiny.bin",
             "/var/lib/lifeos/models/whisper/ggml-small.bin",
-            "/usr/share/lifeos/models/whisper/ggml-small.bin",
             "/var/lib/lifeos/models/whisper/ggml-base.bin",
-            "/usr/share/lifeos/models/whisper/ggml-base.bin",
         ]
     };
 
@@ -5958,11 +5957,10 @@ fn resolve_existing_stt_model(candidate: &str) -> Option<String> {
     let file_name = Path::new(candidate)
         .file_name()
         .and_then(|name| name.to_str())?;
+    // Phase 6b/7: STT models live exclusively under /var/lib/lifeos/models.
     [
         "/var/lib/lifeos/models/whisper",
-        "/usr/share/lifeos/models/whisper",
         "/var/lib/lifeos/models",
-        "/usr/share/lifeos/models",
     ]
     .iter()
     .map(|dir| format!("{dir}/{file_name}"))
@@ -6008,22 +6006,29 @@ async fn detect_llama_runtime_backend() -> Option<String> {
 }
 
 async fn detect_llama_runtime_gpu_failure() -> Option<String> {
-    let output = Command::new("journalctl")
-        .args(["-u", "llama-server.service", "-b", "-n", "80", "--no-pager"])
-        .output()
-        .await
-        .ok()?;
-
-    if !output.status.success() {
+    // Phase 4: probe both the Quadlet unit name and the legacy host unit
+    // name so a recent GPU failure in either is matched (rollback-safe).
+    let mut combined = String::new();
+    for unit in ["lifeos-llama-server.service", "llama-server.service"] {
+        let Ok(output) = Command::new("journalctl")
+            .args(["-u", unit, "-b", "-n", "80", "--no-pager"])
+            .output()
+            .await
+        else {
+            continue;
+        };
+        if !output.status.success() {
+            continue;
+        }
+        combined.push_str(&String::from_utf8_lossy(&output.stdout));
+        combined.push('\n');
+        combined.push_str(&String::from_utf8_lossy(&output.stderr));
+        combined.push('\n');
+    }
+    if combined.trim().is_empty() {
         return None;
     }
-
-    let journal = format!(
-        "{}\n{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    )
-    .to_lowercase();
+    let journal = combined.to_lowercase();
 
     if journal.contains("no usable gpu found")
         || journal.contains("ggml_vulkan: no devices found")


### PR DESCRIPTION
## Summary

Wider drift cleanup that surfaced during JD round-2 on PR #84. The daemon and CLI Rust source still referenced legacy systemd unit names that the architecture pivot removed weeks ago (or never created with the new \`lifeos-\` prefix). Some of these were silently broken in production:

- \`/api/v1/health\` reported \"AI inactive\" on every Phase-4-deployed host.
- \`life doctor --repair\` was a no-op (called \`systemctl --user lifeosd\` against a unit removed by Phase 3).
- Self-defense repair path in \`agent_runtime.rs\` was dead.
- STT model resolution wasted strace/auditd noise probing \`/usr/share/lifeos/models/whisper/\` paths that don't exist post-Phase-6b.

## Strategy

For every probe of \`llama-server.service\` / \`lifeosd.service\`, try the canonical Quadlet name first (\`lifeos-llama-server.service\`, \`lifeos-lifeosd.service\`) and fall back to the legacy name for rolled-back hosts. Hosts on edge-20260504-df2c733 or later get the new behavior; rolled-back hosts continue to work.

For STT model paths, drop the \`/usr/share/lifeos/models/whisper/\` candidates entirely — Phase 6b removed them.

## Files touched

- \`daemon/src/health.rs\` — check_ai_service probes Quadlet first.
- \`daemon/src/agent_runtime.rs\` — self_defense_status + repair both Quadlet-first.
- \`daemon/src/ai_runtime_profile.rs\` — USER_LLAMA_UNIT_NAME constant value updated.
- \`daemon/src/api/mod.rs\` — systemctl_main_pid Quadlet-first; STT model paths trimmed.
- \`daemon/src/sensory_pipeline.rs\` — try-restart + journalctl probe Quadlet-first; STT paths trimmed.
- \`daemon/src/meeting_assistant.rs\` — STT model paths trimmed.
- \`cli/src/commands/doctor.rs\` — switched from --user lifeosd to system-scope lifeos-lifeosd.service.
- \`cli/src/system/mod.rs\` — assess + restart Quadlet-first.
- \`cli/src/commands/ai.rs\` — life ai start/stop Quadlet-first.

## Out of scope

- \`cli/src/commands/permissions.rs\` and a few user-facing tracking display strings still mention legacy \`lifeosd\`. Display only, no runtime impact — separate docs-sweep PR.
- Removing the dead \`LlamaServiceScope::User\` fallback path in \`ai_runtime_profile.rs\`. Surgical fix here only renames the constant.

## Test plan

- [ ] CI: cargo build / cargo clippy / cargo test all green
- [ ] CI: bootc build + side-images green
- [ ] Manual on laptop after deploy: \`curl http://127.0.0.1:8081/api/v1/health\` reports AI active (was reporting inactive).
- [ ] Manual: \`life doctor --repair\` actually restarts the daemon if it's down.
- [ ] Manual: \`life ai stop && life ai start\` cycles llama-server cleanly.

## Refs

- PR #84 (Phase 3/7/8 cutover — JD round-2 report identified this drift)
- \`docs/strategy/prd-architecture-pivot-lean-bootc-quadlet.md\` (Phases 3, 4, 6b, 7)