### PR TITLE
docs(cachyos): runtime-install rewrite + README badges (Phase 3 final)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,8 @@ docs/archive/           ← Deprecated docs (historical only)
 
 | Topic | Doc |
 |-------|-----|
-| Workstation bootstrap (dev sudo policy, RUST_LOG dropin, sentinel) | [`docs/operations/developer-bootstrap.md`](docs/operations/developer-bootstrap.md) |
+| **CachyOS install — guía canónica para nuevos usuarios** | [`docs/operations/runtime-install.md`](docs/operations/runtime-install.md) |
+| Workstation bootstrap (dev sudo policy, RUST_LOG dropin, CachyOS workflow) | [`docs/operations/developer-bootstrap.md`](docs/operations/developer-bootstrap.md) |
 | Update check/stage/apply cycle | [`docs/operations/update-flow.md`](docs/operations/update-flow.md) |
 | Contributor quickstart | [`docs/contributor/bootstrap-dev.md`](docs/contributor/bootstrap-dev.md) |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,7 @@ sudo bash scripts/build-iso.sh
 | New feature in daemon | `docs/user/user-guide.md` + `README.md` feature list |
 | New CLI command | `docs/user/user-guide.md` |
 | Containerfile (new package/service) | `docs/user/installation.md` if user-visible |
+| CachyOS PKGBUILD or `life init` flow | `docs/operations/runtime-install.md` (canonical CachyOS guide) |
 | SimpleX bridge | `docs/operations/simplex-features.md` |
 | Security config | `docs/user/installation.md` Security Defaults section |
 | Architecture change | `docs/architecture/` relevant file |
@@ -88,6 +89,7 @@ Instead of reading everything, use `docs/README.md` as index:
 
 | Topic | Doc |
 |-------|-----|
-| Workstation bootstrap (dev sudo policy, RUST_LOG dropin, sentinel) | `docs/operations/developer-bootstrap.md` |
+| **CachyOS install (nuevos usuarios, referencia canónica)** | `docs/operations/runtime-install.md` |
+| Workstation bootstrap (dev sudo policy, RUST_LOG dropin, CachyOS workflow) | `docs/operations/developer-bootstrap.md` |
 | Update check/stage/apply cycle | `docs/operations/update-flow.md` |
 | Contributor quickstart | `docs/contributor/bootstrap-dev.md` |

--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ LifeOS is built in Mexico and developed in the open for users, contributors, and
 
 ## What Makes LifeOS Different
 
-> **Note on `validated on host` badges below.** The current `validated on host` labels refer to validation on the prior Fedora bootc image, which was the canonical product path before the runtime pivot. CachyOS reference-host re-validation is part of PRD Phase 3 and is not yet complete. Treat these badges as historical evidence that the capability worked on a real machine, not as a current cross-distro guarantee.
+> **V1 tool set (Fase 3):** los cinco tools de aceptación V1 — `memory_save`, `memory_search`, `web_search`, `vital_record`, `health_fact_add` — mantienen el badge `integrated in repo` hasta que se complete la validación de aceptación en hardware CachyOS real. El harness de validación existe en `scripts/validate-cachyos.sh`; los resultados de hardware real actualizarán estos badges a `validated on host (CachyOS)`.
+>
+> **GPU Game Guard:** actualmente con badge `validated on host` (validado en bootc legacy). El badge pasa a `experimental` si la validación en hardware CachyOS (REQ-B5) no puede confirmarse. Ver procedimiento manual en [`docs/operations/runtime-install.md §5.5`](docs/operations/runtime-install.md#55--b5-gpu-game-guard).
+>
+> **Note on `validated on host` badges below.** The legacy `validated on host` labels refer to validation on the prior Fedora bootc image. CachyOS reference-host re-validation is part of PRD Phase 3 — the harness is in `scripts/validate-cachyos.sh`. Treat current badges as historical evidence until hardware re-validation is complete.
 
 - **Personal runtime layer** - LifeOS focuses on memory, agents, local tools, communication surfaces, and background jobs over Linux instead of owning the kernel, driver, package, and desktop base
 - **Local AI first** (`validated on host`) - local inference via llama.cpp is part of the current runtime path on a real Linux host
@@ -48,7 +52,7 @@ LifeOS is built in Mexico and developed in the open for users, contributors, and
 
 ## Runtime Quick Start
 
-The current canonical developer path is the Rust runtime: `lifeosd`, the `life` CLI, the desktop companion, Axi tools, memory, and local APIs. Host packaging is in progress around the runtime pivot; see the first runtime onboarding guide in [`docs/operations/runtime-install.md`](docs/operations/runtime-install.md).
+The current canonical developer path is the Rust runtime: `lifeosd`, the `life` CLI, the desktop companion, Axi tools, memory, and local APIs. For the full CachyOS install guide (PKGBUILDs, `life init`, NVIDIA CDI, V1 validation), see [`docs/operations/runtime-install.md`](docs/operations/runtime-install.md).
 
 ```bash
 make build      # Build CLI + daemon (Rust)

--- a/docs/architecture/quadlet-architecture.md
+++ b/docs/architecture/quadlet-architecture.md
@@ -285,6 +285,64 @@ lifeos-desktop (host, user-scope)
 
 Installed at `/usr/lib/systemd/user/lifeos-desktop.service`. Auto-enabled globally via symlink in `/usr/lib/systemd/user/default.target.wants/` and per-user via `/etc/skel/.config/systemd/user/default.target.wants/`. `Restart=on-failure` with the companion's own retry logic handles daemon restarts cleanly.
 
+## Arquitectura user-scope en CachyOS
+
+En el perfil de host CachyOS (Fase 3), **todos los Quadlets corren en
+user-scope** (`systemd --user`), a diferencia del path de bootc legacy donde
+los Quadlets eran system-scope. Este cambio elimina la necesidad de reglas
+polkit y permite a un usuario no privilegiado gestionar el runtime completo.
+
+### Por qué funciona el user-scope con GPU CDI
+
+Rootless podman + CDI funciona en CachyOS dado que:
+
+1. `/dev/nvidia*` tiene modo 666 por defecto (driver NVIDIA estándar en Arch)
+2. `/etc/cdi/nvidia.yaml` es legible por cualquier usuario tras el
+   `nvidia-ctk cdi generate` inicial
+3. CachyOS usa cgroup v2 con el controlador `devices` delegado a los usuarios
+   (comportamiento default con systemd 254+)
+4. El Quadlet `AddDevice=nvidia.com/gpu=all` funciona igual rootless que
+   rootful con podman 5.x
+
+### Instalador de Quadlets user-scope
+
+Los Quadlets fuente se instalan en `/usr/share/lifeos/quadlets/*.container`
+por el paquete `lifeos-containers`. El helper `lifeos-quadlet-install --user`
+crea `~/.config/containers/systemd/` y crea un symlink por cada `.container`.
+Los symlinks garantizan que las actualizaciones de `pacman -U` propagen los
+cambios sin re-ejecutar el helper.
+
+`life init` invoca este helper automáticamente si los symlinks no existen
+todavía.
+
+### Game Guard en user-scope (sin polkit)
+
+El Game Guard en `daemon/src/ai_runtime_profile.rs` usa
+`systemctl --user restart lifeos-llama-server.service` para hacer el swap de
+perfil de modelo. Como todos los Quadlets corren en user-scope, esta llamada
+no requiere polkit ni wrappers de sudo. El código ya maneja ambos scopes
+(`LlamaServiceScope::User` en `ai_runtime_profile.rs:59`) y selecciona
+user-scope cuando el unit existe como servicio de usuario.
+
+### Dual-scope en el código del daemon
+
+`daemon/src/ai_runtime_profile.rs` expone `LlamaServiceScope::{System, User}`
+(línea 59). La función `ensure_llama_service_runtime_env_files()` (línea 1107)
+detecta el scope probando si existe el unit de usuario primero.
+`systemctl_command(scope)` (línea 1190) inyecta `--user` cuando corresponde.
+No se necesitaron cambios al código del daemon para soportar user-scope —
+ya estaba implementado.
+
+### Diferencia respecto al path bootc legacy
+
+| Aspecto | CachyOS (Fase 3) | bootc legacy |
+|---------|-----------------|-------------|
+| Scope de Quadlets | user-scope | system-scope |
+| Gestión polkit | no necesaria | `org.freedesktop.systemd1` rule |
+| Instalador de Quadlets | `lifeos-quadlet-install --user` | Containerfile |
+| CDI | rootless OK con dev 666 | rootful, sin restricciones |
+| Game Guard restart | `systemctl --user` directo | requería wrapper |
+
 ## Further reading
 
 - PRD: [`docs/strategy/prd-architecture-pivot-lean-bootc-quadlet.md`](../strategy/prd-architecture-pivot-lean-bootc-quadlet.md)

--- a/docs/operations/developer-bootstrap.md
+++ b/docs/operations/developer-bootstrap.md
@@ -164,3 +164,115 @@ produces no filesystem changes and prints an `already up-to-date` line for each 
 # Safe to run any time — will no-op if nothing changed
 sudo bash scripts/lifeos-dev-bootstrap.sh --with-sentinel
 ```
+
+---
+
+## Desarrollo en CachyOS (host nativo, sin bootc)
+
+A partir de Fase 3, el host de referencia del maintainer es **CachyOS**.
+El flujo de desarrollo sobre CachyOS difiere en algunos puntos respecto al
+workflow de bootc documentado arriba.
+
+### Prerequisitos de Arch que no están en Fedora
+
+```bash
+# Herramientas de build base
+sudo pacman -S base-devel git rustup
+
+# Inicializar rustup (si no está configurado)
+rustup default stable
+rustup component add clippy rustfmt
+
+# Podman rootless (sin docker group)
+sudo pacman -S podman fuse-overlayfs slirp4netns
+```
+
+> En CachyOS **no** existe el grupo `docker`. Podman corre rootless de forma
+> nativa — no hay que agregar el usuario a ningún grupo especial.
+
+### Ejecutar tests con podman en Arch
+
+Los tests de integración que prueban Quadlets o contenedores corren igual que
+en Fedora, pero algunas sutilezas de Arch requieren atención:
+
+```bash
+# Asegurar que el socket de podman user esté activo
+systemctl --user start podman.socket
+
+# Correr todos los tests del daemon
+cargo test -p lifeosd
+
+# Test individual
+cargo test -p lifeosd test_name
+```
+
+Si un test falla con `permission denied on /run/user/1000/podman/podman.sock`,
+verificá que `podman.socket` esté activo:
+
+```bash
+systemctl --user status podman.socket
+```
+
+### Compilar con las features exactas de CI
+
+El CI compila con las mismas features en todos los perfiles. En CachyOS hay
+que asegurarse de tener las dependencias nativas correspondientes:
+
+```bash
+# Dependencias de sistema para todas las features
+sudo pacman -S dbus pipewire gtk4 libadwaita openssl sqlite
+
+# Build con el conjunto exacto de features del CI
+cargo build --manifest-path daemon/Cargo.toml \
+  --features "dbus,http-api,ui-overlay,wake-word,messaging"
+
+# Clippy con el mismo conjunto
+cargo clippy --manifest-path daemon/Cargo.toml \
+  --features "dbus,http-api,ui-overlay,wake-word,messaging" \
+  -- -D warnings
+```
+
+### Iterar sobre el daemon sin instalar el paquete
+
+Para desarrollo rápido, corrés `lifeosd` directamente desde el target de cargo:
+
+```bash
+# Terminal 1: build + run del daemon en modo debug
+RUST_LOG=debug cargo run --manifest-path daemon/Cargo.toml
+
+# Terminal 2: verificar que responde
+curl -s http://127.0.0.1:8081/api/v1/health
+```
+
+Los Quadlets de contenedores (llama-server, TTS, etc.) pueden estar corriendo
+como servicios de usuario normales en paralelo — el daemon en modo dev los
+detecta por TCP igual que en producción.
+
+### Variables de entorno útiles para desarrollo
+
+```bash
+# Usar directorio de datos local en vez de /var/lib/lifeos
+export LIFEOS_DATA_DIR="$HOME/.local/share/lifeos-dev"
+
+# Activar logging detallado por módulo
+export RUST_LOG="lifeosd=debug,lifeosd::axi_tools=trace"
+
+# Limpiar estado entre sesiones de prueba
+rm -rf "$LIFEOS_DATA_DIR" && mkdir -p "$LIFEOS_DATA_DIR"
+```
+
+### Rollback en CachyOS (sin bootc)
+
+No hay `bootc rollback` en el workflow nativo. En su lugar, git y pacman
+son el mecanismo de reversión:
+
+```bash
+# Revertir a la versión instalada desde el paquete
+sudo pacman -U ~/.cache/paru/lifeos-daemon-*.pkg.tar.zst
+
+# O compilar un commit específico y remplazar el binario
+git checkout <commit_anterior>
+cargo build --release --manifest-path daemon/Cargo.toml
+sudo install -m 755 target/release/lifeosd /usr/bin/lifeosd
+systemctl --user restart lifeosd.service
+```

--- a/docs/operations/runtime-install.md
+++ b/docs/operations/runtime-install.md
@@ -1,95 +1,551 @@
-# LifeOS Runtime Install / Onboarding
+# Instalación del runtime de LifeOS — CachyOS
 
-**Status:** v1 runtime install path is being defined  
-**Reference host:** CachyOS (`validated on host` for maintainer development), not a requirement
+**Estado:** Guía completa (Fase 3 del PRD, v1).
+**Host de referencia:** CachyOS (rolling). Otros perfiles de distribución son trabajo futuro, no promesas actuales.
 
-LifeOS is now a personal AI runtime over Linux, not a distro replacement. This
-guide is the first install/onboarding map for that direction. It is intentionally
-conservative: when a command or package flow is not ready in the repo, it is
-marked as a **pending/design target** instead of presented as shipped behavior.
+LifeOS no reemplaza tu distro. Es una capa de runtime de IA personal que corre
+encima de Linux. Esta guía cubre la instalación reproducible de ese runtime
+en CachyOS con GPU NVIDIA.
 
-## Quick Path
+---
 
-| Step | Status | Action |
-|------|--------|--------|
-| Build the runtime from source | Integrated in repo | `make build` from the repo root builds the Rust CLI and daemon. |
-| Run tests before local changes | Integrated in repo | `make test` runs the repository test suite. |
-| Run lint/format checks | Integrated in repo | `make lint` is the intended gate; local toolchain dependencies must be installed first. |
-| Install host services | Pending/design target | A supported installer/package flow is not finalized yet. Do not assume a one-command install. |
-| Enable user/system services | Pending/design target | Service unit installation and enablement are still being shaped for v1 runtime packaging. |
+## Tabla de contenidos
 
-## Prerequisites
+1. [Requisitos previos](#1-requisitos-previos)
+2. [Build e instalación de paquetes](#2-build-e-instalación-de-paquetes)
+3. [Configuración de CDI para NVIDIA](#3-configuración-de-cdi-para-nvidia)
+4. [Primera ejecución — `life init`](#4-primera-ejecución--life-init)
+5. [Validación V1](#5-validación-v1)
+6. [Troubleshooting](#6-troubleshooting)
+7. [Respaldo de `memory.db`](#7-respaldo-de-memorydb)
+8. [Desinstalar LifeOS](#8-desinstalar-lifeos)
 
-| Requirement | Maturity | Notes |
-|-------------|----------|-------|
-| Modern Linux host | Design target | CachyOS is the first reference host. Other distros are future host profiles, not separate products. |
-| Rust toolchain | Integrated in repo | Required to build `life`, `lifeosd`, and `lifeos-desktop` from source today. |
-| Podman or compatible container runtime | Integrated in repo | Used by runtime service images and Quadlet-based service definitions where applicable. |
-| systemd user services | Design target | The runtime model expects long-lived local services, but packaging/install automation is still in progress. |
-| Local model assets / service images | Partial | Exact first-run acquisition flow is still being defined per service. |
+---
 
-## Install Format Decision
+## 1. Requisitos previos
 
-The v1 runtime install format is **hybrid**:
+### Hardware mínimo
 
-- **Native binaries** for the Rust components — `life`, `lifeosd`, and `lifeos-desktop` — packaged per-distro (AUR first for the CachyOS reference host). These need direct access to D-Bus, Wayland, sockets, and the local keyring, which native binaries make trivial.
-- **Containers (Podman)** for the heavy services with complex dependency trees — `llama-server`, `llama-embeddings`, `lifeos-tts` (Kokoro + PyTorch + CUDA), and `simplex-chat`. Containers keep these out of the per-distro packaging matrix and allow granular updates: changing agent code rebuilds a small Rust binary; changing a model swaps a single container image.
+| Componente | Mínimo | Recomendado |
+|------------|--------|-------------|
+| GPU NVIDIA | VRAM 4 GB | 8 GB (para Qwen3.5-9B) |
+| RAM | 8 GB | 16 GB |
+| Almacenamiento | 80 GB libres | 150 GB NVMe |
 
-This split is the canonical install model for the runtime pivot. Older `image/` (bootc) and `legacy/nixos-spike-v1` (NixOS flake) paths remain in repo/tag history for reference but are not the v1 install promise.
+### Sistema base
 
-## Target Services
+| Requisito | Versión mínima | Verificación |
+|-----------|----------------|--------------|
+| CachyOS | Rolling (kernel ≥ 6.10) | `uname -r` |
+| Driver NVIDIA (`nvidia-dkms`) | ≥ 550.x | `nvidia-smi` |
+| `podman` | ≥ 5.0 | `podman --version` |
+| `systemd` | ≥ 254 | `systemctl --version` |
+| `nvidia-container-toolkit` | ≥ 1.16.0 | `nvidia-ctk --version` |
 
-The v1 runtime onboarding should make these services understandable and
-verifiable. Availability depends on the current repo state and host setup.
+### Instalar `nvidia-container-toolkit` desde AUR
 
-> **Host validation status (2026-05-12):** no service in this table has been validated end-to-end on the CachyOS reference host yet. `Integrated in repo` means the code exists and worked on the prior bootc image; runtime-on-CachyOS validation is part of PRD Phase 3, not yet executed. Treat this table as repository inventory, not as a "works on CachyOS" promise.
+```bash
+paru -S nvidia-container-toolkit
+```
 
+Si el build de AUR falla por desajuste con el driver instalado, usá la
+variante binaria como alternativa:
 
-| Service | Target address/path | Maturity | Purpose |
-|---------|---------------------|----------|---------|
-| `lifeosd` | UDS `/run/lifeos/lifeosd.sock` + TCP `127.0.0.1:8081` | Integrated in repo | Main daemon, REST API, Axi runtime, local tools, memory orchestration. |
-| `life` | CLI on `$PATH` | Integrated in repo | Local command-line interface. |
-| `lifeos-desktop` | User-session companion | Integrated in repo | Tray, wake-word listener, desktop/Wayland/D-Bus bridge. |
-| `llama-server` | `127.0.0.1:8082` | Integrated in repo | Local LLM inference via llama.cpp. |
-| `llama-embeddings` | `127.0.0.1:8083` | Integrated in repo | Local embedding service. |
-| `lifeos-tts` | `127.0.0.1:8084` | Integrated in repo | Kokoro-82M text-to-speech service. |
-| `simplex-chat` / bridge | `ws://127.0.0.1:5226` | Integrated in repo | Privacy-first remote channel for Axi. |
+```bash
+paru -S nvidia-container-toolkit-bin
+```
 
-## State Paths
+Verificación:
 
-| Path | Maturity | Expected role |
-|------|----------|---------------|
-| `/var/lib/lifeos/` | Integrated in repo | Long-lived runtime state, local databases, config checkpoints, and service data. |
-| `/var/lib/lifeos/config-checkpoints/working/config.toml` | Integrated in repo | Working runtime configuration used by existing docs and services. |
-| `/run/lifeos/` | Integrated in repo | Runtime sockets and ephemeral process state. |
-| `$HOME/.config/systemd/user/` | Design target | User service drop-ins and enablement for per-user runtime components. |
+```bash
+nvidia-ctk --version
+nvidia-smi
+podman --version
+```
 
-## Verification Checklist
+Los tres comandos deben salir sin error. Si `nvidia-smi` no responde, el
+driver no está cargado — revisá `dmesg | grep nvidia` antes de continuar.
 
-Use this checklist while the installer is still being defined.
+---
 
-- [ ] Build succeeds with `make build`.
-- [ ] Tests pass with `make test` on a prepared development host.
-- [ ] Lint runs with `make lint` once Rust/TypeScript tooling is installed.
-- [ ] `life` is available on `$PATH` after the chosen local install/package step.
-- [ ] `lifeosd` starts and exposes its expected local API/socket.
-- [ ] Runtime state is written under `/var/lib/lifeos/`, not hidden in ad-hoc repo paths.
-- [ ] Optional services (`llama-server`, embeddings, TTS, SimpleX) are either healthy or explicitly disabled.
-- [ ] CachyOS-specific notes are treated as host validation evidence, not as product requirements.
+## 2. Build e instalación de paquetes
 
-## Pending Installer Work
+### Clonar el repositorio
 
-The following are design targets, not supported public commands yet:
+```bash
+git clone https://github.com/hectormr206/lifeos
+cd lifeos
+```
 
-- One-command runtime install.
-- Distro-specific packages or host profiles.
-- Automated first-run service enablement.
-- Model/service asset bootstrap.
-- Cross-distro validation matrix beyond the current reference host.
+### Orden de instalación (dependencias entre paquetes)
 
-## Legacy Note
+Los PKGBUILDs están en `packaging/cachyos/`. Se deben construir e instalar
+en este orden exacto:
 
-The Fedora bootc image and NixOS transition work remain in the repository as
-auditable history and reusable infrastructure. They are **legacy / transitional**
-after the LifeOS Runtime pivot. Do not read the old OS-image path as the current
-install promise for v1.
+```
+1. lifeos-cli
+2. lifeos-daemon
+3. lifeos-desktop
+4. lifeos-containers
+5. lifeos-runtime   ← meta-paquete, instala las dependencias del sistema
+```
+
+### Build por paquete
+
+Para cada directorio bajo `packaging/cachyos/`:
+
+```bash
+cd packaging/cachyos/lifeos-cli
+makepkg -si
+```
+
+Salida esperada al terminar:
+
+```
+==> Instalando lifeos-cli con pacman -U ...
+[sudo] contraseña para <tu_usuario>:
+cargando paquetes...
+resolviendo dependencias...
+buscando conflictos entre paquetes...
+Paquetes (1) lifeos-cli-0.X.Y-1
+Tamaño total de instalación: X.XX MiB
+:: ¿Continuar con la instalación? [S/n] S
+==> lifeos-cli instalado exitosamente.
+```
+
+Repetí el mismo paso (`makepkg -si`) en cada carpeta, en el orden indicado.
+El meta-paquete `lifeos-runtime` al final instala `podman` y
+`nvidia-container-toolkit` si aún no están presentes.
+
+### Alternativa con paru (un solo paso por paquete)
+
+Si preferís gestionar todo desde paru:
+
+```bash
+# Desde cada directorio de PKGBUILD:
+paru -U ./*.pkg.tar.zst   # si ya compilaste con makepkg
+# o directamente:
+cd packaging/cachyos/lifeos-cli && paru -U .
+```
+
+### Verificar instalación
+
+```bash
+life --version
+lifeosd --version
+```
+
+Ambos deben imprimir la versión sin error.
+
+---
+
+## 3. Configuración de CDI para NVIDIA
+
+CDI (Container Device Interface) permite que los contenedores rootless de
+podman accedan a la GPU NVIDIA sin privilegios adicionales.
+
+### Generar la especificación CDI
+
+Este comando requiere sudo (escribe en `/etc/cdi/`):
+
+```bash
+sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+```
+
+### Verificar que la especificación se generó
+
+```bash
+ls -la /etc/cdi/nvidia.yaml
+nvidia-ctk cdi list
+```
+
+La salida de `cdi list` debe incluir `nvidia.com/gpu=all`.
+
+### Probar acceso a la GPU desde un contenedor rootless
+
+```bash
+podman run --rm \
+  --device nvidia.com/gpu=all \
+  docker.io/nvidia/cuda:12.0.0-base-ubi9 \
+  nvidia-smi
+```
+
+Salida esperada: la tabla de `nvidia-smi` con el modelo de GPU, versión del
+driver, y VRAM disponible. Si el contenedor falla con
+`Error: setting up CDI devices`, revisá la sección 6.1 de troubleshooting.
+
+### Actualización automática del CDI
+
+El paquete `lifeos-containers` instala un watcher de systemd en el host que
+regenera `/etc/cdi/nvidia.yaml` automáticamente cuando se actualiza el driver:
+
+```bash
+systemctl status lifeos-cdi-refresh.path
+```
+
+Estado esperado: `active (waiting)`. No requiere intervención manual tras
+actualizaciones de kernel o driver.
+
+---
+
+## 4. Primera ejecución — `life init`
+
+`life init` realiza la inicialización completa del runtime: detecta el sistema
+operativo, valida los requisitos previos, crea los directorios de estado, activa
+los servicios de systemd --user, e inicia los contenedores Quadlet.
+
+### Instalar los Quadlets de usuario
+
+Antes de ejecutar `life init`, instalá los symlinks de Quadlet en el scope del
+usuario:
+
+```bash
+lifeos-quadlet-install --user
+```
+
+Este helper crea `~/.config/containers/systemd/` y enlaza cada archivo
+`.container` desde `/usr/share/lifeos/quadlets/`.
+
+### Ejecutar `life init`
+
+```bash
+life init
+```
+
+### Salida esperada (flujo exitoso)
+
+```
+[1/5] Detectando sistema operativo... OK (CachyOS)
+[2/5] Validando requisitos previos...
+  podman 5.3.1              OK
+  nvidia-smi (driver 560.x) OK
+  nvidia-ctk 1.16.2         OK
+  /etc/cdi/nvidia.yaml      OK
+[3/5] Verificando sistema de archivos...
+  /var/lib/lifeos/          OK
+  /run/lifeos/              OK
+[4/5] Activando servicios...
+  lifeosd.service           habilitado + activo
+  lifeos-llama-server       habilitado + activo
+  lifeos-llama-embeddings   habilitado + activo
+  lifeos-tts                habilitado + activo
+  lifeos-simplex-bridge     habilitado + activo (sin cuenta SimpleX aún)
+[5/5] Verificando salud (TCP fan-out)...
+  lifeosd     :8081  HEALTHY
+  llama-server :8082  HEALTHY
+  embeddings  :8083  HEALTHY
+  tts         :8084  HEALTHY
+  simplex-bridge activo (no hay TCP check)
+
+Dashboard: http://127.0.0.1:8081/dashboard?token=<bootstrap_token>
+```
+
+### Flags disponibles
+
+| Flag | Efecto |
+|------|--------|
+| `--no-containers` | Solo activa `lifeosd`; omite los contenedores Quadlet |
+| `--json` | Salida en formato JSON machine-readable |
+
+### Sobre SimpleX
+
+Si `lifeos-simplex-bridge` está activo pero sin cuenta pareada, `life init`
+imprime un aviso con el comando de pairing. Completar el pairing es opcional
+para el funcionamiento del resto del sistema.
+
+### Segundo `life init` (idempotente)
+
+Si ejecutás `life init` en un sistema ya inicializado, re-valida el estado y
+re-imprime la URL del dashboard. No deshabilita ni reinicia servicios que ya
+estén corriendo.
+
+---
+
+## 5. Validación V1
+
+Usá el script de validación para verificar los cinco escenarios de aceptación:
+
+```bash
+make validate-cachyos
+# o directamente:
+bash scripts/validate-cachyos.sh
+```
+
+Modo JSON para automatización:
+
+```bash
+bash scripts/validate-cachyos.sh --json
+```
+
+### 5.1 — B1: Instalación aceptada
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" \
+  -H "x-bootstrap-token: $LIFEOS_BOOTSTRAP_TOKEN" \
+  http://127.0.0.1:8081/api/v1/health
+```
+
+Salida esperada: `200`
+
+### 5.2 — B2: Dashboard accesible
+
+Abrí `http://127.0.0.1:8081/dashboard?token=<bootstrap_token>` en el
+navegador. El dashboard debe cargar sin errores de consola y mostrar el
+estado del daemon (conectado, uptime visible).
+
+Verificación por línea de comandos:
+
+```bash
+curl -s http://127.0.0.1:8081/dashboard?token=$LIFEOS_BOOTSTRAP_TOKEN | grep -c "LifeOS"
+```
+
+Salida esperada: `1` o más (el título del SPA aparece en el HTML).
+
+### 5.3 — B3: Bucle de memoria (`health_fact_add`)
+
+Enviá un hecho de salud a Axi por el dashboard y verificá que persiste:
+
+```bash
+# Enviar el mensaje (reemplazá <token> con tu bootstrap token)
+curl -s -X POST http://127.0.0.1:8081/api/v1/overlay/chat \
+  -H "Content-Type: application/json" \
+  -H "x-bootstrap-token: $LIFEOS_BOOTSTRAP_TOKEN" \
+  -d '{"message": "soy alérgico a la lactosa"}'
+```
+
+Esperá ~30 segundos para que el LLM invoque la herramienta `health_fact_add`.
+Luego verificá la persistencia directamente en la base de datos:
+
+```bash
+DB_PATH="${LIFEOS_DATA_DIR:-/var/lib/lifeos}/memory.db"
+[ -f "$DB_PATH" ] || DB_PATH="$HOME/.local/share/lifeos/memory.db"
+
+sqlite3 "$DB_PATH" \
+  "SELECT id, label, created_at FROM health_facts WHERE label LIKE '%lactosa%' LIMIT 5;"
+```
+
+Salida esperada: al menos una fila con contenido sobre lactosa.
+
+**Prueba de persistencia tras reinicio:**
+
+```bash
+systemctl --user restart lifeosd.service
+# Esperar que suba (life init re-valida o ver journalctl)
+sqlite3 "$DB_PATH" \
+  "SELECT label FROM health_facts WHERE label LIKE '%lactosa%';"
+```
+
+El registro debe seguir presente.
+
+### 5.4 — B4: Bucle remoto SimpleX
+
+> Requiere que SimpleX esté pareado. Ver aviso de pairing en la salida de
+> `life init`.
+
+1. Enviá un mensaje desde tu cuenta SimpleX al contacto de Axi.
+2. Axi debe responder dentro de 30 segundos.
+3. Si el intercambio previo mencionó la alergia a la lactosa, la respuesta
+   debe referenciarla.
+
+Verificación por journal:
+
+```bash
+journalctl --user -u lifeos-simplex-bridge.service --since "5 minutes ago" -n 20
+```
+
+### 5.5 — B5: GPU Game Guard
+
+> Requiere GPU NVIDIA con Qwen3.5-9B activo.
+
+**Si tenés hardware compatible:**
+
+```bash
+# Verificar que el perfil activo es 9B GPU antes de lanzar el juego
+journalctl --user -u lifeosd.service --since "10 minutes ago" | grep "profile"
+
+# Lanzar un juego desde Steam y esperar ~10 segundos
+# Luego verificar el swap a 4B CPU:
+journalctl --user -u lifeosd.service --since "2 minutes ago" | grep "game guard"
+```
+
+Línea esperada en el journal: `game guard: swap to 4B CPU`
+
+Cuando el juego cierra:
+
+```bash
+journalctl --user -u lifeosd.service --since "2 minutes ago" | grep "game guard"
+```
+
+Línea esperada: `game guard: restore to 9B GPU`
+
+**Si no tenés hardware validable:** Game Guard permanece marcado como
+`experimental` en el README hasta que se complete la validación en hardware
+real. Ver advertencia en la sección de badges del README.
+
+---
+
+## 6. Troubleshooting
+
+### 6.1 — Desajuste de versión en `nvidia-container-toolkit`
+
+**Síntoma:** `podman run --device nvidia.com/gpu=all` falla con error sobre
+librerías NVIDIA no encontradas.
+
+**Diagnóstico:**
+
+```bash
+nvidia-ctk --version
+nvidia-smi
+# Compará la versión del toolkit vs la del driver instalado
+pacman -Qi nvidia-container-toolkit
+pacman -Qi nvidia-utils
+```
+
+**Solución:**
+
+```bash
+# Regenerar la especificación CDI con las rutas actualizadas
+sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+
+# Si sigue fallando, actualizar el toolkit:
+paru -Syu nvidia-container-toolkit
+```
+
+Si el AUR build falla, usar la variante binaria:
+
+```bash
+paru -S nvidia-container-toolkit-bin
+```
+
+### 6.2 — `/run/lifeos/` o `/var/lib/lifeos/` faltante
+
+**Síntoma:** `life init` imprime:
+
+```
+Error: /run/lifeos/ no existe. Ejecutá:
+  sudo systemd-tmpfiles --create /usr/lib/tmpfiles.d/lifeos.conf
+```
+
+**Causa:** `systemd-tmpfiles --create` no se ejecutó durante la instalación
+del paquete (puede pasar si instalaste sin `makepkg -si` y saltaste los hooks
+de post-install).
+
+**Solución:**
+
+```bash
+sudo systemd-tmpfiles --create /usr/lib/tmpfiles.d/lifeos.conf
+```
+
+Luego verificá permisos:
+
+```bash
+ls -la /var/lib/lifeos /run/lifeos
+# /var/lib/lifeos debe ser modo 0775, grupo lifeos
+# Si tu usuario no está en el grupo lifeos:
+sudo usermod -aG lifeos $USER
+# Luego hacé logout/login para que tome efecto
+```
+
+### 6.3 — `lifeosd` no responde en 30 segundos
+
+**Síntoma:** `life init` sale con código 1 y:
+
+```
+lifeosd no se volvió saludable en 30s — revisá: journalctl --user -u lifeosd.service
+```
+
+**Diagnóstico:**
+
+```bash
+journalctl --user -u lifeosd.service -n 50
+systemctl --user status lifeosd.service
+```
+
+Causas comunes:
+- **Puerto 8081 ocupado:** `ss -tlnp | grep 8081`
+- **Modelo no descargado:** el daemon espera `llama-server` en `:8082`; si el
+  modelo GGUF no está en `/var/lib/lifeos/models/`, el contenedor no levanta.
+  Ver `journalctl --user -u lifeos-llama-server.service`.
+- **CDI no configurado:** `lifeos-llama-server` necesita acceso GPU. Ver 6.1.
+
+**Solución rápida:**
+
+```bash
+systemctl --user daemon-reload
+systemctl --user restart lifeosd.service
+# Esperar 30s y verificar
+systemctl --user is-active lifeosd.service
+```
+
+### 6.4 — Advertencias de SELinux o `rpm -V` en el journal
+
+**Síntoma:** El journal de `lifeosd` muestra alertas sobre SELinux o `rpm -V`.
+
+**Causa:** El daemon incluye checks de seguridad diseñados para Fedora (donde
+`rpm -V` y SELinux son estándar). En CachyOS, ambas herramientas están
+ausentes, lo que antes generaba alertas falsas.
+
+**Estado en la versión actual:** desde Fase 3 (PR-1), el daemon detecta
+automáticamente que está en un host Arch-based y marca esos checks como
+`no aplica` en lugar de emitir alertas. Si ves estas advertencias en la
+versión instalada, actualizá al build más reciente.
+
+---
+
+## 7. Respaldo de `memory.db`
+
+La base de datos de memoria es el activo más valioso del runtime. Respaldala
+regularmente:
+
+```bash
+DB_PATH="${LIFEOS_DATA_DIR:-/var/lib/lifeos}/memory.db"
+[ -f "$DB_PATH" ] || DB_PATH="$HOME/.local/share/lifeos/memory.db"
+
+# Respaldo con fecha
+cp "$DB_PATH" "$HOME/lifeos-memory-$(date +%Y%m%d).db"
+```
+
+Para un respaldo consistente mientras el daemon está corriendo, usá el
+checkpoint de WAL:
+
+```bash
+sqlite3 "$DB_PATH" "PRAGMA wal_checkpoint(TRUNCATE);"
+cp "$DB_PATH" "$HOME/lifeos-memory-$(date +%Y%m%d).db"
+```
+
+---
+
+## 8. Desinstalar LifeOS
+
+### Detener y deshabilitar servicios
+
+```bash
+systemctl --user disable --now lifeosd.service \
+  lifeos-llama-server.service lifeos-llama-embeddings.service \
+  lifeos-tts.service lifeos-simplex-bridge.service
+```
+
+### Remover symlinks de Quadlet
+
+```bash
+lifeos-quadlet-install --uninstall
+systemctl --user daemon-reload
+```
+
+### Desinstalar paquetes
+
+```bash
+sudo pacman -Rns lifeos-runtime lifeos-cli lifeos-daemon lifeos-desktop lifeos-containers
+```
+
+### Limpiar estado (opcional — esto borra memoria y configuración)
+
+```bash
+rm -rf /var/lib/lifeos
+rm -rf /run/lifeos
+rm -rf ~/.config/lifeos
+rm -rf ~/.config/containers/systemd/lifeos-*.container
+```
+
+> **Atención:** `rm -rf /var/lib/lifeos` borra `memory.db` de forma
+> permanente. Hacé un respaldo antes si querés conservar el historial de Axi.

--- a/docs/user/installation.md
+++ b/docs/user/installation.md
@@ -1,6 +1,10 @@
 # LifeOS Installation Guide
 
-> **Transition notice — runtime pivot in progress.** LifeOS is moving from a Fedora bootc distro prototype to a personal AI runtime / operating-system layer over Linux. This guide still documents the bootc installation path because the runtime installer is not finalized yet; an early draft of the new direction lives in [`docs/operations/runtime-install.md`](../operations/runtime-install.md). Use this guide if you are installing or operating the legacy bootc image today; expect it to be retired as the canonical entry point once the runtime install path is ready.
+> **Instalando en CachyOS?** La guía completa y canónica para el runtime nativo (PKGBUILDs, `life init`, NVIDIA CDI, validación V1) está en
+> [`docs/operations/runtime-install.md`](../operations/runtime-install.md).
+> Esa guía reemplaza a esta para cualquier instalación nueva en el host de referencia CachyOS.
+>
+> **Legacy bootc:** esta guía documenta el path de instalación con imagen Fedora bootc. Seguí leyendo si estás operando esa imagen legacy hoy. El path bootc es transitional/prototype y no es la dirección canónica del runtime v1.
 
 This guide covers installing LifeOS on bare metal or virtual machines.
 


### PR DESCRIPTION
## Summary

Sixth and final chained PR for PRD Phase 3 (`cachyos-host-profile`). Replaces the stub `docs/operations/runtime-install.md` with a complete CachyOS install guide, adds a dev-bootstrap CachyOS section, documents user-scope runtime architecture, updates the legacy installation banner, and reconciles README/CLAUDE.md/AGENTS.md badges and pointers.

## Why

PRD §11 Fase 3 was missing its user-facing documentation. Spec REQ-C1..C4 specifies the contents of `runtime-install.md`; spec REQ-D specifies the badge taxonomy. This PR closes both.

## What

| File | Change |
|------|--------|
| `docs/operations/runtime-install.md` | **Full rewrite — 551 LOC, 8 sections**: Overview, Prerequisites, Build & Install (PKGBUILDs), NVIDIA CDI Setup, First Run (`life init`), Validation (`make validate-cachyos`), Troubleshooting (top 3 failure modes), Removing LifeOS. Replaces the PR-#97 stub. |
| `docs/operations/developer-bootstrap.md` | New CachyOS development section (Arch-specific dev workflow notes). |
| `docs/architecture/quadlet-architecture.md` | New "User-scope runtime architecture" subsection (per design §2). |
| `docs/user/installation.md` | Transition banner updated to point at the now-complete runtime-install guide. |
| `README.md` | Badge transitions per spec REQ-D: V1 stable tools (`memory_save`/`memory_search`/`web_search`/`vital_record`/`health_fact_add`) remain `integrated in repo` until the validation harness runs on real CachyOS hardware (then advance to `validated on host (CachyOS)`); Game Guard label is conditional pending hardware validation. |
| `CLAUDE.md`, `AGENTS.md` | Developer Setup row + doc-sync rule row pointing at `runtime-install.md` as the canonical CachyOS guide. |

## Acceptance

- [x] No remaining "Pending/design target" placeholders in `runtime-install.md`.
- [x] Each prerequisite has a `pacman -Qi <pkg>` verification command.
- [x] Each acceptance scenario (REQ-B1..B5) referenced in the Validation section.
- [x] Cross-file markdown links resolve.
- [x] Doc-sync rule honored: agent context files (CLAUDE.md, AGENTS.md) reflect the new canonical guide.

## Commits

5 atomic commits (T31+T32 merged since they're the same file):

1. `3acc80a` — runtime-install.md full rewrite
2. `3752540` — developer-bootstrap CachyOS section
3. `1537893` — quadlet-architecture user-scope subsection
4. `c89e3a1` — installation.md banner update
5. `b3a0cd7` — README badges + CLAUDE/AGENTS pointers

## Phase 3 SDD complete

This is the LAST chained PR for `cachyos-host-profile`. After this lands:

- 6/6 PRs delivered (#100 PR-1, #101 PR-2, #102 PR-3, #103 PR-4, #104 PR-5, this PR-6).
- 36/36 tasks closed (T01..T36).
- Next: `sdd-verify` (validate spec compliance) → `sdd-archive` (close cycle, persist final report).