### PR TITLE
docs(readme): clarify validated-on-host badges refer to prior bootc image

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ LifeOS is built in Mexico and developed in the open for users, contributors, and
 
 ## What Makes LifeOS Different
 
+> **Note on `validated on host` badges below.** The current `validated on host` labels refer to validation on the prior Fedora bootc image, which was the canonical product path before the runtime pivot. CachyOS reference-host re-validation is part of PRD Phase 3 and is not yet complete. Treat these badges as historical evidence that the capability worked on a real machine, not as a current cross-distro guarantee.
+
 - **Personal runtime layer** - LifeOS focuses on memory, agents, local tools, communication surfaces, and background jobs over Linux instead of owning the kernel, driver, package, and desktop base
 - **Local AI first** (`validated on host`) - local inference via llama.cpp is part of the current runtime path on a real Linux host
 - **Encrypted local memory foundations** (`integrated in repo`) - encrypted memory is a core design pillar, with public docs kept conservative about what is fully validated end-to-end today


### PR DESCRIPTION
## Summary

Adds one note above the README feature list clarifying that `validated on host` badges reflect validation on the prior Fedora bootc image, not on the CachyOS reference host introduced by the runtime pivot.

## Why

After the pivot in #97, the README still implicitly suggested current cross-distro validation. CachyOS re-validation is PRD Phase 3 and not yet complete. The note keeps the README honest without degrading every individual badge.

## Scope

- 1 file, 2 lines added.
- Closes the last loose end from the §15 decision #4 audit ("README claims to degrade").
- Companion to #97 (narrative) and #98 (CI cleanup). Together: Fase 1 + Fase 2 of the runtime pivot fully landed.

## Test plan

- [ ] Open README; verify the note appears immediately above `## What Makes LifeOS Different` feature list.
- [ ] Confirm no other text was modified.