### PR TITLE
docs: reposition LifeOS as personal AI runtime over Linux (pivot Fase 1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## What is LifeOS?
 
-AI-native Linux distribution (Fedora bootc + COSMIC Desktop). Three Rust crates:
+LifeOS is a personal AI runtime / operating-system layer over Linux, not a replacement distro. CachyOS is the current reference host for validation; Fedora bootc and NixOS work are legacy/transitional paths. Three Rust crates:
 
 | Crate | Binary | Purpose |
 |-------|--------|---------|
@@ -11,7 +11,7 @@ AI-native Linux distribution (Fedora bootc + COSMIC Desktop). Three Rust crates:
 | `desktop/` | `lifeos-desktop` | Per-user companion: system tray + wake-word listener |
 | `tests/` | — | Integration tests |
 
-Plus: `image/` (OS container), `scripts/` (automation), `docs/` (documentation).
+Plus: `image/` (legacy/prototype OS container), `nix/` (transitional packaging/VM work), `scripts/` (automation), `docs/` (documentation).
 
 ## Build & Test (essential commands)
 
@@ -28,7 +28,7 @@ cargo fmt --manifest-path daemon/Cargo.toml       # Format
 1. **No orphaned modules** — register in `main.rs`, wire to SimpleX/API/event bus/supervisor
 2. **Use `anyhow::Result`** for all fallible functions
 3. **Run `cargo fmt` + `clippy`** before committing
-4. **`/usr` is read-only** at runtime (bootc immutable) — state goes to `/var/` or `/home/`
+4. **Host paths vary by profile** — legacy bootc keeps `/usr` read-only; runtime state should still prefer `/var/` or `/home/`
 5. **Auth required** — all API routes need `x-bootstrap-token` header
 
 ## Contribution Workflow Policy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-LifeOS — AI-native Linux distribution on Fedora bootc (immutable). Rust CLI (`life`) + user-session daemon (`lifeosd`) + bootc OS image.
+LifeOS — personal AI runtime / operating-system layer over Linux. Rust CLI (`life`) + user-session daemon (`lifeosd`) + desktop companion (`lifeos-desktop`). Fedora bootc and NixOS work are legacy/transitional paths after the runtime pivot.
 
 **Language:** Rust 2021. Documentation in Spanish, code in English.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,6 +1,6 @@
 # GEMINI.md — LifeOS Context
 
-LifeOS — AI-native Linux distribution on Fedora bootc. Rust CLI (`life`) + daemon (`lifeosd`) + COSMIC Desktop.
+LifeOS — personal AI runtime / operating-system layer over Linux. Rust CLI (`life`) + daemon (`lifeosd`) + desktop companion (`lifeos-desktop`). CachyOS is the current reference host; Fedora bootc and NixOS are legacy/transitional paths after the runtime pivot.
 
 ## Build & Test
 
@@ -16,7 +16,7 @@ cargo test -p lifeosd test_name   # Single test
 
 - **Rust 2021**, `anyhow` for errors, `tokio` async runtime
 - **Formatting:** `cargo fmt` before commit, clippy with `-D warnings`
-- **Immutability:** `/usr` is read-only. State goes to `/var/`, `/etc/`, `/home/`
+- **Host paths:** legacy bootc keeps `/usr` read-only; runtime state should still prefer `/var/`, `/etc/`, or `/home/`
 - **No dead code:** Every new module must be wired to SimpleX/API/event bus/supervisor
 - **AI:** Local `llama-server` on `:8082` (Qwen3.5-4B). LLM router with 13+ providers
 

--- a/README.md
+++ b/README.md
@@ -2,36 +2,39 @@
 
 ![Beta](https://img.shields.io/badge/status-beta-orange?style=for-the-badge) ![Version](https://img.shields.io/badge/version-0.7.17-teal?style=for-the-badge)
 
-**AI-native Linux distribution built on Fedora bootc (immutable) with COSMIC Desktop.**
+**The personal operating system for your digital life: a local-first AI runtime that runs over Linux.**
 
-> **Heads up — LifeOS is in Beta.** Things work, things break, things change. Running LifeOS on your primary machine means opting into fast iteration over long-term stability. Feedback and issue reports are welcome and actively shape the roadmap.
+> **Heads up — LifeOS is in Beta.** Things work, things break, things change. Running the LifeOS runtime on your primary machine means opting into fast iteration over long-term stability. Feedback and issue reports are welcome and actively shape the roadmap.
 
-LifeOS is building toward an OS-level assistant named **Axi** with local inference, encrypted memory, desktop control, and privacy-first defaults.
+LifeOS is not trying to replace your distro. It is the personal runtime layer for **Axi**: local inference, persistent memory, private communication, desktop actions, and privacy-first defaults on top of the Linux host you choose.
+
+The first host the maintainer is using to validate the runtime is **CachyOS**, because it fits a real workstation profile — fresh packages, NVIDIA, Steam, modern kernels, gaming performance. CachyOS is a validation target, **not** the product identity, and LifeOS is not becoming a CachyOS distribution. Other modern Linux systems (Fedora, Arch, Ubuntu, NixOS, etc.) are future host profiles.
 
 Public docs use a simple maturity taxonomy so repo capabilities are not confused with default shipped behavior:
 
 - **Validated on host** - integrated and observed working on a real machine recently
 - **Integrated in repo** - wired in code and runtime, but not recently re-validated on a real host
 - **Experimental / partial** - foundation exists, but the end-to-end product path is still incomplete
-- **Shipped disabled / feature-gated** - present in repo, but not compiled or enabled by default in the standard image
+- **Shipped disabled / feature-gated** - present in repo, but not compiled or enabled by default in the standard runtime/image path
+- **Legacy / archived** - belongs to an earlier Fedora bootc or NixOS direction and is not the current canonical product path
 
 LifeOS is built in Mexico and developed in the open for users, contributors, and supporters anywhere.
 
 ## What Makes LifeOS Different
 
-- **OS-level architecture** - not just an app inside another OS; the project targets kernel, systemd, GPU, hardware, and desktop surfaces directly
-- **Local AI first** (`validated on host`) - local inference via llama.cpp is part of the current real product path
+- **Personal runtime layer** - LifeOS focuses on memory, agents, local tools, communication surfaces, and background jobs over Linux instead of owning the kernel, driver, package, and desktop base
+- **Local AI first** (`validated on host`) - local inference via llama.cpp is part of the current runtime path on a real Linux host
 - **Encrypted local memory foundations** (`integrated in repo`) - encrypted memory is a core design pillar, with public docs kept conservative about what is fully validated end-to-end today
-- **Immutable + rollback base** (`integrated in repo`) - bootc-style atomic updates and rollback shape the platform direction, while install/update validation is still an active focus
+- **Host-aware runtime operations** (`integrated in repo`) - watchdog, sentinel, circuit breaker, runtime profiles, and guarded maintenance workflows exist in the repo; bootc rollback/update work is now legacy/prototype infrastructure, not the current product direction
 - **Desktop control tooling** (`integrated in repo`) - the repo includes tools for windows, apps, clipboard, browser, LibreOffice, COSMIC desktop, and accessibility trees
 - **Provider routing** (`integrated in repo`) - multiple LLM providers are wired with privacy-aware routing policies
 - **Interaction surfaces** - SimpleX is the privacy-first remote channel (`simplex_bridge.rs` + `simplex-chat.service`, E2E encrypted, no phone number required); the local dashboard (`http://127.0.0.1:8081/dashboard`) is the in-host web UI (`integrated in repo`); the `lifeos-desktop` companion binary (`desktop/` crate) provides the system tray icon and wake-word listener as a per-user host service, bridging the containerized daemon with Wayland/D-Bus surfaces
 - **Voice: Kokoro-82M** (`integrated in repo`) - 50+ voices, Apache 2.0, CPU-only inference via `lifeos-tts.service` on `:8084`; dashboard voice selector lets users pick and preview any voice; SimpleX voice replies send OGG attachments when you send Axi a voice note
 - **Reliability layers** (`integrated in repo`) - watchdog, sentinel, circuit breaker, safe mode, and config rollback exist, but not every repair flow is equally mature
-- **Security baseline** (`integrated in repo`) - the image ships firewalld, auditd, DNS-over-TLS, SSH hardening, and related guardrails; broader hardening claims should be read as a baseline, not as a finished benchmark story. A read-only `GET /api/security/alerts` endpoint (localhost-only, no auth) exposes the in-memory ring buffer of recent security monitor events for the dashboard
+- **Security baseline** (`integrated in repo`) - the legacy image path includes firewalld, auditd, DNS-over-TLS, SSH hardening, and related guardrails; current runtime claims should be read as local-first service hardening, not as a finished distro benchmark story. A read-only `GET /api/security/alerts` endpoint (localhost-only, no auth) exposes the in-memory ring buffer of recent security monitor events for the dashboard
 - **GPU Game Guard with per-profile model swap** (`validated on host`) - when a game grabs the GPU, lifeosd swaps Axi from Qwen3.5-9B (full GPU) to Qwen3.5-4B in CPU **keeping the same 131K-token context** (on 64GB+ RAM hosts) so tool-calling and long-conversation memory stay intact instead of degrading to a 4K fallback. The runtime profile is auto-tuned per hardware via a microbenchmark; the 9B+GPU profile is restored when the game closes
-- **Flatpak auto-update** (`validated on host`) - updates run automatically with guards for active gaming sessions, battery level, and metered network connections
-- **Nvidia GL extension auto-sync** (`validated on host`) - host driver version is detected on boot and the matching GL extension layer is applied automatically; no manual intervention after driver updates
+- **Flatpak auto-update** (`legacy / host-integration experiment`) - the earlier OS path included guarded Flatpak updates for active gaming sessions, battery level, and metered network connections; this is no longer part of the v1 runtime promise
+- **Nvidia GL extension auto-sync** (`legacy / host-integration experiment`) - the earlier OS path included host-driver detection and matching GL extension sync; this is not a current cross-distro runtime guarantee
 - **Automated maintenance cleanup** (`integrated in repo`) - scheduled cleanup of podman image layers, Rust build cache, and orphaned Flatpak runtimes to keep disk usage in check
 - **Speaker identification** (`experimental / partial`) - WeSpeaker ONNX model is integrated for speaker diarization; end-to-end product path is still being completed
 - **Web search tool** (`integrated in repo`) - Axi's `web_search` tool queries Brave Search (free tier, ~2,000 queries/month at <https://api.search.brave.com/app/subscriptions/subscribe>). Configure via env `BRAVE_SEARCH_API_KEY=<token>` or `/var/lib/lifeos/config-checkpoints/working/config.toml` under `[web_search] brave_api_key = "..."`. Works on all channels including SimpleX.
@@ -39,15 +42,31 @@ LifeOS is built in Mexico and developed in the open for users, contributors, and
 - **Intent inference and ambiguity guard** (`integrated in repo`) - Axi infers when to record from data shape, not from keyword triggers. "116/78 59 pulsos" → three `vital_record` calls (sys/dia/heart_rate). "Soy alérgico a la lactosa" → `health_fact_add`. Ambiguous messages ("sentí una bola en el cuello") prompt Axi to ask before recording, instead of either silently saving a worry as a medical fact or ignoring it entirely
 - **Life Areas backends** (`integrated in repo`) - first-class domains for **Freelance** (clientes/sesiones/facturas/tarifas), **Finanzas**, **Vehículos**, **Viajes**, **Proyectos** — each with schemas, LLM tools, and REST endpoints. Freelance has a full dashboard tab; the others ship backend-only for now
 - **User-configurable AI context size** (`integrated in repo`) - the dashboard exposes `LIFEOS_AI_CTX_SIZE` so you can pin the llama.cpp ctx (default 128K) and the daemon honors it across restarts and benchmark cycles. The auto-benchmarker still tunes threads/batch/parallel per hardware
-- **VPS-first deploy with layer deltas** (`developer convenience`) - solo dev workflow: `~/bin/vps-prepare-laptop-update.sh` syncs GHCR → VPS local registry, `~/bin/vps-deploy-to-laptop.sh` makes the laptop pull only changed layers via WireGuard. Typical update: ~20 seconds vs ~8 minutes with the previous tar-archive flow. Not part of the bootc image — these are personal scripts in the maintainer's `~/bin/`
+- **VPS-first deploy with layer deltas** (`validated on host`) - solo dev workflow: `~/bin/vps-prepare-laptop-update.sh` syncs GHCR → VPS local registry, `~/bin/vps-deploy-to-laptop.sh` makes the maintainer laptop pull only changed layers via WireGuard. Typical update: ~20 seconds vs ~8 minutes with the previous tar-archive flow. These are personal maintainer scripts, not part of the public product path
 
-## Quick Start
+## Runtime Quick Start
+
+The current canonical developer path is the Rust runtime: `lifeosd`, the `life` CLI, the desktop companion, Axi tools, memory, and local APIs. Host packaging is in progress around the runtime pivot; see the first runtime onboarding guide in [`docs/operations/runtime-install.md`](docs/operations/runtime-install.md).
 
 ```bash
 make build      # Build CLI + daemon (Rust)
 make test       # Run repository test suite
 make lint       # Clippy + fmt
 ```
+
+> **Host note:** CachyOS is the current reference host for validation. It is not a required base system and LifeOS is not becoming a CachyOS distro.
+
+## Legacy / Transitional Build Paths
+
+The repository still contains earlier OS-image and NixOS transition work. Those paths are retained as auditable history and reusable infrastructure, but they are no longer the canonical product direction after the personal runtime pivot.
+
+### NixOS transition (`legacy / archived`)
+
+The Nix flake and modules from the NixOS spike are preserved at tag [`legacy/nixos-spike-v1`](https://github.com/) — restore with `git checkout legacy/nixos-spike-v1`. They are no longer in the active branch tree after the runtime pivot.
+
+### Fedora bootc image (`legacy / prototype`)
+
+The bootc image build path and `image/` tree document the original distro prototype. They are legacy/prototype paths and should not be read as the current shipped product promise.
 
 ### AI Tools
 
@@ -85,7 +104,8 @@ See the full feature matrix above and the operations docs under
 lifeos/
 ├── cli/        # `life` command-line tool (Rust)
 ├── daemon/     # `lifeosd` daemon and API runtime
-├── image/      # Containerfile + system files for bootc OS image
+├── desktop/    # `lifeos-desktop` companion: tray + host integration
+├── image/      # Legacy/prototype Fedora bootc OS image path
 ├── scripts/    # Build, CI, icon generation, verification scripts
 ├── docs/       # Strategy, architecture, operations, research
 ├── evidence/   # Phase closeout evidence (auditable history)
@@ -113,13 +133,15 @@ All documentation is organized in [`docs/`](docs/README.md):
 ## Tech Stack
 
 - **Language:** Rust 2021 (daemon + CLI)
-- **OS Base:** Fedora bootc (immutable, OCI-based) + per-service podman Quadlets
-- **Desktop:** COSMIC (System76) on Wayland
+- **Product layer:** Personal AI runtime over Linux, centered on `lifeosd`, Axi, local memory, tools, and host integration
+- **Reference host:** CachyOS (`validated on host` for the maintainer workflow); other distros are future host profiles, not separate product identities
+- **Legacy OS image:** Fedora bootc + COSMIC + per-service podman Quadlets (`legacy / prototype`)
+- **Transitional packaging:** Nix flake and NixOS VM work (`legacy / transitional` after the runtime pivot)
 - **AI Runtime:** llama.cpp / llama-server
 - **TTS:** Kokoro-82M (Apache 2.0) — runs as a podman Quadlet (`lifeos-tts.service`) pulling `ghcr.io/hectormr206/lifeos-tts:stable`, exposes `127.0.0.1:8084`
-- **Service architecture:** lean bootc host + ghcr.io side images per service
+- **Service architecture:** local runtime services with GHCR side images where useful
   (`lifeos-tts`, `lifeos-llama-embeddings`, `lifeos-lifeosd`, `lifeos-simplex-bridge`).
-  See `docs/strategy/prd-architecture-pivot-lean-bootc-quadlet.md`.
+  Earlier lean-bootc architecture notes remain as historical context in `docs/strategy/prd-architecture-pivot-lean-bootc-quadlet.md`.
 - **Database:** SQLite with WAL + sqlite-vec for embeddings
 - **API:** Axum REST + WebSocket on localhost:8081
 - **Protocols:** MCP (Model Context Protocol), AT-SPI2, D-Bus, CDP
@@ -131,4 +153,4 @@ Created by **Héctor Martínez Reséndiz** — [hectormr.com](https://hectormr.c
 ## License
 
 - **Daemon & CLI:** Apache-2.0
-- **OS Image:** GPL-3.0
+- **Legacy OS Image:** GPL-3.0

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,10 +14,10 @@ Start here based on what you need:
 
 | Folder | Purpose | Key Files |
 |--------|---------|-----------|
-| [strategy/](strategy/) | Strategic roadmap, phases, competition | unified-strategy |
+| [strategy/](strategy/) | Strategic roadmap, phases, competition | unified-strategy, prd-lifeos-personal-runtime-pivot |
 | [public/](public/) | Public-facing summaries for users and sponsors | roadmap, roadmap.es-mx |
 | [architecture/](architecture/) | Technical architecture and specs | ai-runtime, service-runtime, llm-providers, threat-model, update-channels |
-| [operations/](operations/) | Runbooks and operational guides | bootc-playbook, incident-response, build-iso, nvidia-secure-boot, system-admin |
+| [operations/](operations/) | Runbooks and operational guides | runtime-install, developer-bootstrap, update-flow, tts, bootc-playbook (legacy), incident-response |
 | [user/](user/) | End-user documentation | installation, user-guide, troubleshooting |
 | [branding/](branding/) | Visual identity and design | brand-guidelines, axi-visual-system, design-tokens, icon-theme-guide |
 | [privacy/](privacy/) | Privacy analysis per LLM provider | claude, gemini, openai, grok, kimi, qwen, zai + routing policy |

--- a/docs/architecture/ai-runtime.md
+++ b/docs/architecture/ai-runtime.md
@@ -1985,7 +1985,7 @@ LifeOS ya tiene captura sensorial (vision, audio, presencia) pero NO persiste lo
 
 - [ ] **Discord server:** Canales: general, dev, feedback, showcase, español, english
 - [ ] **Reddit:** Posts en r/linux, r/LocalLLaMA, r/rust, r/selfhosted, r/COSMIC
-- [ ] **Hacker News:** "Show HN: LifeOS — AI-native Linux distribution built in Rust"
+- [ ] **Hacker News:** "Show HN: LifeOS — a personal AI runtime for Linux built in Rust"
 - [ ] **Twitter/X:** Cuenta @LifeOS_dev — posts diarios con tips, progress, screenshots
 - [ ] **YouTube canal:** Videos semanales: tutoriales, updates, behind-the-scenes
 - [ ] **Telegram grupo:** Para usuarios de LifeOS en español

--- a/docs/operations/runtime-install.md
+++ b/docs/operations/runtime-install.md
@@ -1,0 +1,95 @@
+# LifeOS Runtime Install / Onboarding
+
+**Status:** v1 runtime install path is being defined  
+**Reference host:** CachyOS (`validated on host` for maintainer development), not a requirement
+
+LifeOS is now a personal AI runtime over Linux, not a distro replacement. This
+guide is the first install/onboarding map for that direction. It is intentionally
+conservative: when a command or package flow is not ready in the repo, it is
+marked as a **pending/design target** instead of presented as shipped behavior.
+
+## Quick Path
+
+| Step | Status | Action |
+|------|--------|--------|
+| Build the runtime from source | Integrated in repo | `make build` from the repo root builds the Rust CLI and daemon. |
+| Run tests before local changes | Integrated in repo | `make test` runs the repository test suite. |
+| Run lint/format checks | Integrated in repo | `make lint` is the intended gate; local toolchain dependencies must be installed first. |
+| Install host services | Pending/design target | A supported installer/package flow is not finalized yet. Do not assume a one-command install. |
+| Enable user/system services | Pending/design target | Service unit installation and enablement are still being shaped for v1 runtime packaging. |
+
+## Prerequisites
+
+| Requirement | Maturity | Notes |
+|-------------|----------|-------|
+| Modern Linux host | Design target | CachyOS is the first reference host. Other distros are future host profiles, not separate products. |
+| Rust toolchain | Integrated in repo | Required to build `life`, `lifeosd`, and `lifeos-desktop` from source today. |
+| Podman or compatible container runtime | Integrated in repo | Used by runtime service images and Quadlet-based service definitions where applicable. |
+| systemd user services | Design target | The runtime model expects long-lived local services, but packaging/install automation is still in progress. |
+| Local model assets / service images | Partial | Exact first-run acquisition flow is still being defined per service. |
+
+## Install Format Decision
+
+The v1 runtime install format is **hybrid**:
+
+- **Native binaries** for the Rust components — `life`, `lifeosd`, and `lifeos-desktop` — packaged per-distro (AUR first for the CachyOS reference host). These need direct access to D-Bus, Wayland, sockets, and the local keyring, which native binaries make trivial.
+- **Containers (Podman)** for the heavy services with complex dependency trees — `llama-server`, `llama-embeddings`, `lifeos-tts` (Kokoro + PyTorch + CUDA), and `simplex-chat`. Containers keep these out of the per-distro packaging matrix and allow granular updates: changing agent code rebuilds a small Rust binary; changing a model swaps a single container image.
+
+This split is the canonical install model for the runtime pivot. Older `image/` (bootc) and `legacy/nixos-spike-v1` (NixOS flake) paths remain in repo/tag history for reference but are not the v1 install promise.
+
+## Target Services
+
+The v1 runtime onboarding should make these services understandable and
+verifiable. Availability depends on the current repo state and host setup.
+
+> **Host validation status (2026-05-12):** no service in this table has been validated end-to-end on the CachyOS reference host yet. `Integrated in repo` means the code exists and worked on the prior bootc image; runtime-on-CachyOS validation is part of PRD Phase 3, not yet executed. Treat this table as repository inventory, not as a "works on CachyOS" promise.
+
+
+| Service | Target address/path | Maturity | Purpose |
+|---------|---------------------|----------|---------|
+| `lifeosd` | UDS `/run/lifeos/lifeosd.sock` + TCP `127.0.0.1:8081` | Integrated in repo | Main daemon, REST API, Axi runtime, local tools, memory orchestration. |
+| `life` | CLI on `$PATH` | Integrated in repo | Local command-line interface. |
+| `lifeos-desktop` | User-session companion | Integrated in repo | Tray, wake-word listener, desktop/Wayland/D-Bus bridge. |
+| `llama-server` | `127.0.0.1:8082` | Integrated in repo | Local LLM inference via llama.cpp. |
+| `llama-embeddings` | `127.0.0.1:8083` | Integrated in repo | Local embedding service. |
+| `lifeos-tts` | `127.0.0.1:8084` | Integrated in repo | Kokoro-82M text-to-speech service. |
+| `simplex-chat` / bridge | `ws://127.0.0.1:5226` | Integrated in repo | Privacy-first remote channel for Axi. |
+
+## State Paths
+
+| Path | Maturity | Expected role |
+|------|----------|---------------|
+| `/var/lib/lifeos/` | Integrated in repo | Long-lived runtime state, local databases, config checkpoints, and service data. |
+| `/var/lib/lifeos/config-checkpoints/working/config.toml` | Integrated in repo | Working runtime configuration used by existing docs and services. |
+| `/run/lifeos/` | Integrated in repo | Runtime sockets and ephemeral process state. |
+| `$HOME/.config/systemd/user/` | Design target | User service drop-ins and enablement for per-user runtime components. |
+
+## Verification Checklist
+
+Use this checklist while the installer is still being defined.
+
+- [ ] Build succeeds with `make build`.
+- [ ] Tests pass with `make test` on a prepared development host.
+- [ ] Lint runs with `make lint` once Rust/TypeScript tooling is installed.
+- [ ] `life` is available on `$PATH` after the chosen local install/package step.
+- [ ] `lifeosd` starts and exposes its expected local API/socket.
+- [ ] Runtime state is written under `/var/lib/lifeos/`, not hidden in ad-hoc repo paths.
+- [ ] Optional services (`llama-server`, embeddings, TTS, SimpleX) are either healthy or explicitly disabled.
+- [ ] CachyOS-specific notes are treated as host validation evidence, not as product requirements.
+
+## Pending Installer Work
+
+The following are design targets, not supported public commands yet:
+
+- One-command runtime install.
+- Distro-specific packages or host profiles.
+- Automated first-run service enablement.
+- Model/service asset bootstrap.
+- Cross-distro validation matrix beyond the current reference host.
+
+## Legacy Note
+
+The Fedora bootc image and NixOS transition work remain in the repository as
+auditable history and reusable infrastructure. They are **legacy / transitional**
+after the LifeOS Runtime pivot. Do not read the old OS-image path as the current
+install promise for v1.

--- a/docs/public/roadmap.md
+++ b/docs/public/roadmap.md
@@ -1,12 +1,14 @@
 # LifeOS Public Roadmap
 
-Last updated: `2026-04-01`
+Last updated: `2026-05-11`
 
-LifeOS is an AI-native Linux distribution focused on:
+LifeOS is the personal operating system for your digital life: a local-first AI runtime over Linux focused on:
 
 - local-first intelligence
 - privacy by default
 - sovereign personal computing
+
+LifeOS runs over the Linux host you choose. CachyOS is the current reference host for validation, not the product identity; Fedora bootc and NixOS work are legacy/transitional paths after the runtime pivot.
 
 This roadmap is the public, readable version of where the project stands today and where it is going next.
 
@@ -37,12 +39,13 @@ LifeOS is still early. The goal here is not to pretend the system is finished, b
 
 These are the areas we are actively pushing forward right now.
 
-### 1. Stabilize the public beta foundation
+### 1. Stabilize the public runtime foundation
 
 We are making the real system more dependable on real hardware:
 
-- install and first-boot reliability
-- update and rollback confidence
+- local runtime onboarding
+- host validation on the reference machine
+- memory, SimpleX, and Axi continuity
 - runtime consistency
 - host validation of features that already exist in repo
 

--- a/docs/research/public-presence/README.md
+++ b/docs/research/public-presence/README.md
@@ -325,11 +325,11 @@ Short 3-step roadmap, not giant roadmap dump.
 
 **Subheadline**
 
-`LifeOS is an AI-native Linux distribution where your assistant runs on your own machine, remembers locally, and helps across your desktop without sending your life to the cloud.`
+`LifeOS is the personal operating system for your digital life: a local-first AI runtime over Linux where your assistant runs on your own machine, remembers locally, and helps across your desktop without sending your life to the cloud.`
 
 Safer variant if you want tighter truth alignment:
 
-`LifeOS is an AI-native Linux distribution exploring a local-first assistant that runs on your own machine, keeps core data local, and is being hardened across desktop control and remote interaction.`
+`LifeOS is a personal AI runtime over Linux exploring a local-first assistant that runs on your own machine, keeps core data local, and is being hardened across desktop control and remote interaction.`
 
 **Primary CTA**
 

--- a/docs/research/public-presence/landing-v1-brief.md
+++ b/docs/research/public-presence/landing-v1-brief.md
@@ -229,7 +229,7 @@ Un bloque muy claro:
 
 **Subheadline**
 
-`LifeOS is an AI-native Linux distribution exploring a local-first assistant that runs on your own machine, keeps core data local, and is being hardened across desktop control and remote interaction.`
+`LifeOS is a personal AI runtime over Linux exploring a local-first assistant that runs on your own machine, keeps core data local, and is being hardened across desktop control and remote interaction.`
 
 **Primary CTA**
 

--- a/docs/strategy/prd-lifeos-personal-runtime-pivot.md
+++ b/docs/strategy/prd-lifeos-personal-runtime-pivot.md
@@ -1,0 +1,360 @@
+# PRD — LifeOS Personal Runtime Pivot
+
+**Status:** Draft v1 · 2026-05-11  
+**Owner:** LifeOS Lab  
+**Decision:** LifeOS deja de competir como distro completa y pasa a ser un **sistema operativo para tu vida**: una capa/runtime Linux-first que corre sobre la distro que el usuario elija.
+
+---
+
+## 1. Resumen ejecutivo
+
+LifeOS no debe seguir intentando ganar en la capa de kernel, drivers, paquetes, imagen bootc o distribución base. Esa capa ya la hacen mejor Fedora, CachyOS, Arch, Ubuntu, NixOS y otros proyectos dedicados a operar sistemas Linux.
+
+La nueva tesis es:
+
+> **LifeOS es el sistema operativo para tu vida digital: una capa local-first sobre Linux que organiza memoria, contexto, agentes, comunicación privada y acciones en tu computadora sin reemplazar tu distro.**
+
+Esto preserva el nombre y la ambición de “LifeOS”, pero corrige el alcance técnico: LifeOS no pretende ser “otro Linux”. LifeOS pretende ser la capa personal de IA, memoria y agencia que vive arriba de Linux.
+
+La primera plataforma de referencia será el entorno real de Hector, empezando por CachyOS, porque resuelve mejor el daily driver: paquetes frescos, NVIDIA, Steam, kernel moderno y hardware al máximo. CachyOS es host de referencia, **no identidad del producto**.
+
+---
+
+## 2. Problema
+
+### El enfoque anterior
+
+LifeOS nació como una distribución Linux AI-native basada en Fedora bootc, COSMIC Desktop, servicios del sistema, imagen OCI, actualizaciones bootc y rollback.
+
+Después de meses de trabajo, el aprendizaje real fue claro:
+
+| Dolor | Impacto |
+|------|---------|
+| Rebuilds de imagen completa | Cada cambio pequeño podía arrastrar kernel, desktop, drivers y servicios. |
+| Acoplamiento a NVIDIA/desktop/bootc | El proyecto invertía energía en operar una distro, no en mejorar Axi. |
+| Laptop diaria como campo de pruebas | Programar y jugar quedaban condicionados por la estabilidad de LifeOS OS. |
+| Paquetes y drivers | Un programador/gamer necesita moverse rápido con Steam, NVIDIA, kernel y tooling moderno. |
+| Mensaje público difícil de sostener | “AI-native Linux distribution” obliga a demostrar una distro completa, no solo una experiencia inteligente. |
+
+### El problema real del usuario
+
+El usuario no necesita otra distro. Necesita que Axi:
+
+- recuerde sin olvidar silenciosamente;
+- entienda interrupciones y retome contexto;
+- hable por canales privados como SimpleX;
+- use memoria corta y larga;
+- delegue trabajo a subagentes para no bloquearse;
+- procese en background cuando el usuario no está mirando;
+- vea, escuche, hable y entienda el entorno local cuando el host lo permita;
+- respete la GPU, el gaming y los recursos de la máquina.
+
+Nada de eso requiere que LifeOS controle el kernel o sea la distro principal.
+
+---
+
+## 3. Objetivo
+
+Reposicionar LifeOS como un **runtime personal Linux-first** que se instala sobre cualquier distro moderna y entrega la experiencia de Axi.
+
+### Objetivos principales
+
+1. **Separar LifeOS de la distro base.** Fedora bootc, NixOS y CachyOS pasan a ser hosts o empaquetados, no la identidad central.
+2. **Preservar la marca “LifeOS”.** LifeOS sigue siendo un sistema operativo, pero en el sentido de sistema operativo personal/de vida digital, no kernel+distro.
+3. **Actualizar GitHub y la web pública.** El repo ya no debe presentarse como una imagen bootc que se construye y actualiza como producto principal.
+4. **Reducir el v1 a una demostración creíble.** Menos promesas, más loop funcional: Axi + memoria + acciones locales + SimpleX + host validation.
+5. **Mantener LifeOS Lab creíble.** El cambio se comunica como aprendizaje estratégico, no como abandono.
+
+---
+
+## 4. No objetivos
+
+- No construir una nueva distro completa basada en CachyOS.
+- No continuar la migración NixOS como camino principal del producto.
+- No mantener Fedora bootc como la promesa pública principal.
+- No prometer “multimodal always-on” como estable antes de validarlo.
+- No reescribir todo el backend antes de actualizar la narrativa pública.
+- No acoplar LifeOS a CachyOS; CachyOS es referencia, no dependencia.
+
+---
+
+## 5. Nueva definición de producto
+
+### Frase canónica
+
+> **LifeOS es un sistema operativo personal de IA para tu vida digital, instalado sobre Linux: memoria persistente, agencia local, comunicación privada y contexto continuo sin obligarte a cambiar de distro.**
+
+### Taglines posibles
+
+| Idioma | Tagline |
+|--------|---------|
+| ES | El sistema operativo para tu vida digital. |
+| ES | Tu memoria, tus agentes y tu contexto sobre el Linux que ya usás. |
+| EN | The personal operating system for your digital life. |
+| EN | Memory, agents, and context over the Linux you already use. |
+
+### Qué es LifeOS ahora
+
+| Capa | Responsabilidad |
+|------|-----------------|
+| Distro host | Kernel, drivers, paquetes, Steam, desktop base, hardware. |
+| LifeOS Runtime | Daemon local, memoria, herramientas, SimpleX, eventos, agentes, background jobs. |
+| Axi | Interfaz/orquestador conversacional. |
+| Web app/dashboard | Configuración, estado, memoria, conversaciones, controles y onboarding. |
+| Host profiles | Instaladores/configuración por distro: CachyOS primero, otras después. |
+
+---
+
+## 6. Arquitectura objetivo
+
+```text
+┌────────────────────────────────────────────┐
+│ Usuario                                    │
+│ - Chat local / web app                     │
+│ - SimpleX remoto privado                   │
+│ - Voz / escritorio / acciones              │
+└──────────────────────┬─────────────────────┘
+                       │
+┌──────────────────────▼─────────────────────┐
+│ Axi                                        │
+│ - Orquestador                              │
+│ - Delegación a subagentes                  │
+│ - Continuidad conversacional               │
+│ - Respuesta final al usuario               │
+└──────────────────────┬─────────────────────┘
+                       │
+┌──────────────────────▼─────────────────────┐
+│ LifeOS Runtime                             │
+│ - lifeosd                                  │
+│ - memoria local                            │
+│ - tools del sistema                        │
+│ - SimpleX bridge                           │
+│ - jobs/background processing               │
+│ - runtime profile / GPU guard              │
+└──────────────────────┬─────────────────────┘
+                       │
+┌──────────────────────▼─────────────────────┐
+│ Linux host                                 │
+│ CachyOS, Fedora, Ubuntu, Arch, NixOS, etc. │
+│ - kernel                                   │
+│ - drivers                                  │
+│ - desktop                                  │
+│ - Steam/gaming                             │
+│ - paquetes                                 │
+└────────────────────────────────────────────┘
+```
+
+---
+
+## 7. Producto v1
+
+El v1 NO debe intentar entregar toda la visión. Debe demostrar el loop único de LifeOS.
+
+### V1 mínimo creíble
+
+| Capability | Estado objetivo | Razón |
+|------------|-----------------|-------|
+| Axi local runtime | Funcional en host Linux | Es el punto de entrada al producto. |
+| Memoria persistente real | Guardar, recuperar y corregir memoria | Diferenciador contra chatbots que olvidan. |
+| SimpleX remote loop | Chat remoto privado con continuidad | Canal soberano y útil fuera de la laptop. |
+| Acciones locales seguras | Ejecutar tools limitadas y auditables | Demuestra agencia sin vender humo. |
+| CachyOS host profile | Instalación validada en una máquina real | Primer host de referencia para desarrollo diario. |
+| Dashboard/web app | Estado, configuración y onboarding básicos | Necesario para usuarios y demos públicas. |
+
+### Fuera de v1 estable
+
+- Visión por cámara always-on.
+- Captura permanente de pantalla/audio.
+- “Dreaming” avanzado sin definición operativa.
+- Marketplace de agentes.
+- Soporte oficial multi-distro completo.
+- ISO propia como canal principal.
+
+Estas capacidades pueden existir como experimentales, pero no deben ser la promesa estable inicial.
+
+---
+
+## 8. Implicaciones para GitHub
+
+El repo principal de LifeOS ya no debe abrir con “AI-native Linux distribution built on Fedora bootc”. Esa frase quedó histórica.
+
+### Cambios requeridos en README
+
+| Sección actual | Cambio requerido |
+|----------------|------------------|
+| Hero / descripción | Reemplazar distro bootc por runtime personal Linux-first. |
+| What Makes LifeOS Different | Cambiar “OS-level architecture” por “personal runtime layer”. |
+| Building with Nix | Mover a sección histórica/experimental; no canonical path. |
+| Quick Start bootc | Reemplazar por “Runtime quick start” cuando exista instalador. |
+| Repository Layout | Marcar `image/` como legacy/archived path si queda en repo. |
+| Tech Stack | Separar host OS de runtime stack. |
+| Update docs | Dejar claro que bootc update flow ya no es producto principal. |
+
+### Cambios requeridos en GitHub Actions
+
+| Workflow | Decisión |
+|----------|----------|
+| Rust CI/test/lint | Mantener. Es el core runtime. |
+| Docker/service images | Mantener si sirven para servicios del runtime. |
+| bootc image build/release | Archivar, desactivar o mover a manual/legacy. |
+| release channels bootc | Reescribir o congelar como legacy. |
+| nightly OS image | Desactivar hasta nueva decisión. |
+| truth/docs drift | Actualizar reglas para detectar claims obsoletos de distro. |
+
+### Nueva taxonomía pública
+
+Para evitar repetir el error de mezclar repo capability con producto estable:
+
+- **validated on host** — integrado y probado recientemente en hardware real.
+- **integrated in repo** — existe en código/runtime, pero no validado recientemente end-to-end.
+- **experimental** — base parcial o spike.
+- **legacy / archived** — pertenece al camino Fedora bootc/NixOS anterior.
+
+---
+
+## 9. Implicaciones para la web de LifeOS
+
+La landing actual también debe dejar de vender una distribución Linux como promesa central.
+
+### Cambios requeridos en copy
+
+| Área | Cambio |
+|------|--------|
+| SEO title | De “AI-native Linux” a “personal AI runtime for Linux”. |
+| Meta description | Enfatizar runtime/capa personal local-first. |
+| Hero | “AI that lives with you” puede quedarse; el body debe decir que corre sobre Linux. |
+| Proofs | Reemplazar “Immutable + rollback base” por “Runs over your Linux host”. |
+| Principles | Cambiar “AI-native operating system” por “personal operating system layer”. |
+| Roadmap | Pasar de estabilizar install/boot/update a estabilizar runtime/onboarding. |
+| GitHub CTA | Apuntar a la nueva narrativa del repo. |
+
+### Mensaje web recomendado
+
+> LifeOS is the personal operating system for your digital life: a local-first AI runtime that runs on Linux, remembers with you, acts through Axi, and keeps your context under your control.
+
+Versión español:
+
+> LifeOS es el sistema operativo para tu vida digital: un runtime de IA local-first que corre sobre Linux, recuerda con vos, actúa mediante Axi y mantiene tu contexto bajo tu control.
+
+---
+
+## 10. Implicaciones para LifeOS Lab
+
+Este pivot debe contarse como una evolución, no como fracaso.
+
+### Narrativa pública honesta
+
+> LifeOS Lab empezó explorando qué pasaría si la IA personal viviera en la capa del sistema operativo. Después de construir una base real con Fedora bootc, servicios locales, memoria, SimpleX y control de escritorio, la conclusión fue clara: el valor no está en reemplazar tu distro, sino en llevar esa capa personal a cualquier Linux moderno.
+
+### Cómo se preserva la credibilidad
+
+- No se borra la historia Fedora bootc; se archiva como aprendizaje.
+- No se afirma que LifeOS sea kernel/distro completa.
+- Se mantiene el término OS como metáfora de producto: sistema operativo para la vida digital.
+- Se publican estados reales por capability.
+- Se muestra un host real validado: CachyOS primero.
+
+---
+
+## 11. Roadmap de lanzamiento
+
+### Fase 0 — Decisión y freeze
+
+- [ ] Congelar nuevas inversiones en bootc como producto principal.
+- [ ] Congelar NixOS migration como spike histórico, no roadmap principal.
+- [ ] Mantener backups antes de tocar la laptop o borrar state.
+
+### Fase 1 — Narrativa pública
+
+- [ ] Actualizar README principal.
+- [ ] Actualizar landing page.
+- [ ] Agregar este PRD al índice de docs.
+- [ ] Marcar bootc/NixOS docs como legacy/transitional.
+- [ ] Crear una nota pública corta: “LifeOS is becoming a personal AI runtime for Linux”.
+
+### Fase 2 — GitHub/runtime cleanup
+
+- [ ] Revisar GitHub Actions y desactivar builds de imagen OS por default.
+- [ ] Mantener CI de Rust/runtime.
+- [ ] Separar workflows de imágenes de servicio vs imagen OS legacy.
+- [ ] Crear `docs/operations/runtime-install.md`.
+- [ ] Definir un primer instalador/profile para CachyOS.
+
+### Fase 3 — CachyOS host profile
+
+- [ ] Documentar prerequisitos: GPU/NVIDIA, audio, desktop, systemd user, Podman/Docker según decisión.
+- [ ] Instalar lifeosd + CLI + dashboard como runtime local.
+- [ ] Validar memoria persistente.
+- [ ] Validar SimpleX loop.
+- [ ] Validar GPU Game Guard o degradarlo a experimental si no se valida.
+
+### Fase 4 — Runtime v1 demo
+
+- [ ] Demo: usuario habla con Axi local.
+- [ ] Demo: Axi recuerda un dato y lo recupera después.
+- [ ] Demo: SimpleX interrumpe y luego la conversación original continúa.
+- [ ] Demo: una acción local segura se ejecuta con audit trail.
+- [ ] Demo: dashboard muestra estado del runtime.
+
+---
+
+## 12. Métricas de éxito
+
+| Métrica | Target |
+|---------|--------|
+| Mensaje público consistente | README, landing y docs no se contradicen. |
+| Bootc no es producto principal | Workflows OS image no corren por default. |
+| CachyOS validated host | Runtime probado en laptop real. |
+| Instalación reproducible | Documentación suficiente para repetir setup. |
+| Loop de memoria | Guardar/recuperar/corregir memoria funciona end-to-end. |
+| SimpleX loop | Usuario puede escribir remoto y Axi responde con contexto. |
+| Demo pública | Una demo muestra el loop sin prometer capacidades no validadas. |
+
+---
+
+## 13. Riesgos
+
+| Riesgo | Severidad | Mitigación |
+|--------|-----------|------------|
+| Parecer que LifeOS “abandonó” el OS | Alta | Comunicar como evolución de arquitectura, no retirada. |
+| CachyOS absorbe la identidad | Media | Usar “reference host”, no “LifeOS basado en CachyOS”. |
+| Scope v1 demasiado grande | Alta | V1 limitado a Axi + memoria + SimpleX + acciones locales + dashboard. |
+| Multimodalidad suena a humo | Media | Clasificar como experimental hasta validación real. |
+| Docs antiguas contradicen la nueva narrativa | Alta | Marcar legacy y actualizar README/web primero. |
+| GitHub Actions siguen publicando OS images | Media | Desactivar builds automáticos de bootc OS y documentar legacy path. |
+
+---
+
+## 14. Decisiones tomadas
+
+- LifeOS no será, por ahora, una distro completa como producto principal.
+- CachyOS será el primer host de referencia de desarrollo diario.
+- Fedora bootc queda como historia técnica/legacy, no como promesa pública central.
+- NixOS queda como spike útil, no como dirección principal inmediata.
+- LifeOS se comunicará como sistema operativo personal/de vida digital.
+- El primer lanzamiento público debe enfocarse en narrativa + runtime loop, no en ISO.
+
+---
+
+## 15. Decisiones pendientes
+
+- [ ] ¿El runtime se instala primero como binarios nativos, contenedores, systemd user services o mezcla?
+- [ ] ¿La web app vive dentro de `lifeosd` o como app separada empaquetada?
+- [ ] ¿Cuál es el primer set estable de tools locales?
+- [ ] ¿Qué claims actuales del README se degradan a experimental?
+- [ ] ¿Se archivan workflows bootc o se dejan manuales para investigación?
+- [ ] ¿Cómo se va a nombrar públicamente el canal legacy? (`LifeOS OS Legacy`, `LifeOS bootc prototype`, etc.)
+
+---
+
+## 16. Primer paso de implementación
+
+El primer PR no debe tocar lógica de runtime. Debe ser un PR de narrativa y verdad pública:
+
+1. Actualizar README principal.
+2. Actualizar landing page copy.
+3. Linkear este PRD desde `docs/README.md`.
+4. Marcar NixOS/bootc docs como transitional/legacy.
+5. No borrar workflows todavía; solo dejar claro qué está activo y qué queda legacy.
+
+Después de ese PR, el segundo PR debe revisar GitHub Actions y separar runtime CI de OS image legacy.

--- a/docs/user/installation.md
+++ b/docs/user/installation.md
@@ -1,8 +1,10 @@
 # LifeOS Installation Guide
 
+> **Transition notice — runtime pivot in progress.** LifeOS is moving from a Fedora bootc distro prototype to a personal AI runtime / operating-system layer over Linux. This guide still documents the bootc installation path because the runtime installer is not finalized yet; an early draft of the new direction lives in [`docs/operations/runtime-install.md`](../operations/runtime-install.md). Use this guide if you are installing or operating the legacy bootc image today; expect it to be retired as the canonical entry point once the runtime install path is ready.
+
 This guide covers installing LifeOS on bare metal or virtual machines.
 
-LifeOS is an immutable, AI-native Linux distribution built on Fedora bootc. It ships with **COSMIC Desktop**, a modern Wayland-native desktop environment developed by System76 (the team behind Pop!\_OS), designed for speed, composability, and a clean user experience.
+The Fedora bootc image documented here shipped with **COSMIC Desktop**, a modern Wayland-native desktop environment developed by System76 (the team behind Pop!\_OS), designed for speed, composability, and a clean user experience.
 
 ## Table of Contents
 


### PR DESCRIPTION
## Summary

- Repositions LifeOS from *AI-native Linux distribution built on Fedora bootc* to **personal AI runtime / operating-system layer over Linux**. Adopts the strategy in `docs/strategy/prd-lifeos-personal-runtime-pivot.md`.
- Narrative-only PR per PRD §16. Touches docs and agent context files; no Rust code, no workflows. The CI cleanup (PRD §11 Fase 2) lives in a separate PR.
- CachyOS is documented as the first validation host, not the product identity. Bootc and NixOS work are preserved (tag `legacy/nixos-spike-v1` for the NixOS spike, `image/` tree for bootc) but no longer presented as the canonical path.

## Key changes

- **README**: new hero, runtime quick start, legacy/transitional build paths section pointing to `legacy/nixos-spike-v1`, maturity taxonomy expanded with `legacy / archived`, repository layout updated (`nix/` no longer present on `main`).
- **`docs/strategy/prd-lifeos-personal-runtime-pivot.md`** (new): source PRD with full rationale, V1 scope, roadmap, risks, and pending decisions.
- **`docs/operations/runtime-install.md`** (new): first runtime-install draft. Includes the install format decision (**hybrid native binaries + containers**) and an explicit *"no service validated end-to-end on CachyOS yet"* caveat so the maturity table reads as repo inventory, not a host-validation promise.
- **`docs/user/installation.md`**: transition banner on top of the bootc install guide. Guide kept usable until `runtime-install.md` becomes the canonical entry point.
- `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`: agent context reflects the pivot.
- `docs/architecture/ai-runtime.md`, `docs/public/roadmap.md`, `docs/research/public-presence/*`, `docs/README.md`: wording aligned with the runtime pivot.

## Out of scope (separate PR)

CI cleanup that disables OS-image build/release workflows (PRD §11 Fase 2) — see #N (workflows PR, link will be added).

## Test plan

- [ ] Read README top-to-bottom; verify no remaining "AI-native Linux distribution" claims and no implication that LifeOS is "becoming CachyOS".
- [ ] Open `docs/operations/runtime-install.md`; confirm install format decision and host-validation caveat are visible.
- [ ] Open `docs/user/installation.md`; confirm the transition banner points to the new runtime guide.
- [ ] Verify `docs/strategy/prd-lifeos-personal-runtime-pivot.md` is linked from `docs/README.md`.
- [ ] Confirm agent files (CLAUDE/AGENTS/GEMINI) are consistent and no longer call LifeOS a Fedora bootc distribution.