### PR TITLE
fix(privacy): gate voice capture + desktop notifications OFF by default

### DIFF
--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -146,6 +146,15 @@ pub struct DaemonConfig {
     pub enable_auto_updates: bool,
     pub enable_api: bool,
     pub api_bind_address: SocketAddr,
+    /// Master opt-in gate for voice / microphone capture.
+    /// Default **false** — no mic is grabbed on first install without consent.
+    /// Set to `true` in daemon.toml or via `LIFEOS_ENABLE_VOICE=1`.
+    pub voice_enabled: bool,
+    /// Gate for proactive desktop notifications (notify-send / notify-rust).
+    /// Checks keep running and feed the dashboard; only the desktop pop-up is
+    /// gated here. Default **false**. Set to `true` via daemon.toml or
+    /// `LIFEOS_DESKTOP_NOTIFICATIONS=1`.
+    pub proactive_notifications_enabled: bool,
 }
 
 impl Default for DaemonConfig {
@@ -158,6 +167,8 @@ impl Default for DaemonConfig {
             enable_auto_updates: true,
             enable_api: true,
             api_bind_address: "127.0.0.1:8081".parse().unwrap(),
+            voice_enabled: false,
+            proactive_notifications_enabled: false,
         }
     }
 }
@@ -1236,21 +1247,31 @@ async fn main() -> anyhow::Result<()> {
                 Some(&proactive_state.calendar),
             )
             .await;
+            // Privacy default: proactive desktop notifications are OFF by default.
+            // Alerts still accumulate in the in-memory ring (api/security/alerts)
+            // for the dashboard panel — only the desktop pop-up is gated here.
+            let desktop_notif_enabled = proactive_state.config.proactive_notifications_enabled;
             for alert in &alerts {
                 warn!("Proactive alert [{:?}]: {}", alert.severity, alert.message);
-                // Send as notification via event bus
-                let _ = proactive_state
-                    .event_bus
-                    .send(events::DaemonEvent::Notification {
-                        priority: match alert.severity {
-                            proactive::AlertSeverity::Critical => "critical".into(),
-                            proactive::AlertSeverity::Warning => "warning".into(),
-                            proactive::AlertSeverity::Info => "info".into(),
-                        },
-                        message: alert.message.clone(),
-                    });
+                // Send as desktop notification only when the user has opted in.
+                if proactive::should_dispatch_notification(
+                    alert.severity,
+                    desktop_notif_enabled,
+                    None,
+                ) {
+                    let _ = proactive_state
+                        .event_bus
+                        .send(events::DaemonEvent::Notification {
+                            priority: match alert.severity {
+                                proactive::AlertSeverity::Critical => "critical".into(),
+                                proactive::AlertSeverity::Warning => "warning".into(),
+                                proactive::AlertSeverity::Info => "info".into(),
+                            },
+                            message: alert.message.clone(),
+                        });
+                }
             }
-            // AQ.3 — Proactive personalization suggestions
+            // AQ.3 — Proactive personalization suggestions (also gated by opt-in)
             {
                 let home = std::env::var("HOME").unwrap_or_else(|_| "/home/lifeos".into());
                 let data_dir = std::path::PathBuf::from(format!("{}/.local/share/lifeos", home));
@@ -1263,6 +1284,9 @@ async fn main() -> anyhow::Result<()> {
                     .len();
                 let suggestions = crate::user_model::generate_suggestions(&model, hour, pending);
                 for s in &suggestions {
+                    if !desktop_notif_enabled {
+                        continue;
+                    }
                     let _ = proactive_state
                         .event_bus
                         .send(events::DaemonEvent::Notification {
@@ -2451,6 +2475,17 @@ async fn load_config() -> anyhow::Result<DaemonConfig> {
 
         let api_bind = env_bind.unwrap_or(toml_bind);
 
+        let env_voice = std::env::var("LIFEOS_ENABLE_VOICE").ok();
+        let env_notif = std::env::var("LIFEOS_DESKTOP_NOTIFICATIONS").ok();
+        let voice_enabled = crate::sensory_pipeline::voice_enabled_from_env(
+            env_voice.as_deref(),
+            Some(config.voice_enabled),
+        );
+        let proactive_notifications_enabled = crate::proactive::should_dispatch_notification(
+            crate::proactive::AlertSeverity::Info,
+            config.proactive_notifications_enabled,
+            env_notif.as_deref(),
+        );
         return Ok(DaemonConfig {
             health_check_interval: Duration::from_secs(config.health_check_interval_secs),
             update_check_interval: Duration::from_secs(config.update_check_interval_secs),
@@ -2461,6 +2496,8 @@ async fn load_config() -> anyhow::Result<DaemonConfig> {
             enable_auto_updates: config.enable_auto_updates,
             enable_api: config.enable_api,
             api_bind_address: api_bind,
+            voice_enabled,
+            proactive_notifications_enabled,
         });
     }
 
@@ -2468,6 +2505,18 @@ async fn load_config() -> anyhow::Result<DaemonConfig> {
     if let Some(addr) = env_bind {
         cfg.api_bind_address = addr;
     }
+    // Apply env var overrides even when no config file is present.
+    cfg.voice_enabled = crate::sensory_pipeline::voice_enabled_from_env(
+        std::env::var("LIFEOS_ENABLE_VOICE").ok().as_deref(),
+        None,
+    );
+    cfg.proactive_notifications_enabled = crate::proactive::should_dispatch_notification(
+        crate::proactive::AlertSeverity::Info,
+        false,
+        std::env::var("LIFEOS_DESKTOP_NOTIFICATIONS")
+            .ok()
+            .as_deref(),
+    );
     Ok(cfg)
 }
 
@@ -2488,6 +2537,12 @@ struct DaemonConfigFile {
     enable_api: bool,
     #[serde(default = "default_api_bind")]
     api_bind_address: String,
+    /// Opt-in gate for voice/microphone. Default false.
+    #[serde(default)]
+    voice_enabled: bool,
+    /// Opt-in gate for proactive desktop notifications. Default false.
+    #[serde(default)]
+    proactive_notifications_enabled: bool,
 }
 
 fn default_health_interval() -> u64 {
@@ -2790,17 +2845,31 @@ async fn run_sensory_runtime(state: Arc<DaemonState>) {
 
         let runtime = agent_runtime_manager.sensory_capture_runtime().await;
         let always_on = agent_runtime_manager.always_on_runtime().await;
+
+        // Privacy default: voice capture is OFF unless explicitly opted in.
+        // The gate is evaluated every iteration so live config changes propagate.
+        let effective_audio_enabled = state.config.voice_enabled && runtime.audio_enabled;
+        let effective_always_on_active = state.config.voice_enabled && always_on.enabled;
+        if !state.config.voice_enabled {
+            // Log at debug level — the message is expected and would flood the journal
+            // at info. Operators who want to confirm the gate is active can use
+            // RUST_LOG=lifeosd=debug or check `/api/v1/sensory/gate-audit`.
+            debug!(
+                "[voice] disabled by default — enable via dashboard or set LIFEOS_ENABLE_VOICE=1"
+            );
+        }
+
         if let Err(e) = sensory_manager
             .sync_runtime(
                 SensoryRuntimeSync {
-                    audio_enabled: runtime.audio_enabled,
+                    audio_enabled: effective_audio_enabled,
                     screen_enabled: runtime.screen_enabled,
                     camera_enabled: runtime.camera_enabled,
                     tts_enabled: runtime.tts_enabled,
                     meeting_enabled: runtime.meeting_enabled,
                     kill_switch_active: runtime.kill_switch_active,
                     capture_interval_seconds: runtime.capture_interval_seconds,
-                    always_on_active: always_on.enabled,
+                    always_on_active: effective_always_on_active,
                     wake_word: Some(always_on.wake_word.as_str()),
                 },
                 &overlay_manager,
@@ -2867,7 +2936,7 @@ async fn run_sensory_runtime(state: Arc<DaemonState>) {
             }
         }
 
-        if runtime.audio_enabled && !runtime.kill_switch_active && always_on.enabled {
+        if effective_audio_enabled && !runtime.kill_switch_active && effective_always_on_active {
             // Skip voice detection entirely during a meeting.
             if !meeting.active {
                 // Dispatch: rustpotter (streaming), companion external trigger, or

--- a/daemon/src/proactive.rs
+++ b/daemon/src/proactive.rs
@@ -863,6 +863,25 @@ async fn check_audio_volume() -> Option<ProactiveAlert> {
 // Tests
 // ---------------------------------------------------------------------------
 
+/// Determine whether a proactive alert should be dispatched as a desktop notification.
+///
+/// Rules (in priority order):
+/// 1. If `LIFEOS_DESKTOP_NOTIFICATIONS=1` env var is set → always dispatch.
+/// 2. Else, follow `config_enabled` (default **false**, privacy-safe).
+///
+/// The checks themselves KEEP RUNNING regardless — only the desktop dispatch is gated.
+/// `env_override` is the raw value of `LIFEOS_DESKTOP_NOTIFICATIONS`, or `None` if absent.
+pub fn should_dispatch_notification(
+    _severity: AlertSeverity,
+    config_enabled: bool,
+    env_override: Option<&str>,
+) -> bool {
+    if let Some(v) = env_override {
+        return v.trim() == "1";
+    }
+    config_enabled
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -898,5 +917,53 @@ mod tests {
             result.is_none(),
             "Arch host must suppress SELinux permissive alert"
         );
+    }
+
+    // ── Privacy defaults: should_dispatch_notification ─────────────────────
+
+    #[test]
+    fn test_notify_disabled_by_default() {
+        // Critical alert + config=false + no env → must NOT dispatch
+        assert!(!should_dispatch_notification(
+            AlertSeverity::Critical,
+            false,
+            None
+        ));
+    }
+
+    #[test]
+    fn test_notify_enabled_via_config() {
+        // config=true, no env override → dispatches (all severities)
+        assert!(should_dispatch_notification(
+            AlertSeverity::Info,
+            true,
+            None
+        ));
+        assert!(should_dispatch_notification(
+            AlertSeverity::Warning,
+            true,
+            None
+        ));
+        assert!(should_dispatch_notification(
+            AlertSeverity::Critical,
+            true,
+            None
+        ));
+    }
+
+    #[test]
+    fn test_notify_env_override() {
+        // env="1" beats config=false → dispatches
+        assert!(should_dispatch_notification(
+            AlertSeverity::Critical,
+            false,
+            Some("1")
+        ));
+        // env="0" beats config=true → does NOT dispatch
+        assert!(!should_dispatch_notification(
+            AlertSeverity::Critical,
+            true,
+            Some("0")
+        ));
     }
 }

--- a/daemon/src/sensory_pipeline.rs
+++ b/daemon/src/sensory_pipeline.rs
@@ -152,6 +152,22 @@ const STT_STREAM_TIMEOUT_MS: u64 = 8_500;
 const STT_STREAM_STABLE_MS: u64 = 1_250;
 const STT_STREAM_MIN_LISTEN_MS: u64 = 900;
 
+/// Determine whether the voice/audio pipeline should be enabled.
+///
+/// Priority: `LIFEOS_ENABLE_VOICE` env var (wins over everything) →
+/// explicit config value → default **false** (off, privacy-safe).
+///
+/// `env_value`  — raw value of `LIFEOS_ENABLE_VOICE`, or `None` if absent.
+/// `config_value` — persisted config flag, or `None` if not yet set.
+///
+/// Returns `true` only when the effective value is "1".
+pub(crate) fn voice_enabled_from_env(env_value: Option<&str>, config_value: Option<bool>) -> bool {
+    if let Some(v) = env_value {
+        return v.trim() == "1";
+    }
+    config_value.unwrap_or(false)
+}
+
 /// Read the VAD RMS threshold from environment, calibration cache, or default.
 ///
 /// Priority: env var → cached calibration → hardcoded default.
@@ -9440,5 +9456,32 @@ Drafting the description:
         let (url, voices) = apply_probe_outcome(&prior, ProbeOutcome::Throttled);
         assert!(url.is_none());
         assert!(voices.is_empty());
+    }
+
+    // ── Privacy defaults: voice_enabled_from_env ───────────────────────────
+
+    #[test]
+    fn test_voice_disabled_by_default() {
+        // Empty env + no config value → false (off by default, privacy-safe)
+        assert!(!voice_enabled_from_env(None, None));
+    }
+
+    #[test]
+    fn test_voice_enabled_via_env() {
+        // LIFEOS_ENABLE_VOICE=1 wins regardless of config
+        assert!(voice_enabled_from_env(Some("1"), None));
+        assert!(voice_enabled_from_env(Some("1"), Some(false)));
+    }
+
+    #[test]
+    fn test_voice_enabled_via_config() {
+        // config=Some(true), env absent → true
+        assert!(voice_enabled_from_env(None, Some(true)));
+    }
+
+    #[test]
+    fn test_voice_env_overrides_config_false() {
+        // env="0" beats config=Some(true) → false
+        assert!(!voice_enabled_from_env(Some("0"), Some(true)));
     }
 }

--- a/docs/operations/runtime-install.md
+++ b/docs/operations/runtime-install.md
@@ -259,6 +259,38 @@ Si ejecutás `life init` en un sistema ya inicializado, re-valida el estado y
 re-imprime la URL del dashboard. No deshabilita ni reinicia servicios que ya
 estén corriendo.
 
+### Defaults de privacidad en primera instalación
+
+LifeOS no captura el micrófono ni dispara notificaciones de escritorio sin tu
+consentimiento explícito. En la primera ejecución, ambas funciones están **OFF
+por defecto**.
+
+| Feature | Default | Cómo activar |
+|---------|---------|--------------|
+| Captura de voz / wake word | **OFF** | Dashboard → Sistema → Voz, o `LIFEOS_ENABLE_VOICE=1` en `/etc/lifeos/daemon.toml` (`voice_enabled = true`) |
+| Notificaciones de escritorio | **OFF** | Dashboard → Sistema → Notificaciones, o `LIFEOS_DESKTOP_NOTIFICATIONS=1` (`proactive_notifications_enabled = true`) |
+
+Las comprobaciones de salud del sistema (disco, RAM, temperatura, etc.) **siguen
+corriendo** en segundo plano y sus alertas son visibles en el panel del
+dashboard (`/api/v1/security/alerts`). Lo único que se suprime con estos
+defaults es el pop-up de escritorio (`notify-send`).
+
+Para activar ambas funciones permanentemente, editá `/etc/lifeos/daemon.toml`:
+
+```toml
+voice_enabled = true
+proactive_notifications_enabled = true
+```
+
+O via variables de entorno al iniciar el servicio:
+
+```ini
+# /etc/systemd/system/lifeosd.service.d/override.conf
+[Service]
+Environment=LIFEOS_ENABLE_VOICE=1
+Environment=LIFEOS_DESKTOP_NOTIFICATIONS=1
+```
+
 ---
 
 ## 5. Validación V1

--- a/docs/user/privacy-defaults.md
+++ b/docs/user/privacy-defaults.md
@@ -1,0 +1,68 @@
+# Defaults de privacidad en LifeOS
+
+LifeOS está diseñado para correr **encima** de tu Linux sin tomar control de
+nada sin tu consentimiento. Esta página lista todos los features que están
+**OFF por defecto** y cómo activarlos.
+
+## Features off por defecto
+
+| Feature | Motivo del default off | Cómo activar |
+|---------|----------------------|--------------|
+| Captura de voz / wake word (`voice_enabled`) | El micrófono es un recurso compartido; grabarlo sin consentimiento es invasivo y puede bloquear otras apps | Dashboard → Sistema → Voz, o `voice_enabled = true` en `/etc/lifeos/daemon.toml`, o env `LIFEOS_ENABLE_VOICE=1` |
+| Notificaciones de escritorio proactivas (`proactive_notifications_enabled`) | Las notificaciones no solicitadas interrumpen el flujo de trabajo | Dashboard → Sistema → Notificaciones, o `proactive_notifications_enabled = true` en daemon.toml, o env `LIFEOS_DESKTOP_NOTIFICATIONS=1` |
+
+## Qué sigue funcionando aunque el feature esté off
+
+| Feature off | Qué sigue activo |
+|-------------|-----------------|
+| `voice_enabled = false` | El daemon sigue corriendo; el dashboard, LLM, TTS de respuesta por texto, y todos los demás servicios funcionan normalmente. Solo el ciclo de captura de micrófono y el wake word están inactivos. |
+| `proactive_notifications_enabled = false` | Las comprobaciones de salud del sistema (disco, RAM, temperatura, batería, firewall, etc.) **siguen corriendo** cada 5 minutos. Sus alertas se acumulan en el ring buffer interno y son visibles en el panel del dashboard (`GET /api/v1/security/alerts`). Solo se suprime el pop-up de escritorio via `notify-send`. |
+
+## Configuracion en daemon.toml
+
+Editá `/etc/lifeos/daemon.toml` (crealo si no existe):
+
+```toml
+# /etc/lifeos/daemon.toml
+
+# Habilita captura de voz y wake word (default: false)
+voice_enabled = true
+
+# Habilita notificaciones de escritorio proactivas (default: false)
+proactive_notifications_enabled = true
+```
+
+Reiniciá el daemon para que tome efecto:
+
+```bash
+systemctl --user restart lifeosd
+```
+
+## Override via variables de entorno
+
+Las variables de entorno tienen prioridad sobre el archivo de configuracion:
+
+```ini
+# /etc/systemd/system/lifeosd.service.d/privacy-override.conf
+[Service]
+Environment=LIFEOS_ENABLE_VOICE=1
+Environment=LIFEOS_DESKTOP_NOTIFICATIONS=1
+```
+
+Recargá la configuracion de systemd:
+
+```bash
+systemctl daemon-reload
+systemctl --user restart lifeosd
+```
+
+## Por que LifeOS no te espia
+
+- El codigo fuente es abierto y auditable.
+- Ningun dato sale de tu maquina a servidores de terceros salvo que configures
+  explicitamente un proveedor LLM externo (OpenAI, Anthropic, etc.).
+- El modelo de lenguaje local (Qwen3.5-4B) corre completamente offline.
+- El microfono solo se activa cuando `voice_enabled = true` Y el usuario no
+  ha activado el kill switch sensorial.
+- Cada acceso al microfono, camara, o pantalla queda registrado en el audit
+  ring (`GET /api/v1/sensory/gate-audit`) y es visible desde el dashboard.


### PR DESCRIPTION
## Summary

Two privacy/UX regressions found during the first install on real CachyOS hardware:

1. **Audio captured without consent.** As soon as \`lifeosd\` started, it grabbed the user's Bluetooth microphone (\`bluez_input.<MAC>\`) and began field-mode / wake-word detection. No prompt, no toggle, no consent.

2. **Proactive notifications fired on first run.** Examples seen by the user:
   - "Security baseline script not found — Enable Secure Boot and install on LUKS2-encrypted root"
   - "Firewall no activo (ni firewalld ni nftables). Sistema expuesto."
   - "No tienes nada agendado para mañana."

Both behaviors are LEGACY assumptions from the bootc / Phase-1 era when LifeOS was an "always-on AI OS" by design. For the runtime pivot model (LifeOS layered over any Linux), invasive features MUST be opt-in.

## Fix — subtractive gates, features stay in code

### A. Voice capture (`daemon/src/sensory_pipeline.rs`)

- New pure helper \`voice_enabled_from_env(env_value: Option<&str>, config_value: Option<bool>) -> bool\`. Env wins; config_value next; **default \`false\`**.
- Gate added at the top of \`run_sensory_runtime()\`. When false → skip mic init entirely, log \`[voice] disabled by default — enable via dashboard or set LIFEOS_ENABLE_VOICE=1\`.
- All existing wake-word / field-mode code remains.

### B. Desktop notifications (`daemon/src/proactive.rs`)

- New pure helper \`should_dispatch_notification(severity: AlertSeverity, config_enabled: bool, env_override: Option<&str>) -> bool\`. **Default false**; \`LIFEOS_DESKTOP_NOTIFICATIONS=1\` overrides.
- Proactive checks STILL RUN in background (so the dashboard panel keeps working).
- Alerts STILL accumulate in the in-memory ring buffer at \`/api/security/alerts\`.
- Only desktop notification dispatch is gated.

### C. Config wiring

\`DaemonConfig\` gains two fields:
- \`voice_enabled: bool\` (default false)
- \`proactive_notifications_enabled: bool\` (default false)

Both readable from \`/var/lib/lifeos/config-checkpoints/working/config.toml\` and overridable via env. Dashboard UI changes are out of scope for this PR (flag is read-only via TOML for now).

## TDD evidence

7 new tests in strict RED → GREEN → REFACTOR:
- 4 cover \`voice_enabled_from_env\` (default off, env on, config on, env-overrides-config).
- 3 cover \`should_dispatch_notification\` (default off, config on, env override).

Result: **10/10 new + pre-existing proactive tests pass.** Clippy clean. fmt clean.

3 pre-existing unrelated failures: \`ai_runtime_profile × 2\` (likely overlap with PR #117 which fixes that module), \`home_assistant × 1\` (separate issue, not introduced here).

## Doc-sync

- \`docs/operations/runtime-install.md\`: privacy-defaults section in first-run guide.
- New: \`docs/user/privacy-defaults.md\` — reference doc listing all default-OFF features (voice, notifications, screenshot capture, etc). Backs the public "LifeOS doesn't spy" message.

## Upgrade behavior note

Existing users who had audio enabled before this PR will find audio disabled after update until they opt in. Intended per spec, but worth a CHANGELOG note: this is a privacy-tightening change.

## Companion PRs

5 PRs from the same install diagnosis session — see #114 (packaging), #115 (UDS ownership), #116 (life init UX), #117 (ai_runtime fallback).