### PR TITLE
fix(side-images): docker.io/nvidia/cuda FQDN for self-hosted runner

### DIFF
--- a/containers/lifeos-llama-server/Containerfile
+++ b/containers/lifeos-llama-server/Containerfile
@@ -50,7 +50,7 @@
 # "Invalid target architecture 'sm_120'" when nvcc is asked to build
 # for our CMAKE_CUDA_ARCHITECTURES list. Hector's RTX 5070 Ti Laptop is
 # sm_120, so dropping below 12.8 means nvcc fails the build entirely.
-FROM nvidia/cuda:12.8.1-cudnn-devel-ubi9 AS builder
+FROM docker.io/nvidia/cuda:12.8.1-cudnn-devel-ubi9 AS builder
 
 RUN dnf -y install \
         cmake \


### PR DESCRIPTION
## Problem

Post-merge of #91 (Vulkan→CUDA), Side Container Images workflow on main failed in 8s with:

```
Error: creating build container: short-name "nvidia/cuda:12.8.1-cudnn-devel-ubi9" did not resolve to an alias and no unqualified-search registries are defined in "/etc/containers/registries.conf"
```

The self-hosted VPS runner's podman is configured strict-mode (no unqualified-search registries). The Containerfile's `FROM nvidia/cuda:...` short-name worked on PR builds (probably ran on github-hosted runner with permissive search) but fails on the VPS self-hosted runner that's used for `runs-on: [self-hosted, vps]`.

## Fix

`FROM nvidia/cuda:...` → `FROM docker.io/nvidia/cuda:...` — explicit FQDN works regardless of registries.conf.

## Test plan

- [ ] CI: `Side Container Images / build-llama-server` should now resolve the image and proceed to actual nvcc compile (~30-45 min).
- [ ] Post-deploy: `journalctl -u lifeos-llama-server | rg 'CUDA|sm_'` shows sm_120 backend init.