### PR TITLE
Fix: daemon GPU detection via nvidia-smi + CPU fallback profile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "life"
-version = "0.8.50"
+version = "0.8.41"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2626,7 +2626,7 @@ dependencies = [
 
 [[package]]
 name = "lifeos-integration-tests"
-version = "0.8.50"
+version = "0.8.41"
 dependencies = [
  "life",
  "serde_json",
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "lifeosd"
-version = "0.8.50"
+version = "0.8.41"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.50"
+version = "0.8.41"
 
 [workspace.metadata.lifeos]
 codename = "Axolotl"

--- a/containers/lifeos-lifeosd/lifeos-lifeosd.container
+++ b/containers/lifeos-lifeosd/lifeos-lifeosd.container
@@ -176,6 +176,16 @@ SecurityLabelType=container_t
 # Quadlet requires ExecStartPre in [Service], not [Container].
 ExecStartPre=/usr/local/bin/lifeos-ensure-images
 
+# CDI spec poll — same guard the lifeos-llama-server Quadlet uses. The
+# AddDevice=nvidia.com/gpu=all directive above only succeeds when CDI
+# has published nvidia.yaml; on cold boot nvidia-cdi-refresh.service
+# may not have run yet (we can't After= it without producing the
+# ordering cycle that bit lifeos-llama-server in production). Up to
+# 60 s, fall through if absent — Restart=always covers a hard miss
+# and on hosts without NVIDIA the loop simply times out and the daemon
+# proceeds with no GPU detected (CPU profile path).
+ExecStartPre=-/bin/bash -c 'i=0; while [ $i -lt 60 ]; do for f in /run/cdi/nvidia.yaml /var/run/cdi/nvidia.yaml /etc/cdi/nvidia.yaml; do [ -s "$f" ] && exit 0; done; sleep 1; i=$((i+1)); done; exit 0'
+
 # Capa 3 of defense-in-depth — auto-restart with watchdog.
 Restart=always
 RestartSec=5s

--- a/containers/lifeos-lifeosd/lifeos-lifeosd.container
+++ b/containers/lifeos-lifeosd/lifeos-lifeosd.container
@@ -138,6 +138,27 @@ Volume=/etc/hostname:/etc/hostname:ro
 # also touched by other host-side LifeOS services in future phases.
 Volume=/run/lifeos:/run/lifeos:z
 
+# === GPU access for hardware-tuned profile detection ===
+#
+# The daemon's ai_runtime_profile.rs::compute_runtime_profile reads
+# /sys/class/drm + nvidia-smi to detect a dedicated GPU and pick the
+# right Qwen model (9B + GPU layers if dedicated GPU present, smaller
+# 4B CPU profile if not). Pre-Phase-3 lifeosd ran on the host and saw
+# /dev/nvidia0 directly. Post-Phase-3 it lives in this container with
+# no device access — so it always reports "no dedicated GPU", writes
+# /var/lib/lifeos/llama-server-runtime-profile.env without
+# LIFEOS_AI_MODEL/LIFEOS_AI_MMPROJ, and lifeos-llama-server.service
+# then starts with an empty `--model` flag and crash-loops.
+#
+# CDI passthrough fixes this — same mechanism lifeos-llama-server
+# uses. The daemon doesn't actually do GPU compute (that's
+# llama-server's job); it just needs to *detect* the GPU. The host
+# nvidia-container-toolkit publishes nvidia.yaml at /run/cdi or
+# /etc/cdi; podman injects /dev/nvidia* + libnvidia-* into the
+# container at start. Skipped silently on hosts with no NVIDIA driver
+# (CDI spec absent) — daemon falls back to CPU profile.
+AddDevice=nvidia.com/gpu=all
+
 # === Container hardening (Quadlet [Container] directives) ===
 # Strategy: drop everything by default, add only what the daemon needs.
 DropCapability=all

--- a/containers/lifeos-llama-server/lifeos-llama-server.container
+++ b/containers/lifeos-llama-server/lifeos-llama-server.container
@@ -146,6 +146,8 @@ Exec=/bin/bash -c 'exec /usr/sbin/llama-server \
     --ubatch-size ${LIFEOS_AI_UBATCH_SIZE} \
     --n-predict 2048 \
     -kvu -cram -1 \
+    --cache-type-k q8_0 \
+    --cache-type-v q8_0 \
     ${LIFEOS_AI_DEVICE_FLAGS:+$LIFEOS_AI_DEVICE_FLAGS} \
     ${LIFEOS_AI_GPU_TUNING:+$LIFEOS_AI_GPU_TUNING} \
     --temp 0.6 --top-p 0.95 --top-k 20 --min-p 0.0 \

--- a/containers/lifeos-llama-server/lifeos-llama-server.container
+++ b/containers/lifeos-llama-server/lifeos-llama-server.container
@@ -124,7 +124,14 @@ Volume=/var/lib/lifeos/models:/var/lib/lifeos/models:ro,z
 # devices: 0)" when the binary couldn't enumerate Vulkan devices in the
 # headless container — the proximate cause of every restart-loop in the
 # field today.
-Exec=/usr/sbin/llama-server \
+# systemd's Exec= tokenises BEFORE expanding ${VAR}, so an empty
+# variable expands to a literal empty-string argv token (`""`) — not
+# zero tokens. llama-server then sees `argv[i] == ""` and either errors
+# out or misparses the next flag. We therefore wrap the command in
+# `bash -c '...'` and use `${VAR:+$VAR}` so an empty value produces
+# zero tokens (proper shell word-splitting of a single space-separated
+# flag string).
+Exec=/bin/bash -c 'exec /usr/sbin/llama-server \
     --model /var/lib/lifeos/models/${LIFEOS_AI_MODEL} \
     --mmproj /var/lib/lifeos/models/${LIFEOS_AI_MMPROJ} \
     --alias lifeos \
@@ -139,12 +146,12 @@ Exec=/usr/sbin/llama-server \
     --ubatch-size ${LIFEOS_AI_UBATCH_SIZE} \
     --n-predict 2048 \
     -kvu -cram -1 \
-    ${LIFEOS_AI_DEVICE_FLAGS} \
-    ${LIFEOS_AI_GPU_TUNING} \
+    ${LIFEOS_AI_DEVICE_FLAGS:+$LIFEOS_AI_DEVICE_FLAGS} \
+    ${LIFEOS_AI_GPU_TUNING:+$LIFEOS_AI_GPU_TUNING} \
     --temp 0.6 --top-p 0.95 --top-k 20 --min-p 0.0 \
     --presence-penalty 0.0 --repeat-penalty 1.0 \
     --reasoning off \
-    --jinja
+    --jinja'
 
 [Service]
 # Defense-in-depth Capa 4: ensure image is present locally before starting.

--- a/containers/lifeos-llama-server/lifeos-llama-server.container
+++ b/containers/lifeos-llama-server/lifeos-llama-server.container
@@ -113,6 +113,17 @@ Volume=/var/lib/lifeos/models:/var/lib/lifeos/models:ro,z
 # Reads model + tuning from the runtime-profile env file. The benchmarker
 # (defer benchmark, PR #65) writes that file with hardware-tuned values.
 # Game-guard env file overrides for low-power profiles when gaming detected.
+# LIFEOS_AI_DEVICE_FLAGS / LIFEOS_AI_GPU_TUNING are written by lifeosd
+# alongside the rest of the runtime profile, parameterizing the
+# GPU-vs-CPU split:
+#   GPU profile (Vulkan/CUDA OK) → LIFEOS_AI_DEVICE_FLAGS=""           (no override)
+#                                  LIFEOS_AI_GPU_TUNING="-sm none -mg 0 --cache-type-k q8_0 --cache-type-v q8_0 --flash-attn auto"
+#   CPU profile (no GPU)         → LIFEOS_AI_DEVICE_FLAGS="--device none"
+#                                  LIFEOS_AI_GPU_TUNING=""
+# Hardcoding `-mg 0` produced "invalid value for main_gpu: 0 (available
+# devices: 0)" when the binary couldn't enumerate Vulkan devices in the
+# headless container — the proximate cause of every restart-loop in the
+# field today.
 Exec=/usr/sbin/llama-server \
     --model /var/lib/lifeos/models/${LIFEOS_AI_MODEL} \
     --mmproj /var/lib/lifeos/models/${LIFEOS_AI_MMPROJ} \
@@ -127,10 +138,9 @@ Exec=/usr/sbin/llama-server \
     --batch-size ${LIFEOS_AI_BATCH_SIZE} \
     --ubatch-size ${LIFEOS_AI_UBATCH_SIZE} \
     --n-predict 2048 \
-    --flash-attn auto \
-    --cache-type-k q8_0 \
-    --cache-type-v q8_0 \
-    -kvu -cram -1 -sm none -mg 0 \
+    -kvu -cram -1 \
+    ${LIFEOS_AI_DEVICE_FLAGS} \
+    ${LIFEOS_AI_GPU_TUNING} \
     --temp 0.6 --top-p 0.95 --top-k 20 --min-p 0.0 \
     --presence-penalty 0.0 --repeat-penalty 1.0 \
     --reasoning off \
@@ -150,6 +160,19 @@ ExecStartPre=/usr/local/bin/lifeos-ensure-images
 # best-effort: if 60 s pass without a spec we still try to start (Restart=
 # always handles a hard failure).
 ExecStartPre=-/bin/bash -c 'i=0; while [ $i -lt 60 ]; do for f in /run/cdi/nvidia.yaml /var/run/cdi/nvidia.yaml /etc/cdi/nvidia.yaml; do [ -s "$f" ] && exit 0; done; sleep 1; i=$((i+1)); done; exit 0'
+
+# Wait up to 90 s for lifeosd (running in its own Quadlet container) to
+# write LIFEOS_AI_MODEL into the runtime profile file. Without this, the
+# container starts with --model "/var/lib/lifeos/models/" (empty model
+# name from unset env var), llama-server exits 1 with "failed to load
+# model", Restart=always kicks in, and we restart-loop forever — exactly
+# the regression first observed when lifeosd lost host /dev/nvidia0
+# access in Phase 3 and stopped picking a GPU profile. Keeping this
+# guard even after the lifeos-lifeosd Quadlet gains AddDevice=nvidia.com/
+# gpu=all so a still-warming-up daemon doesn't trigger false-failure
+# Restart= cycles. Hyphen + `exit 0` on timeout: if 90 s pass we still
+# try to start; the underlying failure mode is logged the same way.
+ExecStartPre=-/bin/bash -c 'i=0; while [ $i -lt 90 ]; do f=/var/lib/lifeos/llama-server-runtime-profile.env; if [ -s "$f" ] && grep -q "^LIFEOS_AI_MODEL=" "$f"; then exit 0; fi; sleep 1; i=$((i+1)); done; echo "WARN: LIFEOS_AI_MODEL not set after 90s — starting anyway"; exit 0'
 
 # CRITICAL: these paths are HOST paths (systemd evaluates EnvironmentFile=
 # on the host before the container is created). The benchmarker writes

--- a/daemon/src/ai_runtime_profile.rs
+++ b/daemon/src/ai_runtime_profile.rs
@@ -107,6 +107,23 @@ impl RuntimeSettings {
         if let Some(mmproj) = &self.mmproj {
             lines.push(format!("LIFEOS_AI_MMPROJ={mmproj}"));
         }
+        // GPU-vs-CPU device split for the lifeos-llama-server Quadlet's Exec
+        // line. The Quadlet expands these literally into the llama-server
+        // command, so empty is fine — but keeping `-mg 0 --cache-type-* q8_0`
+        // hardcoded in the Quadlet causes "invalid value for main_gpu: 0
+        // (available devices: 0)" the moment Vulkan can't enumerate a
+        // device (every CPU-only deploy + every host where lifeos-nvidia-
+        // drivers ships without proper headless Vulkan support).
+        if self.gpu_layers == 0 {
+            lines.push("LIFEOS_AI_DEVICE_FLAGS=--device none".to_string());
+            lines.push("LIFEOS_AI_GPU_TUNING=".to_string());
+        } else {
+            lines.push("LIFEOS_AI_DEVICE_FLAGS=".to_string());
+            lines.push(
+                "LIFEOS_AI_GPU_TUNING=-sm none -mg 0 --cache-type-k q8_0 --cache-type-v q8_0 --flash-attn auto"
+                    .to_string(),
+            );
+        }
         lines
     }
 
@@ -628,6 +645,13 @@ fn heuristic_cpu_profile(
         inputs.requested_ctx_size.min(4_096)
     };
 
+    // Pin the small Qwen 3.5 4B Q4_K_M as the CPU baseline: ~2.7 GB on disk,
+    // ~3-4 GB RAM at runtime, runs at ~10-20 tokens/s on a Raptor Lake-S CPU
+    // (measured 14 t/s on Hector's machine post-Phase-3 cutover before the
+    // Vulkan-headless workaround landed). Without this default the daemon
+    // would write a profile with no LIFEOS_AI_MODEL, and the
+    // lifeos-llama-server Quadlet would crash-loop on `--model
+    // /var/lib/lifeos/models/` (empty path).
     RuntimeSettings {
         ctx_size,
         threads,
@@ -635,8 +659,8 @@ fn heuristic_cpu_profile(
         parallel: 1,
         batch_size,
         ubatch_size,
-        model: None,
-        mmproj: None,
+        model: Some("Qwen3.5-4B-Q4_K_M.gguf".into()),
+        mmproj: Some("Qwen3.5-4B-mmproj-F16.gguf".into()),
     }
 }
 
@@ -816,6 +840,19 @@ fn detect_accelerator() -> Option<AcceleratorInfo> {
         return None;
     }
 
+    // Phase 4 of the architecture pivot moved llama-server into its own
+    // Quadlet container, so the binary is no longer guaranteed to live next
+    // to lifeosd. Try the binary first (still present on dev hosts and CPU
+    // builds), and fall back to nvidia-smi for the headless-container case
+    // where chat inference runs in lifeos-llama-server but lifeosd needs to
+    // know the GPU exists to pick the right runtime profile.
+    if let Some(info) = detect_accelerator_via_llama_server() {
+        return Some(info);
+    }
+    detect_accelerator_via_nvidia_smi()
+}
+
+fn detect_accelerator_via_llama_server() -> Option<AcceleratorInfo> {
     let output = Command::new("llama-server")
         .arg("--list-devices")
         .output()
@@ -844,6 +881,54 @@ fn detect_accelerator() -> Option<AcceleratorInfo> {
         }
     }
 
+    best
+}
+
+/// Probe the GPU directly through nvidia-smi. Used when no llama-server
+/// binary is reachable (lifeosd runs in a Quadlet container with the
+/// nvidia-smi tool injected by CDI, but no llama-server next to it).
+/// Returns the highest-VRAM NVIDIA device or None.
+fn detect_accelerator_via_nvidia_smi() -> Option<AcceleratorInfo> {
+    let output = Command::new("nvidia-smi")
+        .args([
+            "--query-gpu=name,memory.total",
+            "--format=csv,noheader,nounits",
+        ])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    parse_nvidia_smi_query(&stdout)
+}
+
+fn parse_nvidia_smi_query(output: &str) -> Option<AcceleratorInfo> {
+    let mut best: Option<AcceleratorInfo> = None;
+    for line in output.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        // CSV format with `--format=csv,noheader,nounits`:
+        //   "NVIDIA GeForce RTX 5070 Laptop GPU, 12227"
+        let mut parts = line.splitn(2, ',');
+        let name = parts.next()?.trim().to_string();
+        let mem = parts.next()?.trim().parse::<u64>().ok()?;
+        if name.is_empty() {
+            continue;
+        }
+        let candidate = AcceleratorInfo {
+            backend: "nvidia".to_string(),
+            name,
+            total_mem_mb: mem,
+        };
+        match &best {
+            None => best = Some(candidate),
+            Some(current) if candidate.total_mem_mb > current.total_mem_mb => best = Some(candidate),
+            _ => {}
+        }
+    }
     best
 }
 

--- a/daemon/src/ai_runtime_profile.rs
+++ b/daemon/src/ai_runtime_profile.rs
@@ -114,15 +114,18 @@ impl RuntimeSettings {
         // (available devices: 0)" the moment Vulkan can't enumerate a
         // device (every CPU-only deploy + every host where lifeos-nvidia-
         // drivers ships without proper headless Vulkan support).
+        // --cache-type-k/v q8_0 are GOOD for both CPU and GPU paths
+        // (they cut KV cache memory ~2× regardless of backend), so they
+        // live in the unconditional part of the Quadlet's Exec= line.
+        // Only the truly GPU-specific flags (`-sm none -mg 0
+        // --flash-attn auto`) need parameterising — those error on a
+        // CPU-only binary that can't enumerate a Vulkan/CUDA device.
         if self.gpu_layers == 0 {
             lines.push("LIFEOS_AI_DEVICE_FLAGS=--device none".to_string());
             lines.push("LIFEOS_AI_GPU_TUNING=".to_string());
         } else {
             lines.push("LIFEOS_AI_DEVICE_FLAGS=".to_string());
-            lines.push(
-                "LIFEOS_AI_GPU_TUNING=-sm none -mg 0 --cache-type-k q8_0 --cache-type-v q8_0 --flash-attn auto"
-                    .to_string(),
-            );
+            lines.push("LIFEOS_AI_GPU_TUNING=-sm none -mg 0 --flash-attn auto".to_string());
         }
         lines
     }
@@ -1007,19 +1010,35 @@ fn parse_llama_list_devices_output(output: &str) -> Vec<AcceleratorInfo> {
 }
 
 fn detect_nvidia_driver_version() -> Option<String> {
-    let output = Command::new("nvidia-smi")
-        .args(["--query-gpu=driver_version", "--format=csv,noheader"])
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
+    // Mirror detect_accelerator_via_nvidia_smi's two-candidate lookup so
+    // the daemon's HardwareFingerprint stays consistent regardless of
+    // whether `nvidia-smi` is on $PATH inside its container. CDI injects
+    // it at /usr/bin/nvidia-smi; some container images don't include /usr/
+    // bin in PATH for non-root users, so a bare Command::new("nvidia-smi")
+    // returns Err and driver_version flips to None — that flip flips
+    // PartialEq on HardwareFingerprint and triggers a benchmark re-run on
+    // every restart.
+    for binary in ["nvidia-smi", "/usr/bin/nvidia-smi"] {
+        let Ok(output) = Command::new(binary)
+            .args(["--query-gpu=driver_version", "--format=csv,noheader"])
+            .output()
+        else {
+            continue;
+        };
+        if !output.status.success() {
+            continue;
+        }
+        let parsed = String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .next()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned);
+        if parsed.is_some() {
+            return parsed;
+        }
     }
-    String::from_utf8_lossy(&output.stdout)
-        .lines()
-        .next()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(ToOwned::to_owned)
+    None
 }
 
 fn detect_llama_server_version() -> Option<String> {
@@ -2212,8 +2231,11 @@ Available devices:
             mmproj: Some("Qwen3.5-9B-mmproj-F16.gguf".into()),
         };
         let content = settings.to_env_content("test");
-        assert!(content.contains("LIFEOS_AI_DEVICE_FLAGS=\n") || content.contains("LIFEOS_AI_DEVICE_FLAGS="));
-        assert!(content.contains("LIFEOS_AI_GPU_TUNING=-sm none -mg 0 --cache-type-k q8_0 --cache-type-v q8_0 --flash-attn auto"));
+        // Pin the EMPTY-line invariant precisely so a future regression
+        // that emits `LIFEOS_AI_DEVICE_FLAGS=--device none` for a GPU
+        // profile (CPU value swapped in) trips this test.
+        assert!(content.contains("LIFEOS_AI_DEVICE_FLAGS=\n"));
+        assert!(content.contains("LIFEOS_AI_GPU_TUNING=-sm none -mg 0 --flash-attn auto"));
     }
 
     #[test]

--- a/daemon/src/ai_runtime_profile.rs
+++ b/daemon/src/ai_runtime_profile.rs
@@ -887,20 +887,32 @@ fn detect_accelerator_via_llama_server() -> Option<AcceleratorInfo> {
 /// Probe the GPU directly through nvidia-smi. Used when no llama-server
 /// binary is reachable (lifeosd runs in a Quadlet container with the
 /// nvidia-smi tool injected by CDI, but no llama-server next to it).
-/// Returns the highest-VRAM NVIDIA device or None.
+/// Returns the highest-VRAM dedicated NVIDIA device or None. Tries the
+/// PATH binary first then falls back to the toolkit's canonical
+/// /usr/bin/nvidia-smi (CDI sometimes lands the binary at a path that
+/// isn't on $PATH inside the daemon container).
 fn detect_accelerator_via_nvidia_smi() -> Option<AcceleratorInfo> {
-    let output = Command::new("nvidia-smi")
-        .args([
-            "--query-gpu=name,memory.total",
-            "--format=csv,noheader,nounits",
-        ])
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
+    let candidates = ["nvidia-smi", "/usr/bin/nvidia-smi"];
+    for binary in candidates {
+        let Ok(output) = Command::new(binary)
+            .args([
+                "--query-gpu=name,memory.total",
+                "--format=csv,noheader,nounits",
+            ])
+            .output()
+        else {
+            continue;
+        };
+        if !output.status.success() {
+            continue;
+        }
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let parsed = parse_nvidia_smi_query(&stdout);
+        if parsed.is_some() {
+            return parsed;
+        }
     }
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    parse_nvidia_smi_query(&stdout)
+    None
 }
 
 fn parse_nvidia_smi_query(output: &str) -> Option<AcceleratorInfo> {
@@ -912,17 +924,35 @@ fn parse_nvidia_smi_query(output: &str) -> Option<AcceleratorInfo> {
         }
         // CSV format with `--format=csv,noheader,nounits`:
         //   "NVIDIA GeForce RTX 5070 Laptop GPU, 12227"
+        // Bad rows must `continue`, never `?`-return — `?` exits the whole
+        // function and silently drops every following GPU line. Locale-
+        // formatted numbers (`12,227`) and `[N/A]` driver-init failures
+        // would otherwise mask working GPUs further down the list.
         let mut parts = line.splitn(2, ',');
-        let name = parts.next()?.trim().to_string();
-        let mem = parts.next()?.trim().parse::<u64>().ok()?;
+        let Some(name_raw) = parts.next() else {
+            continue;
+        };
+        let name = name_raw.trim().to_string();
         if name.is_empty() {
             continue;
         }
+        let Some(mem_raw) = parts.next() else {
+            continue;
+        };
+        let Ok(mem) = mem_raw.trim().parse::<u64>() else {
+            continue;
+        };
         let candidate = AcceleratorInfo {
             backend: "nvidia".to_string(),
             name,
             total_mem_mb: mem,
         };
+        // Only keep dedicated GPUs (skip Intel/Apple iGPUs that may show
+        // up if nvidia-smi is replaced by a stub or on hybrid hosts).
+        // Mirrors the llama-server selection logic above.
+        if !is_dedicated_gpu(&candidate) {
+            continue;
+        }
         match &best {
             None => best = Some(candidate),
             Some(current) if candidate.total_mem_mb > current.total_mem_mb => best = Some(candidate),
@@ -2157,6 +2187,70 @@ Available devices:
         let content = with_model.to_env_content("test");
         assert!(content.contains("LIFEOS_AI_MODEL=Qwen3.5-4B-Q4_K_M.gguf"));
         assert!(content.contains("LIFEOS_AI_MMPROJ=Qwen3.5-4B-mmproj-F16.gguf"));
+
+        // CPU profile (gpu_layers == 0) emits --device none and an empty
+        // GPU tuning string so the lifeos-llama-server Quadlet's bash
+        // wrapper short-circuits the GPU-only flags. Catches a regression
+        // where a future refactor stops emitting these env vars and
+        // llama-server crash-loops on '-mg 0 (available devices: 0)'.
+        assert!(content.contains("LIFEOS_AI_DEVICE_FLAGS=--device none"));
+        assert!(content.contains("LIFEOS_AI_GPU_TUNING=\n") || content.ends_with("LIFEOS_AI_GPU_TUNING=\n"));
+    }
+
+    #[test]
+    fn runtime_settings_emits_gpu_tuning_when_gpu_layers_active() {
+        // Mirror of the GPU branch — ensures GPU deploys keep getting
+        // the same tuning flags the Quadlet used to hard-code.
+        let settings = RuntimeSettings {
+            ctx_size: 32_768,
+            threads: 8,
+            gpu_layers: 99,
+            parallel: 2,
+            batch_size: 1024,
+            ubatch_size: 256,
+            model: Some("Qwen3.5-9B-Q4_K_M.gguf".into()),
+            mmproj: Some("Qwen3.5-9B-mmproj-F16.gguf".into()),
+        };
+        let content = settings.to_env_content("test");
+        assert!(content.contains("LIFEOS_AI_DEVICE_FLAGS=\n") || content.contains("LIFEOS_AI_DEVICE_FLAGS="));
+        assert!(content.contains("LIFEOS_AI_GPU_TUNING=-sm none -mg 0 --cache-type-k q8_0 --cache-type-v q8_0 --flash-attn auto"));
+    }
+
+    #[test]
+    fn parse_nvidia_smi_query_picks_highest_vram_dedicated_gpu() {
+        // Multi-GPU csv output (one iGPU + one dGPU). is_dedicated_gpu
+        // filters Intel out, so we MUST end up with the NVIDIA card even
+        // though Intel reported more "memory" (it's shared system RAM and
+        // unrelated to dedicated VRAM).
+        let csv = "\
+NVIDIA GeForce RTX 5070 Laptop GPU, 12227
+Intel(R) Iris Xe Graphics, 32768
+NVIDIA GeForce RTX 4060 Laptop GPU, 8192
+";
+        let dev = parse_nvidia_smi_query(csv).expect("expected an NVIDIA device");
+        assert_eq!(dev.name, "NVIDIA GeForce RTX 5070 Laptop GPU");
+        assert_eq!(dev.total_mem_mb, 12_227);
+        assert_eq!(dev.backend, "nvidia");
+    }
+
+    #[test]
+    fn parse_nvidia_smi_query_skips_malformed_rows_without_aborting() {
+        // The pre-fix version used `?` and would early-return None at the
+        // first malformed row, dropping every row after it. With let-else
+        // continue, the second valid row is still found.
+        let csv = "\
+[N/A], [N/A]
+NVIDIA GeForce RTX 5070, 12227
+";
+        let dev = parse_nvidia_smi_query(csv).expect("RTX 5070 must still be picked up");
+        assert_eq!(dev.name, "NVIDIA GeForce RTX 5070");
+    }
+
+    #[test]
+    fn parse_nvidia_smi_query_returns_none_on_empty_or_no_dgpu() {
+        assert!(parse_nvidia_smi_query("").is_none());
+        // Pure iGPU output — no dedicated GPU, must return None.
+        assert!(parse_nvidia_smi_query("Intel(R) UHD Graphics, 8192\n").is_none());
     }
 
     #[test]

--- a/daemon/src/ai_runtime_profile.rs
+++ b/daemon/src/ai_runtime_profile.rs
@@ -958,7 +958,9 @@ fn parse_nvidia_smi_query(output: &str) -> Option<AcceleratorInfo> {
         }
         match &best {
             None => best = Some(candidate),
-            Some(current) if candidate.total_mem_mb > current.total_mem_mb => best = Some(candidate),
+            Some(current) if candidate.total_mem_mb > current.total_mem_mb => {
+                best = Some(candidate)
+            }
             _ => {}
         }
     }
@@ -2213,7 +2215,10 @@ Available devices:
         // where a future refactor stops emitting these env vars and
         // llama-server crash-loops on '-mg 0 (available devices: 0)'.
         assert!(content.contains("LIFEOS_AI_DEVICE_FLAGS=--device none"));
-        assert!(content.contains("LIFEOS_AI_GPU_TUNING=\n") || content.ends_with("LIFEOS_AI_GPU_TUNING=\n"));
+        assert!(
+            content.contains("LIFEOS_AI_GPU_TUNING=\n")
+                || content.ends_with("LIFEOS_AI_GPU_TUNING=\n")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Daemon now detects the active GPU via `nvidia-smi --query-gpu` and writes the runtime profile accordingly. Picks the dedicated GPU with the highest VRAM if multiple present.
- Adds CPU-only fallback profile so the daemon stays usable when GPU init fails (e.g. the lifeos-nvidia-drivers v595.58.03 Vulkan-headless bug).
- Hardens `parse_nvidia_smi_query` against malformed CSV rows; loop-internal `?` would have early-returned and skipped valid rows.
- Quadlet `Exec=` for lifeos-llama-server wrapped in bash so empty `\${VAR:+\$VAR}` arg expansion produces zero argv tokens (was producing literal `""`).
- CDI poll ExecStartPre on the lifeosd Quadlet to wait for the NVIDIA CDI device file before container start.

## JD

Two parallel A+B rounds. R2 verdict: APPROVED.

R1 caught: `?` operator in for-loop early-returns, missing `/usr/bin/nvidia-smi` PATH fallback in `detect_nvidia_driver_version`, KV cache lost in CPU mode (was inside the gpu-tuning env block), CPU profile model defaulted to None instead of Qwen3.5-4B.

R2 caught: nvidia-smi PATH fallback didn't apply to `detect_nvidia_driver_version` either.

Both fixed.

## Test plan

- [ ] CI test suite green
- [ ] Post-CI deploy: verify daemon picks the RTX 5070 Ti (12 GB) over any nvidia integrated nonsense
- [ ] Verify CPU fallback works when `chattr +i` is removed from the runtime profile
- [ ] Verify benchmarker re-runs are not triggered repeatedly (driver-version detection works)