### PR TITLE
feat(packaging): auto-install missing build deps via install.sh

### DIFF
--- a/packaging/cachyos/README.md
+++ b/packaging/cachyos/README.md
@@ -33,9 +33,11 @@ bash install.sh
 
 The installer:
 - Verifies you are on an Arch-based host (CachyOS, Arch, Manjaro, EndeavourOS).
-- Checks that `base-devel` + Rust + GTK4 + the rest of the build deps are present.
+- Checks build dependencies (`base-devel`, Rust, GTK4, etc.) and **auto-installs any that are missing** via `sudo pacman -S --needed --noconfirm`. You are prompted for sudo password once at the start; the rest runs unattended.
 - Runs `makepkg -si` for each of the 5 packages in dependency order.
 - Reports per-package success/failure and exits non-zero if anything failed.
+
+Pass `--no-deps` to skip the dependency auto-install if you want to manage build deps manually.
 
 If you prefer manual control, follow the **Build Order** / **Install Order** sections below.
 

--- a/packaging/cachyos/install.sh
+++ b/packaging/cachyos/install.sh
@@ -67,9 +67,15 @@ Usage:
   install.sh [OPTIONS]
 
 Options:
-  --check       Print what would be done without invoking makepkg
-  --no-deps     Skip the pre-flight build-deps check
+  --check       Dry-run: print what would be installed/built; no changes
+  --no-deps     Skip the pre-flight build-deps check + auto-install
   -h, --help    Show this message
+
+Behavior:
+  Pre-flight auto-installs any missing build dependencies via
+  `sudo pacman -S --needed --noconfirm`. The user is prompted for sudo
+  password once at the start; the rest runs unattended (makepkg will
+  also use sudo internally, but the cached credential covers it).
 
 Build order (dependency-aware):
   1. lifeos-containers (creates system user + tmpfiles)
@@ -89,21 +95,39 @@ is_arch_based() {
     grep -qE '^(ID|ID_LIKE)=.*(arch|cachyos)' /etc/os-release
 }
 
-check_build_deps() {
-    local missing=()
+missing_build_deps() {
     local pkg
     for pkg in "${BUILD_DEPS[@]}"; do
         if ! pacman -Qi "$pkg" >/dev/null 2>&1; then
-            missing+=("$pkg")
+            printf '%s\n' "$pkg"
         fi
     done
-    if (( ${#missing[@]} > 0 )); then
-        log_warn "Missing build dependencies: ${missing[*]}"
-        log_warn "Install them with: sudo pacman -S --needed ${missing[*]}"
+}
+
+install_missing_deps() {
+    # Reads space-separated package list. Auto-installs via pacman.
+    local -a missing=("$@")
+    if (( ${#missing[@]} == 0 )); then
+        log_ok "build dependencies present"
+        return 0
+    fi
+
+    log_warn "Missing build dependencies: ${missing[*]}"
+
+    if (( DRY_RUN == 1 )); then
+        printf '  (dry-run) sudo pacman -S --needed --noconfirm %s\n' "${missing[*]}"
+        return 0
+    fi
+
+    log_step "Auto-installing missing dependencies (you may be prompted for sudo password)"
+    if sudo pacman -S --needed --noconfirm "${missing[@]}"; then
+        log_ok "build dependencies installed"
+        return 0
+    else
+        log_err "Failed to install: ${missing[*]}"
+        log_err "Try manually: sudo pacman -S --needed ${missing[*]}"
         return 1
     fi
-    log_ok "build dependencies present"
-    return 0
 }
 
 install_package() {
@@ -170,9 +194,11 @@ fi
 log_ok "makepkg available"
 
 if (( SKIP_DEPS_CHECK == 0 )); then
-    if ! check_build_deps; then
-        log_err "Pre-flight failed — install the missing dependencies and re-run."
-        log_err "Or run with --no-deps to skip this check (at your own risk)."
+    # Capture missing deps as a real array (newline-separated stdout → array).
+    mapfile -t MISSING < <(missing_build_deps)
+    if ! install_missing_deps "${MISSING[@]}"; then
+        log_err "Pre-flight failed — could not auto-install build dependencies."
+        log_err "Re-run after fixing, or use --no-deps to skip this check."
         exit 2
     fi
 fi


### PR DESCRIPTION
## Summary

Makes \`packaging/cachyos/install.sh\` truly one-command — instead of failing pre-flight and telling the user to run \`sudo pacman -S\` manually, the wrapper now auto-installs missing build dependencies itself. User is prompted for sudo password once at the start; the rest runs unattended.

## Why

Hector flagged it in real install testing: he had to install Rust manually before \`install.sh\` would proceed past pre-flight. That breaks the "automatic install" promise. The wrapper should handle missing deps the same way that any modern installer does (Rustup, Bun, Tailscale).

## What

- \`check_build_deps()\` → split into \`missing_build_deps()\` (returns list) + \`install_missing_deps()\` (runs pacman).
- Pre-flight now: detect missing → \`sudo pacman -S --needed --noconfirm <list>\` → continue. Only fails if pacman fails.
- \`--check\` dry-run prints the exact pacman command that would be invoked, doesn't execute.
- \`--no-deps\` still skips entirely for users who manage their own toolchain.
- Cosmetic fix: missing deps were printing with embedded newlines (because of \`IFS=\$'\\n\\t'\`); now space-separated like a real installer.

## Acceptance

- [x] \`bash -n install.sh\` clean
- [x] \`shellcheck install.sh\` clean
- [x] \`--help\` shows updated behavior
- [x] \`--check\` exercises the dry-run path
- [x] README.md describes the new auto-install flow

## Validation pending

Hector is mid-install on his CachyOS workstation. After this merges he'll \`git pull\` + re-run \`bash install.sh\` to validate the auto-install flow end-to-end.