### PR TITLE
fix(packaging): use --locked instead of --frozen in Rust PKGBUILDs

### DIFF
--- a/packaging/cachyos/lifeos-cli/PKGBUILD
+++ b/packaging/cachyos/lifeos-cli/PKGBUILD
@@ -33,12 +33,13 @@ build() {
 
     export CARGO_HOME="$srcdir/.cargo"
     export RUSTFLAGS="-C opt-level=3"
-    # --frozen: respect Cargo.lock exactly (reproducible builds).
+    # --locked: respect Cargo.lock exactly (reproducible builds), but allow
+    # cargo to fetch crates from crates.io (we don't vendor deps).
     # --manifest-path: build only the `life` CLI crate, not the full workspace.
     CARGO_PROFILE_RELEASE_LTO=thin \
         cargo build \
             --release \
-            --frozen \
+            --locked \
             --manifest-path cli/Cargo.toml
 }
 

--- a/packaging/cachyos/lifeos-daemon/PKGBUILD
+++ b/packaging/cachyos/lifeos-daemon/PKGBUILD
@@ -44,10 +44,12 @@ build() {
     export RUSTFLAGS="-C opt-level=3"
     # Features must match CI exactly. See CLAUDE.md:
     #   cargo clippy -p lifeosd --all-features — uses dbus,http-api,ui-overlay,wake-word,messaging
+    # --locked: respect Cargo.lock exactly (reproducible builds), but allow
+    # cargo to fetch crates from crates.io (we don't vendor deps).
     CARGO_PROFILE_RELEASE_LTO=thin \
         cargo build \
             --release \
-            --frozen \
+            --locked \
             --manifest-path daemon/Cargo.toml \
             --features "dbus,http-api,ui-overlay,wake-word,messaging"
 }

--- a/packaging/cachyos/lifeos-desktop/PKGBUILD
+++ b/packaging/cachyos/lifeos-desktop/PKGBUILD
@@ -33,10 +33,12 @@ build() {
 
     export CARGO_HOME="$srcdir/.cargo"
     export RUSTFLAGS="-C opt-level=3"
+    # --locked: respect Cargo.lock exactly (reproducible builds), but allow
+    # cargo to fetch crates from crates.io (we don't vendor deps).
     CARGO_PROFILE_RELEASE_LTO=thin \
         cargo build \
             --release \
-            --frozen \
+            --locked \
             --manifest-path desktop/Cargo.toml \
             --features "tray"
 }


### PR DESCRIPTION
## Summary

makepkg builds failed on the maintainer's CachyOS workstation with:

\`\`\`
error: no matching package named \`bytes\` found
location searched: crates.io index
required by package \`life v0.8.42\`
As a reminder, you're using offline mode (--frozen) which can sometimes
cause surprising resolution failures, if this error is too confusing
you may wish to retry without \`--frozen\`.
\`\`\`

## Root cause

All 3 Rust PKGBUILDs (\`lifeos-cli\`, \`lifeos-daemon\`, \`lifeos-desktop\`) use \`cargo build --frozen\`. That flag means \`--locked\` + \`--offline\`. \`--offline\` forces cargo to NOT touch crates.io.

But the repo does not vendor deps (no \`vendor/\` directory, no \`.cargo/config.toml\` with \`offline = true\`). On a fresh clone — exactly what \`makepkg\` does — there's no cache to read from, so the build can never resolve any dep.

## Fix

Change \`--frozen\` to \`--locked\` in all 3 PKGBUILDs.

\`--locked\` keeps the reproducibility guarantee (Cargo.lock must be respected exactly) while allowing cargo to fetch crates from crates.io. That's what you want when you don't vendor.

## Verified failure trace

On real CachyOS hardware (RTX 5070 Ti, fresh repo clone via \`bash install.sh\`):
- \`lifeos-containers\` installed successfully (no Rust)
- \`lifeos-cli\`, \`lifeos-daemon\`, \`lifeos-desktop\` all failed with the \`bytes\` error
- \`lifeos-runtime\` (meta) then failed because its deps weren't installed

## Acceptance

- [x] All 3 PKGBUILDs updated identically
- [x] Comments updated to explain the trade-off
- [ ] Real install verified on CachyOS after merge

## Out of scope

- A future improvement would be to add a \`vendor/\` directory and use \`--offline\` for fully air-gapped builds. Not needed for V1.