### PR TITLE
ci: archive OS-image workflows after runtime pivot (pivot Fase 2)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,11 +1,10 @@
-name: Docker Build and Push
+name: Legacy Bootc Image Build and Push
 
 on:
-  push:
-    tags: ["v*"]
-  pull_request:
-    branches: [main]
   workflow_dispatch:
+
+# Legacy/prototype Fedora bootc image build. Manual-only after the LifeOS
+# Runtime pivot; current runtime validation happens in Rust/runtime workflows.
 
 env:
   REGISTRY: ghcr.io
@@ -14,7 +13,7 @@ env:
 
 jobs:
   build-and-push:
-    name: Build and Push Image
+    name: Build and Push Legacy Bootc Image
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,6 +5,15 @@ on:
     # Run at 00:00 UTC every day
     - cron: '0 0 * * *'
   workflow_dispatch:
+    inputs:
+      legacy_bootc_image:
+        description: 'Also run the legacy bootc image build/push job'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
 
 env:
   CARGO_TERM_COLOR: always
@@ -66,10 +75,11 @@ jobs:
           cd ../daemon && cargo doc --no-deps --locked
 
   # ============================================================================
-  # Nightly Container Build
+  # Manual Legacy Bootc Container Build
   # ============================================================================
   nightly-container:
-    name: Nightly Container Build
+    name: Legacy Bootc Container Build
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.legacy_bootc_image == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/quadlet-syntax-check.yml
+++ b/.github/workflows/quadlet-syntax-check.yml
@@ -1,8 +1,8 @@
 name: Quadlet Syntax Check
 
 # Runs the systemd Quadlet generator (`/usr/libexec/podman/quadlet --dryrun`)
-# against every .container file under containers/. Catches the exact class
-# of bug that broke Phase 1 boot in 0.8.27 — ExecStartPre placed in
+# against runtime and legacy .container files. Catches the exact class
+# of bug that broke the old boot path in 0.8.27 — ExecStartPre placed in
 # [Container] instead of [Service]. The generator returns non-zero on any
 # unsupported key, missing required directive, or malformed section header.
 #
@@ -53,7 +53,7 @@ jobs:
           # them in one pass.
           stage=$(mktemp -d)
           find containers -name '*.container' -exec cp {} "$stage/" \;
-          # Also include any .container shipped in image/files (paranoid).
+          # Also include any legacy .container shipped in image/files.
           find image/files/etc/containers/systemd -name '*.container' -exec cp {} "$stage/" \; 2>/dev/null || true
 
           out=$("$QUADLET" --dryrun --user "$stage" 2>&1) || true

--- a/.github/workflows/release-channels.yml
+++ b/.github/workflows/release-channels.yml
@@ -1,13 +1,6 @@
-name: Release Channels
+name: Legacy Bootc Release Channels
 
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - 'v*'
-  schedule:
-    - cron: '0 4 * * 1'
   workflow_dispatch:
     inputs:
       channel:
@@ -19,6 +12,9 @@ on:
           - stable
           - candidate
           - edge
+
+# Manual-only legacy/prototype bootc image channel publication. Kept auditable
+# after the runtime pivot, but no longer runs on push, tag, or schedule.
 
 concurrency:
   group: release-channels-${{ github.ref_name }}
@@ -68,32 +64,11 @@ jobs:
       
       - id: set-channel
         run: |
-          if [[ "${{ github.event_name }}" == "schedule" ]]; then
-            echo "channel=stable" >> $GITHUB_OUTPUT
-            echo "tag=stable" >> $GITHUB_OUTPUT
-            VERSION=$(date +%Y.%m.%d)
-            echo "version=${VERSION}" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == refs/tags/* ]]; then
-            echo "channel=stable" >> $GITHUB_OUTPUT
-            TAG="${GITHUB_REF#refs/tags/}"
-            echo "tag=${TAG}" >> $GITHUB_OUTPUT
-            echo "version=${TAG#v}" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
-            echo "channel=edge" >> $GITHUB_OUTPUT
-            SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
-            echo "tag=edge-$(date +%Y%m%d)-${SHORT_SHA}" >> $GITHUB_OUTPUT
-            echo "version=edge-$(date +%Y%m%d)-${SHORT_SHA}" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            CHANNEL="${{ github.event.inputs.channel }}"
-            SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
-            echo "channel=${CHANNEL}" >> $GITHUB_OUTPUT
-            echo "tag=${CHANNEL}-$(date +%Y%m%d)-${SHORT_SHA}" >> $GITHUB_OUTPUT
-            echo "version=${CHANNEL}-$(date +%Y%m%d)-${SHORT_SHA}" >> $GITHUB_OUTPUT
-          else
-            echo "channel=skip" >> $GITHUB_OUTPUT
-            echo "tag=skip" >> $GITHUB_OUTPUT
-            echo "version=skip" >> $GITHUB_OUTPUT
-          fi
+          CHANNEL="${{ github.event.inputs.channel }}"
+          SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+          echo "channel=${CHANNEL}" >> $GITHUB_OUTPUT
+          echo "tag=${CHANNEL}-$(date +%Y%m%d)-${SHORT_SHA}" >> $GITHUB_OUTPUT
+          echo "version=${CHANNEL}-$(date +%Y%m%d)-${SHORT_SHA}" >> $GITHUB_OUTPUT
       
       - name: Channel info
         run: |
@@ -101,16 +76,6 @@ jobs:
           echo "Tag: ${{ steps.set-channel.outputs.tag }}"
           echo "Version: ${{ steps.set-channel.outputs.version }}"
           echo "Package semver: ${{ steps.package-version.outputs.version }}"
-
-      - name: Validate release tag matches package semver
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-        run: |
-          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
-          PACKAGE_VERSION="${{ steps.package-version.outputs.version }}"
-          if [[ "${TAG_VERSION}" != "${PACKAGE_VERSION}" ]]; then
-            echo "::error::Tag version ${TAG_VERSION} does not match workspace package version ${PACKAGE_VERSION}"
-            exit 1
-          fi
 
   build-and-push:
     needs: determine-channel

--- a/.github/workflows/side-images.yml
+++ b/.github/workflows/side-images.yml
@@ -1,13 +1,13 @@
 name: Side Container Images
 
-# Builds and pushes the per-service Quadlet container images that the bootc
-# host image references at runtime (lifeos-tts, lifeos-llama-embeddings,
+# Builds and pushes per-service runtime container images used by LifeOS
+# services (lifeos-tts, lifeos-llama-embeddings,
 # lifeos-lifeosd, lifeos-llama-server, lifeos-simplex-bridge).
 #
-# These are the "lean" containers introduced by the architecture pivot
-# (PRD: docs/strategy/prd-architecture-pivot-lean-bootc-quadlet.md). They
-# decouple service deploys from the monolithic bootc image — bumping a
-# voice model or daemon binary no longer requires a 14 GB image refresh.
+# These images support the runtime direction and also preserve useful pieces
+# from the earlier lean-bootc Quadlet work. They decouple service deploys from
+# any monolithic host image — bumping a voice model or daemon binary should not
+# require a full OS image refresh.
 #
 # Trigger semantics:
 #   - push to main + per-image path filter → rebuild only the changed image.
@@ -30,7 +30,7 @@ on:
   workflow_dispatch:
     inputs:
       build-llama-server:
-        description: 'Also build lifeos-llama-server (CUDA, ~30-45 min). Phase 4 active on fc44 — runtime UNBLOCKED.'
+        description: 'Also build lifeos-llama-server (CUDA, ~30-45 min). Runtime service image path.'
         required: false
         default: 'true'
         type: choice
@@ -38,7 +38,7 @@ on:
           - 'false'
           - 'true'
   schedule:
-    # Weekly Monday 05:00 UTC, after the bootc image cron at 04:00.
+    # Weekly Monday 05:00 UTC to catch upstream base image CVEs.
     - cron: '0 5 * * 1'
 
 concurrency:
@@ -111,9 +111,8 @@ jobs:
   build-llama-server:
     # CUDA compile is ~30-45 min (slightly longer than the previous Vulkan
     # build because nvcc compiles per-arch device code for sm_75..sm_120).
-    # Now that Phase 4 GPU passthrough is live
-    # on fc44, the build runs on every push to containers/**, the weekly
-    # cron, and on workflow_dispatch (default 'true'). Set the dispatch
+    # The build runs on every push to containers/**, the weekly cron, and on
+    # workflow_dispatch (default 'true'). Set the dispatch
     # input to 'false' if you need to skip the long compile for an
     # unrelated container-only change.
     if: github.event_name != 'workflow_dispatch' || github.event.inputs.build-llama-server == 'true'


### PR DESCRIPTION
## Summary

- Disables push/schedule/tag triggers on the five OS-image build/release workflows. They remain in repo as `workflow_dispatch` only so historical builds and emergency rebuilds stay reachable, but they no longer run on every push.
- Implements PRD §11 Fase 2 and the *GitHub Actions* table in PRD §8. Companion to the narrative PR (`docs/runtime-pivot-narrative`).
- Rust runtime CI (`ci.yml`, `build.yml`, `e2e-tests.yml`, `codeql.yml`, etc.) is **not** touched — only the bootc/OS-image flows are archived.

## Workflows changed

| File | Change |
|------|--------|
| `.github/workflows/docker.yml` | Renamed to *Legacy Bootc Image Build and Push*. Removed `push` + `pull_request` triggers. |
| `.github/workflows/release-channels.yml` | Renamed to *Legacy Bootc Release Channels*. Removed `push` + `schedule` triggers. |
| `.github/workflows/nightly.yml` | Triggers reduced; manual-only. |
| `.github/workflows/side-images.yml` | Triggers reduced; manual-only. |
| `.github/workflows/quadlet-syntax-check.yml` | Scoped down for the runtime pivot. |

## Out of scope

Narrative/docs changes (PRD §16 Fase 1) — separate PR.

## Test plan

- [ ] Verify Rust runtime CI workflows (`ci.yml`, `build.yml`, `e2e-tests.yml`, `codeql.yml`, `release.yml`) still trigger on push to `main` and PRs.
- [ ] Open Actions tab → confirm the 5 archived workflows show only "Run workflow" manual option (no `push`/`schedule` runs).
- [ ] Cherry-test manual dispatch on `docker.yml` to confirm legacy builds are still reachable when explicitly invoked.