### PR TITLE
fix(api): UDS stale-socket removal rejecting user-scope daemons

### DIFF
--- a/daemon/src/api/mod.rs
+++ b/daemon/src/api/mod.rs
@@ -12610,13 +12610,60 @@ pub(crate) async fn serve_uds_gate_connection(
     Ok(true)
 }
 
+/// Returns `true` when the daemon is running in user-scope (not as root).
+///
+/// System-scope daemons run as root (`my_uid == 0`). User-scope daemons run
+/// as a regular user and are the legitimate owners of sockets they created,
+/// so the ownership check for stale-socket removal must use the daemon's own
+/// UID instead of requiring root.
+fn is_user_scope(my_uid: u32) -> bool {
+    my_uid != 0
+}
+
+/// Decide whether a stale socket file may be safely removed.
+///
+/// Returns `Ok(true)` when removal is safe (ownership matches), or `Err` with
+/// a human-readable reason when the file must NOT be removed (potential
+/// socket-substitution attack or misconfiguration).
+///
+/// Policy:
+/// - System-scope (`my_uid == 0`): require `file_uid == 0` (root-owned).
+/// - User-scope (`my_uid != 0`): require `file_uid == my_uid` (self-owned).
+fn should_remove_existing_socket(my_uid: u32, file_uid: u32) -> Result<bool, String> {
+    if is_user_scope(my_uid) {
+        if file_uid == my_uid {
+            Ok(true)
+        } else {
+            Err(format!(
+                "socket is owned by uid={file_uid} (expected uid={my_uid}); refusing to remove"
+            ))
+        }
+    } else {
+        // System-scope: only root-owned sockets are safe to remove.
+        if file_uid == 0 {
+            Ok(true)
+        } else {
+            Err(format!(
+                "socket is owned by uid={file_uid} (expected root); refusing to remove"
+            ))
+        }
+    }
+}
+
 /// Bind the UDS API socket, handling stale-socket cleanup.
 /// Mirrors `uds_handout::bind()` pattern (stat → verify socket → remove → bind).
 /// Sets file mode to 0660 (more restrictive than handout's 0666 because the
 /// API socket grants full daemon control, not just token dispensing).
+///
+/// Ownership check is scope-aware: in system-scope (uid=0) the existing socket
+/// must be root-owned; in user-scope (uid!=0) the existing socket must be owned
+/// by the current user. This allows the daemon to restart cleanly after a crash
+/// when running as a non-root user (e.g. CachyOS first-install).
 fn bind_uds_api_socket(path: &std::path::Path) -> anyhow::Result<tokio::net::UnixListener> {
     use anyhow::Context;
     use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    let my_uid = unsafe { libc::getuid() };
 
     if let Ok(meta) = std::fs::symlink_metadata(path) {
         let mode = meta.mode();
@@ -12628,14 +12675,9 @@ fn bind_uds_api_socket(path: &std::path::Path) -> anyhow::Result<tokio::net::Uni
                 mode & libc::S_IFMT
             );
         }
-        // Only remove if owned by root (daemon effective uid).
-        if meta.uid() != 0 {
-            anyhow::bail!(
-                "{} is owned by uid={} (expected root); refusing to remove",
-                path.display(),
-                meta.uid()
-            );
-        }
+        should_remove_existing_socket(my_uid, meta.uid()).map_err(|reason| {
+            anyhow::anyhow!("UDS bind failed at {} ({})", path.display(), reason)
+        })?;
         std::fs::remove_file(path)
             .with_context(|| format!("remove stale socket {}", path.display()))?;
     }
@@ -14193,6 +14235,91 @@ mod tests {
             err_msg.contains("lifeosd.sock"),
             "error must include socket path, got: {err_msg}"
         );
+    }
+
+    // ── fix/uds-ownership-user-scope: ownership helper tests ─────────────
+
+    // RED: is_user_scope — non-root returns true.
+    #[test]
+    fn test_is_user_scope_returns_true_for_non_root() {
+        assert!(is_user_scope(1000));
+    }
+
+    // RED: is_user_scope — root returns false.
+    #[test]
+    fn test_is_user_scope_returns_false_for_root() {
+        assert!(!is_user_scope(0));
+    }
+
+    // RED: user-scope, socket owned by self → Ok(true).
+    #[test]
+    fn test_should_remove_existing_socket_user_scope_self_owned_ok() {
+        let result = should_remove_existing_socket(1000, 1000);
+        assert!(result.is_ok(), "expected Ok, got {:?}", result);
+        assert_eq!(result.unwrap(), true);
+    }
+
+    // RED: user-scope, socket owned by different user → Err.
+    #[test]
+    fn test_should_remove_existing_socket_user_scope_other_user_rejected() {
+        let result = should_remove_existing_socket(1000, 1001);
+        assert!(
+            result.is_err(),
+            "expected Err when different user owns socket"
+        );
+    }
+
+    // RED: user-scope, socket owned by root → Err.
+    #[test]
+    fn test_should_remove_existing_socket_user_scope_root_owned_rejected() {
+        let result = should_remove_existing_socket(1000, 0);
+        assert!(
+            result.is_err(),
+            "expected Err when root owns socket in user-scope"
+        );
+    }
+
+    // RED: system-scope, socket owned by root → Ok(true).
+    #[test]
+    fn test_should_remove_existing_socket_system_scope_root_owned_ok() {
+        let result = should_remove_existing_socket(0, 0);
+        assert!(result.is_ok(), "expected Ok, got {:?}", result);
+        assert_eq!(result.unwrap(), true);
+    }
+
+    // RED: system-scope, socket owned by user → Err.
+    #[test]
+    fn test_should_remove_existing_socket_system_scope_user_owned_rejected() {
+        let result = should_remove_existing_socket(0, 1000);
+        assert!(
+            result.is_err(),
+            "expected Err when user owns socket in system-scope"
+        );
+    }
+
+    // RED: bind_uds_api_socket removes a stale socket owned by the current user
+    // in user-scope. Creates a tempfile socket, calls bind, verifies it rebinds.
+    #[tokio::test]
+    async fn bind_uds_api_socket_removes_stale_user_owned_socket_in_user_scope() {
+        let our_uid = unsafe { libc::getuid() };
+        if our_uid == 0 {
+            // Running as root → this test targets user-scope only; skip.
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("stale.sock");
+
+        // First bind creates the socket owned by us.
+        let _l1 = bind_uds_api_socket(&path).expect("first bind must succeed");
+        assert!(path.exists(), "socket must exist after first bind");
+
+        // Drop _l1 so the fd is released, then attempt second bind.
+        drop(_l1);
+
+        // Second bind must succeed despite the stale socket.
+        let _l2 =
+            bind_uds_api_socket(&path).expect("second bind must succeed (stale socket removal)");
+        assert!(path.exists(), "socket must exist after second bind");
     }
 
     // ── Phase 8b Phase 3: TCP host/origin guard tests ────────────────────

--- a/daemon/src/api/mod.rs
+++ b/daemon/src/api/mod.rs
@@ -14256,7 +14256,7 @@ mod tests {
     fn test_should_remove_existing_socket_user_scope_self_owned_ok() {
         let result = should_remove_existing_socket(1000, 1000);
         assert!(result.is_ok(), "expected Ok, got {:?}", result);
-        assert_eq!(result.unwrap(), true);
+        assert!(result.unwrap());
     }
 
     // RED: user-scope, socket owned by different user → Err.
@@ -14284,7 +14284,7 @@ mod tests {
     fn test_should_remove_existing_socket_system_scope_root_owned_ok() {
         let result = should_remove_existing_socket(0, 0);
         assert!(result.is_ok(), "expected Ok, got {:?}", result);
-        assert_eq!(result.unwrap(), true);
+        assert!(result.unwrap());
     }
 
     // RED: system-scope, socket owned by user → Err.

--- a/docs/operations/runtime-install.md
+++ b/docs/operations/runtime-install.md
@@ -532,6 +532,28 @@ export LIFEOS_BOOTSTRAP_TOKEN="$(< "${XDG_RUNTIME_DIR}/lifeos/bootstrap.token")"
 life init
 ```
 
+### 6.6 — `lifeosd` no arranca después de restart: "UDS bind failed ... refusing to remove"
+
+**Síntoma:** El journal de `lifeosd` muestra:
+
+```
+ERROR lifeosd::api] UDS bind failed at /run/lifeos/lifeosd.sock
+(/run/lifeos/lifeosd.sock is owned by uid=1000 (expected root); refusing to remove);
+daemon will not start
+```
+
+**Causa (resuelto en versiones recientes):** verificación de propiedad del socket era system-scope only. El daemon en user-scope se creó el socket previo como tu usuario, pero la siguiente instancia rechazaba removerlo porque "esperaba root". Bug clásico de cuando LifeOS migró de system-scope (bootc) a user-scope (runtime pivot).
+
+**Solución temporal (si seguís en una versión vieja):**
+
+```bash
+systemctl --user stop lifeosd
+rm -f /run/lifeos/lifeosd.sock
+systemctl --user start lifeosd
+```
+
+**Solución permanente:** actualizar al build más reciente — la verificación ahora distingue user-scope (acepta socket propio) vs system-scope (mantiene la check anti-substitution).
+
 ---
 
 ## 7. Respaldo de `memory.db`


### PR DESCRIPTION
## Summary

Fixes the **fatal restart bug** where `lifeosd` running in user-scope can never recover from a stale socket file. After any crash or restart, the daemon hits:

\`\`\`
ERROR lifeosd::api] UDS bind failed at /run/lifeos/lifeosd.sock 
(/run/lifeos/lifeosd.sock is owned by uid=1000 (expected root); refusing to remove); 
daemon will not start
\`\`\`

## Root cause

The UDS-bind code in `daemon/src/api/mod.rs` carries an anti-substitution security check from the system-scope era: refuse to remove an existing socket unless it's owned by root.

That check is wrong in **user-scope** where:
- The daemon RUNS as the user (uid=1000).
- The previous instance CREATED the socket as the user.
- The current instance refuses to clean up its own predecessor's socket.

Real failure observed during first install on CachyOS hardware (v0.8.42).

## Fix

Two new testable helpers:

| Helper | Purpose |
|---|---|
| `is_user_scope(my_uid: u32) -> bool` | True when `my_uid != 0` (running as non-root). |
| `should_remove_existing_socket(my_uid: u32, file_uid: u32) -> Result<bool, String>` | Pure decision: removal is safe only when the socket is owned by the SAME identity that the daemon is running as. |

Bind policy:

| Daemon | Existing socket owner | Action |
|--------|----------------------|--------|
| root (uid=0) | root | remove + rebind |
| root (uid=0) | user | refuse (legit security check) |
| user (uid=1000) | same user | remove + rebind (THE FIX) |
| user (uid=1000) | different user | refuse |
| user (uid=1000) | root | refuse (don't undo a system-scope predecessor) |

## TDD evidence

8 new tests in strict RED → GREEN → REFACTOR cycle:
- 2 cover `is_user_scope` (uid=0, uid≠0).
- 5 cover all `should_remove_existing_socket` policy combinations.
- 1 integration test creates a temp socket, calls the bind helper, verifies removal happens. Skips when CI runs as root.

903/903 tests pass. Clippy clean. fmt clean.

## Out of scope

`daemon/src/uds_handout.rs::bind()` has the same hardcoded `uid == 0` guard at line 153. In production it only runs in system-scope so the bug doesn't manifest there. Left untouched in this PR to keep the scope tight; will revisit when/if uds_handout is used in user-scope.

## Companion PRs

This is one of 5 PRs from the same install diagnosis session. See PR #114 (packaging combo), plus 3 sub-agent PRs in flight (ai_runtime fallback skip, life init UX, audio+notifications opt-in).