### PR TITLE
fix(packaging): unit file ordering cycle + ship dashboard static files

### DIFF
--- a/packaging/cachyos/lifeos-daemon/PKGBUILD
+++ b/packaging/cachyos/lifeos-daemon/PKGBUILD
@@ -65,6 +65,18 @@ package() {
     install -Dm644 "packaging/cachyos/lifeos-daemon/lifeosd.service" \
         "$pkgdir/usr/lib/systemd/user/lifeosd.service"
 
+    # Dashboard static files served by the daemon's HTTP API at /dashboard.
+    # The unit file sets LIFEOS_DASHBOARD_DIR=/usr/share/lifeos/dashboard to
+    # point ServeDir at this path. Without this, /dashboard returns HTTP 404
+    # because the daemon's default relative path resolves to the cwd of the
+    # systemd-spawned process (usually $HOME, where these files don't exist).
+    install -Dm644 "daemon/static/dashboard/index.html" \
+        "$pkgdir/usr/share/lifeos/dashboard/index.html"
+    install -Dm644 "daemon/static/dashboard/app.js" \
+        "$pkgdir/usr/share/lifeos/dashboard/app.js"
+    install -Dm644 "daemon/static/dashboard/style.css" \
+        "$pkgdir/usr/share/lifeos/dashboard/style.css"
+
     # License
     install -Dm644 "LICENSE" \
         "$pkgdir/usr/share/licenses/$pkgname/LICENSE"

--- a/packaging/cachyos/lifeos-daemon/lifeosd.service
+++ b/packaging/cachyos/lifeos-daemon/lifeosd.service
@@ -10,12 +10,16 @@
 [Unit]
 Description=LifeOS AI Daemon (lifeosd)
 Documentation=https://github.com/hectormr206/lifeos
-# Container services must be ready before the daemon starts probing them.
-# Quadlet-generated names (user-scope): lifeos-llama-server.service etc.
-After=network-online.target lifeos-llama-server.service lifeos-llama-embeddings.service lifeos-tts.service
-Wants=network-online.target lifeos-llama-server.service lifeos-llama-embeddings.service lifeos-tts.service
-# SimpleX bridge is optional — don't block daemon start on it.
-Wants=lifeos-simplex-bridge.service
+# Only depend on network. We do NOT use After= for container services because:
+#   1. Quadlet-generated services are WantedBy=default.target — adding
+#      After= for them creates an ordering cycle with lifeosd which is also
+#      WantedBy=default.target. systemd resolves it by DROPPING lifeosd
+#      and the daemon never starts (real bug observed in v0.8.42 install).
+#   2. lifeosd already health-checks container endpoints at runtime and
+#      degrades gracefully when they're not available, so blocking startup
+#      is over-engineering.
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=simple
@@ -25,6 +29,11 @@ ExecStart=/usr/bin/lifeosd
 # If the user is not in the lifeos group the daemon falls back to
 # ${XDG_DATA_HOME:-~/.local/share}/lifeos per existing env-var logic.
 Environment=LIFEOS_DATA_DIR=/var/lib/lifeos
+
+# Dashboard static files: packaged by lifeos-daemon at /usr/share/lifeos/dashboard/.
+# Without this, the daemon's tower-http::ServeDir falls back to a relative
+# path ("daemon/static/dashboard") that doesn't exist when started by systemd.
+Environment=LIFEOS_DASHBOARD_DIR=/usr/share/lifeos/dashboard
 
 # Restart policy: restart on crash, but not on clean exit (ExecStop or
 # SIGTERM-clean). 5s delay avoids restart storms if the daemon exits fast


### PR DESCRIPTION
## Summary

Two real bugs found during the first install on CachyOS hardware (v0.8.42), both fixable with a single packaging PR:

1. **Ordering cycle in `lifeosd.service`** caused systemd to **silently drop the daemon** — it never started.
2. **Dashboard static files were never shipped** → HTTP 404 on `/dashboard` for everyone.

## Bug 1 — Ordering cycle

The unit had:
\`\`\`
After=… lifeos-llama-server.service lifeos-llama-embeddings.service lifeos-tts.service
WantedBy=default.target
\`\`\`

The Quadlet-generated services for those containers are also \`WantedBy=default.target\`. systemd detected the cycle and resolved it by dropping `lifeosd.service/start`:

\`\`\`
default.target: Found ordering cycle: lifeosd.service/start after lifeos-llama-server.service/start after default.target/start - after lifeosd.service
default.target: Job lifeosd.service/start deleted to break ordering cycle starting with default.target/start
\`\`\`

### Fix
Remove `After=` for container services. \`lifeosd\` already health-checks their endpoints at runtime and degrades gracefully — there's no need to block startup. Keep \`After=network-online.target\` only.

## Bug 2 — Dashboard 404

The PKGBUILD installed:
- \`/usr/bin/lifeosd\` ✓
- \`/usr/lib/systemd/user/lifeosd.service\` ✓

…but **never** \`daemon/static/dashboard/{index.html,app.js,style.css}\`. The daemon's \`tower-http::ServeDir\` defaults to relative path \`daemon/static/dashboard\`, which resolves against the systemd-spawned cwd (\`/home/hectormr\` in user-scope). Result: `/dashboard` → 404 for every user.

### Fix
1. PKGBUILD `package()` adds three new \`install -Dm644\` lines for the static files at \`/usr/share/lifeos/dashboard/\`.
2. Unit file gains \`Environment=LIFEOS_DASHBOARD_DIR=/usr/share/lifeos/dashboard\` so ServeDir resolves correctly.

## Verified

- File contents in repo confirmed (`daemon/static/dashboard/{index.html,app.js,style.css}` all present).
- New PKGBUILD lines syntactically valid (`bash -n` style check).
- Unit file no longer carries the After= for container services.

Install verification will run on real hardware after merge (`life host update` + `life init`).

## Out of scope

There are 6 more bugs from the same install session that need separate PRs:
- `ai_runtime_profile.rs` writes a fallback service file that shadows the Quadlet (separate PR).
- UDS socket ownership check is wrong for user-scope (separate PR).
- `life init` should auto-call \`lifeos-quadlet-install --user\` and detect lifeos group (separate PR).
- Audio/wake-word grabs mic without consent (separate PR — needs design).
- System notifications fire by default (separate PR — needs design).
- No model bootstrap on first run (separate PR — needs design).