### PR TITLE
feat(side-images): switch lifeos-llama-server from Vulkan to CUDA

### DIFF
--- a/.github/workflows/side-images.yml
+++ b/.github/workflows/side-images.yml
@@ -18,7 +18,7 @@ name: Side Container Images
 # llama-server is excluded by default because its runtime is BLOCKED on
 # nvidia-container-toolkit (Fedora 43 RPM digest issue). The container builds
 # fine; production cannot start it. Build is gated behind `build-llama-server`
-# input so we don't waste a 30-min vulkan compile every CI cycle.
+# input so we don't waste a 30-min CUDA compile every CI cycle.
 
 on:
   push:
@@ -30,7 +30,7 @@ on:
   workflow_dispatch:
     inputs:
       build-llama-server:
-        description: 'Also build lifeos-llama-server (vulkan, ~30 min). Phase 4 active on fc44 — runtime UNBLOCKED.'
+        description: 'Also build lifeos-llama-server (CUDA, ~30-45 min). Phase 4 active on fc44 — runtime UNBLOCKED.'
         required: false
         default: 'true'
         type: choice
@@ -109,7 +109,9 @@ jobs:
           podman push ghcr.io/${REPO_OWNER}/${{ matrix.name }}:${GITHUB_SHA::8}
 
   build-llama-server:
-    # Vulkan compile is ~30 min. Now that Phase 4 GPU passthrough is live
+    # CUDA compile is ~30-45 min (slightly longer than the previous Vulkan
+    # build because nvcc compiles per-arch device code for sm_75..sm_120).
+    # Now that Phase 4 GPU passthrough is live
     # on fc44, the build runs on every push to containers/**, the weekly
     # cron, and on workflow_dispatch (default 'true'). Set the dispatch
     # input to 'false' if you need to skip the long compile for an
@@ -126,7 +128,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build lifeos-llama-server (vulkan)
+      - name: Build lifeos-llama-server (CUDA)
         run: |
           podman build \
             -t ghcr.io/${REPO_OWNER}/lifeos-llama-server:stable \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "life"
-version = "0.8.50"
+version = "0.8.41"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2626,7 +2626,7 @@ dependencies = [
 
 [[package]]
 name = "lifeos-integration-tests"
-version = "0.8.50"
+version = "0.8.41"
 dependencies = [
  "life",
  "serde_json",
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "lifeosd"
-version = "0.8.50"
+version = "0.8.41"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.50"
+version = "0.8.41"
 
 [workspace.metadata.lifeos]
 codename = "Axolotl"

--- a/containers/lifeos-llama-server/Containerfile
+++ b/containers/lifeos-llama-server/Containerfile
@@ -44,7 +44,13 @@
 # still getting full GPU offload. Trade-off: CUDA build pulls the CUDA toolkit
 # into the builder stage (~3 GB while compiling, dropped in stage 2). Worth
 # it: ~25-50 t/s on Qwen 9B vs ~14 t/s CPU.
-FROM nvidia/cuda:12.6.3-cudnn-devel-ubi9 AS builder
+#
+# CUDA 12.8+ is REQUIRED — sm_100/sm_120 (Blackwell, RTX 50xx) support
+# was added in 12.8. Earlier toolkits abort with
+# "Invalid target architecture 'sm_120'" when nvcc is asked to build
+# for our CMAKE_CUDA_ARCHITECTURES list. Hector's RTX 5070 Ti Laptop is
+# sm_120, so dropping below 12.8 means nvcc fails the build entirely.
+FROM nvidia/cuda:12.8.1-cudnn-devel-ubi9 AS builder
 
 RUN dnf -y install \
         cmake \
@@ -97,9 +103,18 @@ FROM fedora-minimal:44 AS runtime
 RUN microdnf install -y \
         ca-certificates \
         libcurl \
+        libstdc++ \
         tini \
         --setopt=tsflags=nodocs && \
     microdnf clean all
+# Note on libstdc++: GGML_STATIC=OFF in the builder stage means
+# llama-server is dynamically linked against libstdc++.so.6. fedora-minimal
+# strips libstdc++ from the base, so without this microdnf install the
+# binary fails at startup with "error while loading shared libraries:
+# libstdc++.so.6: cannot open shared object file". The Vulkan build had
+# GGML_STATIC=ON which baked libstdc++ into the binary; CUDA can't fully
+# static-link (libcudart needs to come from the host via CDI) so we ship
+# libstdc++ explicitly.
 
 COPY --from=builder /tmp/llama.cpp/build/bin/llama-server /usr/sbin/llama-server
 

--- a/containers/lifeos-llama-server/Containerfile
+++ b/containers/lifeos-llama-server/Containerfile
@@ -6,8 +6,9 @@
 # read-only from /var/lib/lifeos/models/ at runtime.
 #
 # Phase 4 of the architecture pivot — the most complex piece because it
-# requires GPU passthrough via CDI, Vulkan inside the container, and
-# binding multi-GB GGUF models read-only.
+# requires GPU passthrough via CDI (libcuda.so + /dev/nvidia*) and
+# binding multi-GB GGUF models read-only. Originally built with Vulkan;
+# switched to CUDA in May 2026 (see comment at the builder stage).
 # PRD: docs/strategy/prd-architecture-pivot-lean-bootc-quadlet.md
 #
 # === BLOCKER ===
@@ -29,24 +30,28 @@
 # ---------------------------------------------------------------------------
 # Stage 1 — builder
 # ---------------------------------------------------------------------------
-# Heavy: shader-gen tool needs Vulkan headers + glslang. Build is slower
-# than embeddings (~20-30 min) because shader compilation alone is heavy.
-# Same image base as the host bootc llama-server build for parity.
-FROM fedora:44 AS builder
+# Builder uses the official NVIDIA CUDA devel image because it bundles the
+# CUDA toolkit + nvcc + cuBLAS headers we need to compile llama.cpp with
+# `-DGGML_CUDA=ON`. nvidia/cuda:12.6.3-cudnn-devel-ubi9 is a UBI9 base
+# (RHEL-compatible) and stays close to Fedora 44's runtime ABI.
+#
+# Switched from Vulkan to CUDA in May 2026 because the lifeos-nvidia-drivers
+# proprietary build (v595.58.03) does not expose a working Vulkan driver in
+# headless containers — `libnvidia-glcore` references the Xorg server
+# symbol `ErrorF` and aborts at dlopen-time when no X server is present. nvidia-smi
+# (NVML / CUDA) keeps working through the same CDI passthrough, so building
+# llama-server with `-DGGML_CUDA=ON` sidesteps the entire Vulkan stack while
+# still getting full GPU offload. Trade-off: CUDA build pulls the CUDA toolkit
+# into the builder stage (~3 GB while compiling, dropped in stage 2). Worth
+# it: ~25-50 t/s on Qwen 9B vs ~14 t/s CPU.
+FROM nvidia/cuda:12.6.3-cudnn-devel-ubi9 AS builder
 
 RUN dnf -y install \
         cmake \
         gcc gcc-c++ make \
         git \
         ca-certificates \
-        curl-devel \
-        # Vulkan SDK pieces — same set the host Containerfile installs.
-        vulkan-headers \
-        vulkan-loader-devel \
-        glslang \
-        glslc \
-        spirv-tools \
-        spirv-headers-devel \
+        libcurl-devel \
         pkgconf-pkg-config \
         && \
     dnf clean all
@@ -59,37 +64,38 @@ RUN git clone https://github.com/ggml-org/llama.cpp /tmp/llama.cpp && \
     cd /tmp/llama.cpp && \
     git checkout "${LLAMA_CPP_TAG}"
 
-# Build with Vulkan ON. -j1 because vulkan-shaders-gen forks parallel
-# glslangValidator children which OOM at higher parallelism on weaker
-# runners (we hit this on ubuntu-latest in CI; VPS runner cap respects it).
+# Build with CUDA ON. nvcc parallelism is fine; -j$(nproc) is safe (no
+# vulkan-shaders-gen forking children). The Vulkan-related cmake flags
+# are kept commented for documentation since the swap is reversible if
+# lifeos-nvidia-drivers fixes its headless-Vulkan story.
 RUN cmake -S /tmp/llama.cpp -B /tmp/llama.cpp/build \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=OFF \
-        -DGGML_STATIC=ON \
+        -DGGML_STATIC=OFF \
         -DGGML_NATIVE=OFF \
-        -DGGML_VULKAN=ON \
-        -DGGML_CUDA=OFF \
+        -DGGML_CUDA=ON \
+        -DGGML_VULKAN=OFF \
+        -DCMAKE_CUDA_ARCHITECTURES="75;80;86;89;90;120" \
         -DLLAMA_BUILD_TESTS=OFF \
         -DLLAMA_BUILD_EXAMPLES=OFF \
         -DLLAMA_BUILD_SERVER=ON && \
-    cmake --build /tmp/llama.cpp/build -j1
+    cmake --build /tmp/llama.cpp/build -j"$(nproc)" --target llama-server
 
 # Sanity. Note: this just verifies the binary CAN run; actual GPU access
-# requires the runtime stage's Vulkan ICD + nvidia-container-toolkit on host.
+# requires CDI to inject /dev/nvidia* + libcuda.so on container start.
 RUN /tmp/llama.cpp/build/bin/llama-server --version
 
 # ---------------------------------------------------------------------------
 # Stage 2 — runtime
 # ---------------------------------------------------------------------------
-# Needs: vulkan-loader (libvulkan.so.1), libcurl (HTTP), tini, ca-certs.
-# Critically does NOT need NVIDIA driver libraries — those come from the
-# HOST via CDI passthrough at container start time. The container only
-# needs vulkan-loader to find them.
+# Needs: libcurl (HTTP), tini, ca-certs. NVIDIA libcuda.so.1 + cuBLAS come
+# from the HOST via CDI passthrough at container start time, so we don't
+# bake them in. The runtime stage is intentionally minimal — no Vulkan
+# loader, no Mesa drivers — to keep the image small.
 FROM fedora-minimal:44 AS runtime
 
 RUN microdnf install -y \
         ca-certificates \
-        vulkan-loader \
         libcurl \
         tini \
         --setopt=tsflags=nodocs && \
@@ -123,10 +129,10 @@ EXPOSE 8082
 ENTRYPOINT ["/usr/bin/tini", "--"]
 
 # CMD has no args here — the Quadlet wires the model + ctx + GPU layers.
-# Same image is reusable for any GGUF chat model on Vulkan.
+# Same image is reusable for any GGUF chat model on CUDA.
 CMD ["/usr/sbin/llama-server"]
 
 LABEL org.opencontainers.image.title="lifeos-llama-server"
-LABEL org.opencontainers.image.description="Qwen3.5 chat inference (Vulkan GPU) — stateless; 4B default, 9B opt-in via LIFEOS_AI_MODEL"
+LABEL org.opencontainers.image.description="Qwen3.5 chat inference (CUDA GPU) — stateless; 4B default, 9B opt-in via LIFEOS_AI_MODEL"
 LABEL org.opencontainers.image.source="https://github.com/hectormr206/lifeos"
 LABEL org.opencontainers.image.licenses="Apache-2.0"

--- a/containers/lifeos-llama-server/lifeos-llama-server.container
+++ b/containers/lifeos-llama-server/lifeos-llama-server.container
@@ -1,4 +1,4 @@
-# lifeos-llama-server.container — Qwen3.5 Vulkan inference Quadlet
+# lifeos-llama-server.container — Qwen3.5 CUDA inference Quadlet
 # Default LIFEOS_AI_MODEL is Qwen3.5-4B (per decision_default_model_4b);
 # 9B is opt-in via the runtime-profile env file. The Quadlet itself is
 # model-agnostic.
@@ -8,7 +8,7 @@
 # project_pending_nvidia_container_toolkit memory).
 
 [Unit]
-Description=LifeOS LLM Server (Qwen3.5 chat, Vulkan GPU, containerized)
+Description=LifeOS LLM Server (Qwen3.5 chat, CUDA GPU, containerized)
 Documentation=https://github.com/ggml-org/llama.cpp
 # lifeosd reads from :8082 — keep llama-server up before lifeosd. Use the
 # Quadlet-generated unit name; ordering vs the legacy `llama-server.service`
@@ -162,14 +162,14 @@ EnvironmentFile=-/var/lib/lifeos/llama-server-runtime-profile.env
 EnvironmentFile=-/var/lib/lifeos/llama-server-game-guard.env
 
 # Capa 3 — auto-restart with a longer backoff than embeddings/TTS because
-# Qwen3.5 warmup (model load + GPU upload + Vulkan shader cache prime)
+# Qwen3.5 warmup (model load + GPU upload + CUDA module/PTX JIT prime)
 # takes ~30-60s. Avoid restart-thrash on transient OOM.
 Restart=always
 RestartSec=15s
 TimeoutStartSec=180s
 
 # Resource limits. The model itself fills GPU VRAM (5.3 GB Q4); host RAM is
-# for the kv-cache, server overhead, and Vulkan staging. 8G cap is generous
+# for the kv-cache, server overhead, and CUDA staging. 8G cap is generous
 # but realistic for the 131K context profile.
 MemoryMax=8G
 CPUQuota=400%


### PR DESCRIPTION
## Summary

Switches `lifeos-llama-server`'s llama.cpp build from Vulkan to CUDA. The lifeos-nvidia-drivers v595.58.03 ships with a broken Vulkan-headless code path (libnvidia-glcore aborts at dlopen outside Xorg because GLVnd's libGLX_nvidia.so.0 unconditionally needs Xorg's `ErrorF` symbol). CUDA sidesteps the entire Vulkan stack and uses the NVML/CUDA driver path that the same drivers DO support correctly.

- Containerfile builder stage: `nvidia/cuda:12.8.1-cudnn-devel-ubi9` (was `fedora:44`).
- cmake: `-DGGML_CUDA=ON -DGGML_VULKAN=OFF -DCMAKE_CUDA_ARCHITECTURES="75;80;86;89;90;120"` — sm_120 is Blackwell (RTX 50xx) and requires CUDA ≥ 12.8.
- `-DGGML_STATIC=OFF` (was ON) — required because CUDA artifacts are dynamic. Runtime stage adds `libstdc++` to compensate.
- Drops vulkan-headers / glslang / glslc / spirv-tools / spirv-headers-devel from the build image.
- Workflow + image labels updated from "Vulkan GPU" to "CUDA GPU".

## JD

Two parallel A+B rounds. R2 verdict: APPROVED.

## Test plan

- [ ] CI builds the side image successfully (~30-90 min)
- [ ] Image smoke: `podman run --rm --device nvidia.com/gpu=all lifeos-llama-server:stable llama-server --version` reports CUDA backend
- [ ] Post-deploy on laptop with RTX 5070 Ti: verify `journalctl -u lifeos-llama-server | grep -i 'CUDA\|sm_'` shows sm_120 init
- [ ] Verify GPU layers actually load (not falling back to CPU)
- [ ] After this lands, manually `chattr -i /var/lib/lifeos/llama-server-runtime-profile.env` on the laptop so the daemon GPU detection (PR sibling) takes over the profile management.