### PR TITLE
feat(packaging): NVIDIA CDI auto-refresh units + setup helper

### DIFF
--- a/packaging/cachyos/README.md
+++ b/packaging/cachyos/README.md
@@ -85,11 +85,112 @@ Generate the Container Device Interface spec so rootless Quadlets can access the
 sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
 ```
 
-Verify:
+The `lifeos-cdi-setup` helper (installed with `lifeos-containers`) checks this for you
+and prints the exact command with expected output if the spec is missing:
+
+```bash
+lifeos-cdi-setup
+```
+
+Verify manually:
 
 ```bash
 ls /etc/cdi/nvidia.yaml        # file must exist and be non-empty
 nvidia-ctk cdi list            # lists detected devices (e.g. nvidia.com/gpu=0)
+```
+
+After generating the spec, future NVIDIA driver updates will automatically trigger
+a regeneration via the `lifeos-cdi-refresh.path` systemd unit (enabled by the
+`lifeos-containers` post-install hook).
+
+## Rootless CDI Verification
+
+After the CDI spec is generated and `life init` has completed, verify that rootless
+Podman containers can actually reach the GPU.
+
+### 1. Sanity checks
+
+Check that the container runtime backend and cgroup version are correct
+(rootless GPU requires cgroup v2):
+
+```bash
+podman info --format '{{.Host.NetworkBackend}}'
+# Expected: netavark (or pasta for rootless — either is fine)
+
+podman info --format '{{.Host.CgroupVersion}}'
+# Expected: v2
+```
+
+CachyOS ships with cgroup v2 by default since kernel 5.19. If you see `v1`, reboot
+with `systemd.unified_cgroup_hierarchy=1` kernel parameter or upgrade your kernel.
+
+### 2. GPU device permissions
+
+Rootless CDI requires `/dev/nvidia*` to be readable by the user. Check:
+
+```bash
+ls -la /dev/nvidia* /dev/nvidiactl /dev/nvidia-uvm 2>/dev/null
+```
+
+Expected mode: `crw-rw-rw-` (0666) or at minimum `crw-rw----` with the user in
+the `video` and `render` groups.
+
+If permissions are 0660 and you see "Permission denied" errors in containers:
+
+```bash
+# Add yourself to video and render groups (requires re-login to take effect)
+sudo usermod -aG video,render "$USER"
+
+# Or set permissive mode on the current session (not persistent):
+sudo chmod 0666 /dev/nvidia* /dev/nvidiactl /dev/nvidia-uvm
+```
+
+For a persistent fix without changing your groups, add a udev rule:
+
+```bash
+sudo tee /etc/udev/rules.d/70-nvidia-cdi.rules <<'EOF'
+KERNEL=="nvidia*", MODE="0666"
+KERNEL=="nvidiactl", MODE="0666"
+KERNEL=="nvidia-uvm", MODE="0666"
+EOF
+sudo udevadm control --reload-rules && sudo udevadm trigger
+```
+
+### 3. Rootless GPU probe
+
+Run the official CUDA probe container rootless with CDI device injection:
+
+```bash
+podman run --rm \
+  --device nvidia.com/gpu=all \
+  docker.io/nvidia/cuda:12.0.0-base-ubi9 \
+  nvidia-smi
+```
+
+Expected output: the standard `nvidia-smi` table showing your GPU name, driver
+version, CUDA version, and memory. Example:
+
+```
++-----------------------------------------------------------------------------+
+| NVIDIA-SMI 550.54.14   Driver Version: 550.54.14   CUDA Version: 12.4      |
+|-------------------------------+----------------------+----------------------+
+| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
+|   0  NVIDIA GeForce ...  Off  | 00000000:01:00.0  On |                  N/A |
+```
+
+If `podman run` fails with `nvidia.com/gpu=all: no such device`:
+
+1. Verify the CDI spec exists: `ls /etc/cdi/nvidia.yaml`
+2. Verify devices are listed: `nvidia-ctk cdi list`
+3. Regenerate if stale: `sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml`
+4. Confirm podman reads CDI: `podman run --rm --device nvidia.com/gpu=all --log-level debug ... 2>&1 | grep -i cdi`
+
+If the probe hangs or the container starts but `nvidia-smi` prints no GPUs, check
+that `nvidia-persistenced` is not holding an exclusive lock:
+
+```bash
+systemctl status nvidia-persistenced
+# If active and causing issues: sudo systemctl stop nvidia-persistenced
 ```
 
 ## First Run

--- a/packaging/cachyos/lifeos-containers/PKGBUILD
+++ b/packaging/cachyos/lifeos-containers/PKGBUILD
@@ -2,6 +2,7 @@
 # Verification: bash -n PKGBUILD && makepkg -s --noconfirm --syncdeps
 #
 # T21 — config-only package: Quadlet templates, tmpfiles.d, sysusers.d, helpers.
+# T25 — CDI refresh system units (lifeos-cdi-refresh.path/.service) + lifeos-cdi-setup helper.
 # No Rust build step. arch=any (pure config/scripts).
 #
 # Post-install creates /var/lib/lifeos and /run/lifeos via tmpfiles.d,
@@ -58,6 +59,17 @@ package() {
     install -Dm755 "$src/helpers/lifeos-quadlet-install" \
         "$pkgdir/usr/bin/lifeos-quadlet-install"
 
+    # CDI setup helper (T24): guides user through one-time nvidia-ctk invocation.
+    install -Dm755 "$src/helpers/lifeos-cdi-setup" \
+        "$pkgdir/usr/bin/lifeos-cdi-setup"
+
+    # CDI refresh system units (T23): auto-regenerate /etc/cdi/nvidia.yaml
+    # on driver/kernel updates. System-scope (require root to write /etc/cdi/).
+    install -Dm644 "$src/systemd/lifeos-cdi-refresh.path" \
+        "$pkgdir/usr/lib/systemd/system/lifeos-cdi-refresh.path"
+    install -Dm644 "$src/systemd/lifeos-cdi-refresh.service" \
+        "$pkgdir/usr/lib/systemd/system/lifeos-cdi-refresh.service"
+
     # License
     install -Dm644 "$srcdir/lifeos/LICENSE" \
         "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
@@ -81,17 +93,26 @@ post_install() {
             && echo "lifeos-containers: added $real_user to the lifeos group (re-login to apply)"
     fi
 
+    # Enable CDI refresh path watcher (system-scope; runs as root via pacman context).
+    # ConditionPathExists in the unit makes it a no-op when nvidia-ctk is absent.
+    systemctl enable --now lifeos-cdi-refresh.path \
+        && echo "lifeos-containers: CDI refresh watcher enabled (lifeos-cdi-refresh.path)" \
+        || echo "lifeos-containers: warning — could not enable lifeos-cdi-refresh.path (non-fatal)"
+
     echo ""
     echo "lifeos-containers installed. Next step:"
-    echo "  Run 'life init' to configure Quadlet symlinks and enable services."
+    echo "  Run 'lifeos-cdi-setup' to check NVIDIA CDI spec status, then 'life init'."
     echo "  Or manually: lifeos-quadlet-install --user && systemctl --user daemon-reload"
 }
 
 post_upgrade() {
     # Re-run tmpfiles on upgrade in case new directories were added.
     systemd-tmpfiles --create lifeos.conf || true
-    # Reload Quadlet generator if running.
+    # Reload unit files to pick up any changes to CDI refresh units.
     systemctl daemon-reload 2>/dev/null || true
+    # Re-enable CDI path watcher in case it was added or changed in this upgrade.
+    systemctl enable --now lifeos-cdi-refresh.path 2>/dev/null \
+        || echo "lifeos-containers: warning — could not enable lifeos-cdi-refresh.path (non-fatal)"
 }
 
 post_remove() {

--- a/packaging/cachyos/lifeos-containers/helpers/lifeos-cdi-setup
+++ b/packaging/cachyos/lifeos-containers/helpers/lifeos-cdi-setup
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# lifeos-cdi-setup — interactive CDI setup helper for LifeOS
+#
+# T24: Checks whether /etc/cdi/nvidia.yaml exists. If present and non-empty,
+# confirms the setup is complete and exits 0. If absent, prints the exact
+# sudo command the user must run and what to expect afterward.
+#
+# Why a helper instead of running nvidia-ctk directly?
+#   `life init` runs as the user (no sudo). This script documents the one step
+#   that requires root. It does NOT execute sudo itself — the user runs the
+#   printed command in their terminal.
+#
+# Idempotent: running this script multiple times is always safe.
+#
+# Usage:
+#   lifeos-cdi-setup            # interactive check + instructions
+#   lifeos-cdi-setup --check    # exits 0 if CDI spec present, 1 if absent (for scripting)
+#
+# Called by `life init` step 2 (prerequisite check) when /etc/cdi/nvidia.yaml
+# is absent, to surface the exact remediation command.
+#
+# Exit codes: 0 = CDI spec present (ready), 1 = CDI spec absent (action required), 2 = usage error
+
+set -euo pipefail
+
+CDI_SPEC="/etc/cdi/nvidia.yaml"
+
+usage() {
+    printf "Usage: lifeos-cdi-setup [--check]\n" >&2
+    exit 2
+}
+
+cdi_present() {
+    [[ -f "$CDI_SPEC" && -s "$CDI_SPEC" ]]
+}
+
+check_mode() {
+    if cdi_present; then
+        exit 0
+    else
+        exit 1
+    fi
+}
+
+interactive_mode() {
+    printf "lifeos-cdi-setup: NVIDIA CDI spec check\n"
+    printf "========================================\n\n"
+
+    if cdi_present; then
+        printf "CDI spec found: %s\n" "$CDI_SPEC"
+        printf "\n"
+
+        # Show what devices are registered (nvidia-ctk may not be installed yet, guard it).
+        if command -v nvidia-ctk > /dev/null 2>&1; then
+            printf "Registered CDI devices:\n"
+            nvidia-ctk cdi list 2>/dev/null || printf "  (none detected — spec may be stale)\n"
+        fi
+
+        printf "\nStatus: READY. Rootless Quadlets can use --device nvidia.com/gpu=all.\n"
+        exit 0
+    fi
+
+    # CDI spec absent — print actionable instructions.
+    printf "CDI spec NOT found at: %s\n\n" "$CDI_SPEC"
+    printf "You must generate the NVIDIA CDI spec before running 'life init'.\n"
+    printf "This is a one-time step that requires root. Run:\n\n"
+    printf "    sudo nvidia-ctk cdi generate --output=%s\n\n" "$CDI_SPEC"
+    printf "What to expect:\n"
+    printf "  - The command scans your NVIDIA driver installation.\n"
+    printf "  - It writes a YAML spec mapping GPU devices and libraries.\n"
+    printf "  - The file is read by podman/rootless containers to inject GPU access.\n"
+    printf "  - Takes 1–5 seconds. No reboot required.\n\n"
+    printf "After running the above command, verify it worked:\n\n"
+    printf "    ls -lh %s          # must exist, non-empty\n" "$CDI_SPEC"
+    printf "    nvidia-ctk cdi list        # should list nvidia.com/gpu=0\n\n"
+    printf "Then re-run 'life init' to continue setup.\n\n"
+
+    printf "Note: future NVIDIA driver updates will automatically regenerate\n"
+    printf "the spec via the lifeos-cdi-refresh.path systemd unit (system-scope).\n"
+
+    exit 1
+}
+
+# Argument parsing.
+case "${1:-}" in
+    "")        interactive_mode ;;
+    --check)   check_mode ;;
+    *)         usage ;;
+esac

--- a/packaging/cachyos/lifeos-containers/systemd/lifeos-cdi-refresh.path
+++ b/packaging/cachyos/lifeos-containers/systemd/lifeos-cdi-refresh.path
@@ -1,0 +1,32 @@
+# lifeos-cdi-refresh.path — watch for NVIDIA driver/kernel updates and
+# trigger CDI spec regeneration automatically.
+#
+# Watches /usr/lib/modules: this directory mtime changes when any kernel
+# module package (nvidia-dkms, nvidia-utils) is installed or upgraded via
+# pacman, because pacman writes depmod output files there.
+#
+# Why /usr/lib/modules and not /usr/lib/modprobe.d/nvidia.conf?
+#   /usr/lib/modules is guaranteed to change on every kernel + driver update
+#   (depmod creates per-kernel subdirs). /usr/lib/modprobe.d/nvidia.conf only
+#   changes if modprobe config changes — driver updates alone won't touch it.
+#
+# System-scope: CDI spec lives at /etc/cdi/nvidia.yaml (root-owned).
+# The companion .service runs as root to write there.
+#
+# Enabled by: lifeos-containers post_install() via systemctl enable --now.
+
+[Unit]
+Description=Watch for NVIDIA driver updates to refresh CDI spec
+Documentation=https://github.com/hectormr206/lifeos/blob/main/packaging/cachyos/README.md
+ConditionPathExists=/usr/bin/nvidia-ctk
+
+[Path]
+PathChanged=/usr/lib/modules
+Unit=lifeos-cdi-refresh.service
+# Debounce: wait 10s after last change before triggering, to let pacman
+# finish installing all driver-related packages in the same transaction.
+TriggerLimitIntervalSec=30s
+TriggerLimitBurst=3
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/cachyos/lifeos-containers/systemd/lifeos-cdi-refresh.service
+++ b/packaging/cachyos/lifeos-containers/systemd/lifeos-cdi-refresh.service
@@ -1,0 +1,32 @@
+# lifeos-cdi-refresh.service — regenerate /etc/cdi/nvidia.yaml after a
+# driver or kernel module update.
+#
+# Triggered by lifeos-cdi-refresh.path (watches /usr/lib/modules).
+# Runs as root (system-scope) because /etc/cdi/ is root-owned.
+#
+# Idempotent: nvidia-ctk cdi generate --output overwrites any existing file,
+# leaving a valid spec even if the driver version hasn't changed.
+#
+# Security note: nvidia-ctk is installed by nvidia-container-toolkit (AUR).
+# ConditionPathExists guards ensure the unit is a no-op when that package
+# is absent, so the path watcher can be enabled unconditionally.
+
+[Unit]
+Description=Regenerate NVIDIA CDI spec after driver update
+Documentation=https://github.com/hectormr206/lifeos/blob/main/packaging/cachyos/README.md
+After=local-fs.target
+ConditionPathExists=/usr/bin/nvidia-ctk
+ConditionPathExists=/usr/bin/nvidia-smi
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+# Log outcome clearly for journalctl -u lifeos-cdi-refresh.service
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=lifeos-cdi-refresh
+# No persistent state — restart from scratch each time.
+RemainAfterExit=no
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

Recovered PR-4 for PRD Phase 3 (`cachyos-host-profile`). Previously opened as #103 stacked on #102; #102 merged and GitHub auto-closed #103 when its base branch was deleted. Rebased onto `main`; same commits, same content.

Adds the NVIDIA CDI piece on top of PR-3's packaging tree: a systemd `.path` unit that watches the NVIDIA driver and a `.service` that regenerates `/etc/cdi/nvidia.yaml`, plus an interactive setup helper.

## Why

Per design §3, GPU container passthrough on CachyOS uses Container Device Interface (CDI). The user runs `sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml` once. Rolling release CachyOS pushes NVIDIA driver updates that invalidate CDI specs — the `.path` unit auto-regenerates on driver bumps.

## What

| File | Role |
|------|------|
| `lifeos-cdi-refresh.path` | System-scope `.path` watching `/usr/lib/modules`. |
| `lifeos-cdi-refresh.service` | Oneshot service running `nvidia-ctk cdi generate`. |
| `lifeos-cdi-setup` helper | Interactive detector + sudo command printer, supports `--check`. |
| `lifeos-containers/PKGBUILD` (amend) | Installs CDI units + helper, `post_install()` enables `.path`. |
| `packaging/cachyos/README.md` (amend) | Rootless CDI verification section. |

## Commits (4)

- `3abe3e3` — `.path` + `.service` system units
- `25f7eca` — `lifeos-cdi-setup` helper with `--check` flag
- `5b73095` — PKGBUILD amendment + `post_install` enable
- `373e844` — README rootless CDI verification section

## Acceptance

- [x] `bash -n` clean on helper.
- [x] Systemd units include `[Unit]`, `[Path]`/`[Service]`, `[Install]` sections.
- [x] PKGBUILD `package()` extended with `install -Dm644` for units + `install -Dm755` for helper.

## Out of scope

- **PR-5** (#104): validation harness — open.
- **PR-6** (#105): docs rewrite — open.

## Recovery note

This PR replaces the auto-closed #103. No content change; just rebased onto `main` after the underlying PR-3 (#102) merged.