### PR TITLE
feat(packaging): install.sh auto-installs podman + nvidia-container-toolkit

### DIFF
--- a/packaging/cachyos/install.sh
+++ b/packaging/cachyos/install.sh
@@ -32,6 +32,8 @@ PACKAGES=(
 )
 
 # Build deps that every PKGBUILD assumes are present on the host.
+# These are installed in one pacman batch BEFORE makepkg starts, so the
+# user sees the full picture up front instead of pacman prompting mid-build.
 BUILD_DEPS=(
     base-devel
     rust
@@ -46,6 +48,26 @@ BUILD_DEPS=(
     openssl
     sqlite
 )
+
+# Runtime deps that LifeOS needs to actually FUNCTION after install
+# (declared as `depends=` in the PKGBUILDs, but installing them here means
+# pacman doesn't need to resolve them again during makepkg -i).
+RUNTIME_DEPS=(
+    podman
+)
+
+# Conditional deps appended at runtime based on hardware detection
+# (e.g. nvidia-container-toolkit when an NVIDIA GPU is present).
+CONDITIONAL_DEPS=()
+
+has_nvidia_gpu() {
+    # Cheap signal — lspci or /proc/driver/nvidia. Avoid running nvidia-smi
+    # since the driver might not yet be loaded on a fresh boot.
+    if command -v lspci >/dev/null 2>&1 && lspci | grep -qi 'NVIDIA'; then
+        return 0
+    fi
+    [[ -d /proc/driver/nvidia ]]
+}
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -97,7 +119,8 @@ is_arch_based() {
 
 missing_build_deps() {
     local pkg
-    for pkg in "${BUILD_DEPS[@]}"; do
+    local -a all_deps=("${BUILD_DEPS[@]}" "${RUNTIME_DEPS[@]}" "${CONDITIONAL_DEPS[@]}")
+    for pkg in "${all_deps[@]}"; do
         if ! pacman -Qi "$pkg" >/dev/null 2>&1; then
             printf '%s\n' "$pkg"
         fi
@@ -192,6 +215,14 @@ if ! command -v makepkg >/dev/null 2>&1; then
     exit 2
 fi
 log_ok "makepkg available"
+
+# Hardware detection → optional deps
+if has_nvidia_gpu; then
+    log_ok "NVIDIA GPU detected — adding nvidia-container-toolkit to deps"
+    CONDITIONAL_DEPS+=(nvidia-container-toolkit)
+else
+    log_ok "No NVIDIA GPU detected — skipping nvidia-container-toolkit"
+fi
 
 if (( SKIP_DEPS_CHECK == 0 )); then
     # Capture missing deps as a real array (newline-separated stdout → array).


### PR DESCRIPTION
## Summary

Extends \`packaging/cachyos/install.sh\` so it auto-installs **everything** a working LifeOS install needs, not just build-time toolchain. Follow-up to #111, addressing the gap Hector hit in real install testing: podman + nvidia-container-toolkit were not in the pre-flight list, so the user had to install them separately before \`makepkg -si\` could complete cleanly.

## What

Two new arrays alongside \`BUILD_DEPS\`:

- \`RUNTIME_DEPS\` (unconditional):
  - \`podman\` — the container engine LifeOS targets via Quadlets

- \`CONDITIONAL_DEPS\` (populated by hardware detection at pre-flight):
  - \`nvidia-container-toolkit\` — only when \`has_nvidia_gpu()\` succeeds

\`has_nvidia_gpu()\` uses \`lspci | grep -i NVIDIA\` or \`/proc/driver/nvidia\` — cheap and reliable; avoids \`nvidia-smi\` which may not be loaded on a fresh boot.

Pre-flight now reports the detection outcome explicitly:

\`\`\`
==> Pre-flight checks
  ✓ Arch-based host detected
  ✓ makepkg available
  ✓ NVIDIA GPU detected — adding nvidia-container-toolkit to deps
  ⚠ Missing build dependencies: nvidia-container-toolkit
  ==> Auto-installing missing dependencies (you may be prompted for sudo password)
\`\`\`

## Verified

Live dry-run against the maintainer's CachyOS workstation (RTX 5070 Ti Laptop):

\`\`\`
✓ NVIDIA GPU detected — adding nvidia-container-toolkit to deps
⚠ Missing build dependencies: nvidia-container-toolkit
  (dry-run) sudo pacman -S --needed --noconfirm nvidia-container-toolkit
\`\`\`

Correct: podman was already present (cachyos-extra-v3 ships it), so it's not in the missing set. nvidia-container-toolkit correctly flagged for auto-install.

## Acceptance

- [x] \`bash -n install.sh\` clean
- [x] \`shellcheck install.sh\` clean
- [x] Pre-flight runs on real CachyOS hardware
- [x] NVIDIA detection works on the maintainer's RTX 5070 Ti
- [x] Dry-run shows expected behavior (skips already-installed, flags missing)

## Out of scope

No new dep-class is added besides podman + conditional NVIDIA. Other optdeps from the PKGBUILDs (e.g. SimpleX runtime extras) remain optional and pacman pulls them via the PKGBUILD's own \`depends=\` during \`makepkg -i\`.