### PR TITLE
feat(heartbeat): corazón — self-healing supervisor with liveness watchdog

### DIFF
--- a/axi/INSTALL.md
+++ b/axi/INSTALL.md
@@ -59,3 +59,33 @@ Probar: tap Super+Space → notificación "🎤 Escuchando". Hablar. Tap otra ve
 systemctl --user stop axi-voice.service
 systemctl --user disable axi-voice.service
 ```
+
+## 6. Heartbeat — auto-healing supervisor (corazon)
+
+The heartbeat service watches all core Axi services and revives them if they
+enter the `failed` state. It is rate-capped at 3 revivals per service per hour
+and skips GPU-heavy services (`llama-server`, `llama-nano`) while game mode is
+active. The game-mode lock path is `$XDG_STATE_HOME/axi/game-mode.lock`
+(default: `~/.local/state/axi/game-mode.lock`).
+
+Install and enable:
+
+```fish
+cp ~/LifeOS/lifeos/axi/systemd/axi-heartbeat.service ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable --now axi-heartbeat.service
+systemctl --user status axi-heartbeat.service
+```
+
+View live logs:
+
+```fish
+journalctl --user -u axi-heartbeat -f
+```
+
+Stop / disable:
+
+```fish
+systemctl --user stop axi-heartbeat.service
+systemctl --user disable axi-heartbeat.service
+```

--- a/axi/src/axi/heartbeat.py
+++ b/axi/src/axi/heartbeat.py
@@ -1,0 +1,228 @@
+"""Axi heartbeat — self-healing supervisor (corazon of LifeOS).
+
+Detects systemd user services in the `failed` state and revives them under
+a per-service rate cap, with game-mode protection for GPU-heavy services and a
+liveness pulse via sd_notify so systemd can detect a hung-but-running heart.
+
+Usage (direct / systemd):
+    python -m axi.heartbeat
+"""
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import sys
+import time
+from collections import defaultdict, deque
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Invariant assertion: STARTUP_GRACE_SEC < WatchdogSec (90)
+# ---------------------------------------------------------------------------
+# Verified at module-import time so a misconfiguration fails fast.
+_WATCHDOG_SEC = 90
+
+# ---------------------------------------------------------------------------
+# Module-level constants (monkeypatch seams for tests)
+# ---------------------------------------------------------------------------
+
+HEARTBEAT_SERVICES: list[str] = [
+    "axi-voice.service",
+    "axi-whisper.service",
+    "ydotoold.service",
+    "axi-tray.service",
+    "axi-dashboard.service",
+]
+
+GAME_BRAINS: list[str] = [
+    "llama-server.service",
+    "llama-nano.service",
+]
+
+POLL_INTERVAL_SEC: int = 30       # seconds between poll cycles
+STARTUP_GRACE_SEC: int = 30       # delay before the very first revival cycle
+RATE_CAP: int = 3                 # max revivals per service per rolling window
+RATE_WINDOW_SEC: int = 3600       # 1-hour rolling window
+SYSTEMCTL_TIMEOUT: int = 5        # seconds before a systemctl call is aborted
+
+# Validate STARTUP_GRACE_SEC < WatchdogSec at import time
+assert STARTUP_GRACE_SEC < _WATCHDOG_SEC, (
+    f"STARTUP_GRACE_SEC ({STARTUP_GRACE_SEC}) must be < WatchdogSec ({_WATCHDOG_SEC})"
+)
+
+# ---------------------------------------------------------------------------
+# In-memory rate-cap state  (cleared on restart — intentional; see design)
+# ---------------------------------------------------------------------------
+
+_revivals: dict[str, deque] = defaultdict(deque)
+
+
+# ---------------------------------------------------------------------------
+# sd_notify — vendored ~15-line socket helper (no python-systemd dep)
+# ---------------------------------------------------------------------------
+
+def _sd_notify(state: str) -> None:
+    """Send a datagram to $NOTIFY_SOCKET. No-op if the var is unset."""
+    addr = os.environ.get("NOTIFY_SOCKET")
+    if not addr:
+        return
+    # '@' prefix indicates an abstract-namespace socket; replace with NUL byte.
+    if addr.startswith("@"):
+        addr = "\0" + addr[1:]
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM) as sock:
+            sock.connect(addr)
+            sock.sendall(state.encode())
+    except OSError:
+        pass  # best-effort; running outside systemd or socket unavailable
+
+
+def notify_ready() -> None:
+    """Emit READY=1 to systemd (call exactly once at startup)."""
+    _sd_notify("READY=1")
+
+
+def notify_watchdog() -> None:
+    """Emit WATCHDOG=1 (call only after a clean run_cycle)."""
+    _sd_notify("WATCHDOG=1")
+
+
+# ---------------------------------------------------------------------------
+# Game-mode guard
+# ---------------------------------------------------------------------------
+
+def _game_lock_path() -> Path:
+    """Return the canonical path for the game-mode lock file."""
+    root = os.environ.get("XDG_STATE_HOME") or str(Path.home() / ".local" / "state")
+    return Path(root) / "axi" / "game-mode.lock"
+
+
+def game_mode_active() -> bool:
+    """True iff the game-mode lock file exists."""
+    return _game_lock_path().exists()
+
+
+# ---------------------------------------------------------------------------
+# Watchlist
+# ---------------------------------------------------------------------------
+
+def watched_services(game_active: bool) -> list[str]:
+    """Return the list of services to watch this cycle.
+
+    HEARTBEAT_SERVICES are always watched.
+    GAME_BRAINS are added only when game mode is OFF.
+    """
+    svcs = list(HEARTBEAT_SERVICES)
+    if not game_active:
+        svcs.extend(GAME_BRAINS)
+    return svcs
+
+
+# ---------------------------------------------------------------------------
+# Failed-state detection
+# ---------------------------------------------------------------------------
+
+def is_failed(svc: str) -> bool:
+    """Return True iff `systemctl --user is-failed <svc>` reports 'failed'."""
+    result = subprocess.run(
+        ["systemctl", "--user", "is-failed", svc],
+        capture_output=True,
+        text=True,
+        timeout=SYSTEMCTL_TIMEOUT,
+    )
+    return result.stdout.strip() == "failed"
+
+
+# ---------------------------------------------------------------------------
+# Rate cap
+# ---------------------------------------------------------------------------
+
+def under_cap(svc: str, now: float) -> bool:
+    """Return True if this service has fewer than RATE_CAP revivals in the window.
+
+    Prunes timestamps older than now - RATE_WINDOW_SEC from the left of the
+    deque before evaluating.
+    """
+    dq = _revivals[svc]
+    cutoff = now - RATE_WINDOW_SEC
+    while dq and dq[0] < cutoff:
+        dq.popleft()
+    return len(dq) < RATE_CAP
+
+
+def record_revival(svc: str, now: float) -> None:
+    """Record a revival timestamp for rate-cap accounting."""
+    _revivals[svc].append(now)
+
+
+# ---------------------------------------------------------------------------
+# Side-effect actions
+# ---------------------------------------------------------------------------
+
+def revive(svc: str) -> None:
+    """Execute the revival sequence: reset-failed then start."""
+    subprocess.run(
+        ["systemctl", "--user", "reset-failed", svc],
+        timeout=SYSTEMCTL_TIMEOUT,
+    )
+    subprocess.run(
+        ["systemctl", "--user", "start", svc],
+        timeout=SYSTEMCTL_TIMEOUT,
+    )
+
+
+def alert_cap_exceeded(svc: str) -> None:
+    """Emit a desktop notification when a service has exceeded its revival cap."""
+    subprocess.run(
+        [
+            "notify-send",
+            "--urgency=critical",
+            "Axi heartbeat — revival cap exceeded",
+            f"{svc} is genuinely broken — gave up after {RATE_CAP}/hour",
+        ],
+        timeout=SYSTEMCTL_TIMEOUT,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The spine — run_cycle(now)
+# ---------------------------------------------------------------------------
+
+def run_cycle(now: float | None = None) -> None:
+    """Execute one poll cycle.
+
+    Detects failed services, applies game-mode guard and rate cap, then
+    either revives the service or emits a desktop alert.
+
+    Returns normally only when the entire cycle completes without an
+    unhandled exception. An exception here means no watchdog beat is emitted,
+    which causes systemd to kill and restart the process via WatchdogSec.
+    """
+    now = time.time() if now is None else now
+    game = game_mode_active()
+    for svc in watched_services(game):
+        if not is_failed(svc):
+            continue
+        if under_cap(svc, now):
+            revive(svc)
+            record_revival(svc, now)
+        else:
+            alert_cap_exceeded(svc)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    notify_ready()                   # tell systemd init is done
+    time.sleep(STARTUP_GRACE_SEC)    # let services settle after boot
+    while True:
+        run_cycle()                  # may raise → no beat → watchdog reaps us
+        notify_watchdog()            # beat only after a clean cycle
+        time.sleep(POLL_INTERVAL_SEC)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/axi/src/axi/heartbeat.py
+++ b/axi/src/axi/heartbeat.py
@@ -57,6 +57,10 @@ assert STARTUP_GRACE_SEC < _WATCHDOG_SEC, (
 
 _revivals: dict[str, deque] = defaultdict(deque)
 
+# Per-service alert dedup: set of service names that have already received a
+# cap-exceeded notification this episode. Reset when the service recovers.
+_alerted: set[str] = set()
+
 
 # ---------------------------------------------------------------------------
 # sd_notify — vendored ~15-line socket helper (no python-systemd dep)
@@ -146,7 +150,7 @@ def under_cap(svc: str, now: float) -> bool:
     """
     dq = _revivals[svc]
     cutoff = now - RATE_WINDOW_SEC
-    while dq and dq[0] < cutoff:
+    while dq and dq[0] <= cutoff:
         dq.popleft()
     return len(dq) < RATE_CAP
 
@@ -173,7 +177,14 @@ def revive(svc: str) -> None:
 
 
 def alert_cap_exceeded(svc: str) -> None:
-    """Emit a desktop notification when a service has exceeded its revival cap."""
+    """Emit a desktop notification when a service has exceeded its revival cap.
+
+    Fires at most once per cap-exceeded episode; subsequent calls for the same
+    service are no-ops until the service recovers (is removed from _alerted).
+    """
+    if svc in _alerted:
+        return
+    _alerted.add(svc)
     subprocess.run(
         [
             "notify-send",
@@ -189,39 +200,46 @@ def alert_cap_exceeded(svc: str) -> None:
 # The spine — run_cycle(now)
 # ---------------------------------------------------------------------------
 
-def run_cycle(now: float | None = None) -> None:
-    """Execute one poll cycle.
+def run_cycle(now: float | None = None):
+    """Execute one poll cycle as a generator.
 
-    Detects failed services, applies game-mode guard and rate cap, then
-    either revives the service or emits a desktop alert.
+    Yields once after each service is successfully processed. The caller
+    (main) emits a watchdog beat on each yield, so a beat is produced
+    per-service rather than once per full cycle.
 
-    Returns normally only when the entire cycle completes without an
-    unhandled exception. An exception here means no watchdog beat is emitted,
-    which causes systemd to kill and restart the process via WatchdogSec.
+    Invariant: a yield is emitted ONLY after a healthy step. An unhandled
+    exception inside this generator stops the yields, which causes main()
+    to stop beating, which causes systemd to kill and restart the process
+    via WatchdogSec.
     """
     now = time.time() if now is None else now
     game = game_mode_active()
     for svc in watched_services(game):
         if not is_failed(svc):
-            continue
-        if under_cap(svc, now):
+            # Service recovered — reset alert guard so a future episode fires again.
+            _alerted.discard(svc)
+        elif svc in GAME_BRAINS and game_mode_active():
+            # Game mode started mid-cycle — skip revival to protect the GPU.
+            pass
+        elif under_cap(svc, now):
             revive(svc)
             record_revival(svc, now)
         else:
             alert_cap_exceeded(svc)
+        yield  # beat opportunity: one per service, only if we reach here
 
 
 # ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
 
-def main() -> int:
-    notify_ready()                   # tell systemd init is done
-    time.sleep(STARTUP_GRACE_SEC)    # let services settle after boot
+def main() -> None:
+    notify_ready()                        # tell systemd init is done
+    time.sleep(STARTUP_GRACE_SEC)         # let services settle after boot
     while True:
-        run_cycle()                  # may raise → no beat → watchdog reaps us
-        notify_watchdog()            # beat only after a clean cycle
-        time.sleep(POLL_INTERVAL_SEC)
+        for _ in run_cycle():             # generator: yields once per service
+            notify_watchdog()             # beat after each healthy service step
+        time.sleep(POLL_INTERVAL_SEC)     # wait until next cycle
 
 
 if __name__ == "__main__":

--- a/axi/systemd/axi-heartbeat.service
+++ b/axi/systemd/axi-heartbeat.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Axi heartbeat — self-healing supervisor (the corazon of LifeOS)
+After=graphical-session.target
+PartOf=graphical-session.target
+
+[Service]
+Type=notify
+NotifyAccess=main
+ExecStart=%h/LifeOS/lifeos/axi/.venv/bin/python -m axi.heartbeat
+# systemd is the heart's life force: NEVER allowed to give up on itself.
+Restart=always
+RestartSec=10
+StartLimitIntervalSec=0
+# Liveness spine: a healthy cycle beats sd_notify(WATCHDOG=1). No beat in 90s
+# (3x the 30s poll interval, > worst-case cycle) => systemd kills+restarts us.
+# This catches the lethal hung-but-running case that Restart=always cannot.
+WatchdogSec=90
+
+[Install]
+WantedBy=default.target

--- a/axi/tests/test_heartbeat.py
+++ b/axi/tests/test_heartbeat.py
@@ -31,8 +31,10 @@ def clear_revivals():
     """Reset per-service rate-cap state between tests."""
     from axi import heartbeat
     heartbeat._revivals.clear()
+    heartbeat._alerted.clear()
     yield
     heartbeat._revivals.clear()
+    heartbeat._alerted.clear()
 
 
 # ===========================================================================
@@ -158,7 +160,7 @@ def test_under_cap_allows_first_three():
 
 
 def test_under_cap_prunes_old():
-    """Revivals outside the 3600s window are pruned; cap resets."""
+    """Revivals outside the 3600s window are pruned; cap resets at exactly 3600s."""
     from axi import heartbeat
 
     svc = "axi-voice.service"
@@ -167,8 +169,8 @@ def test_under_cap_prunes_old():
     for _ in range(3):
         heartbeat.record_revival(svc, now=0.0)
 
-    # At t=3601 the window has expired → under cap again
-    assert heartbeat.under_cap(svc, now=3601.0) is True
+    # At t=3600 exactly the window has expired → under cap again (boundary is inclusive)
+    assert heartbeat.under_cap(svc, now=3600.0) is True
 
 
 # ===========================================================================
@@ -259,7 +261,7 @@ def test_run_cycle_revives_failed_service(monkeypatch):
 
     monkeypatch.setattr(heartbeat.subprocess, "run", recording_run)
 
-    heartbeat.run_cycle(now=0.0)
+    list(heartbeat.run_cycle(now=0.0))  # consume generator
 
     # reset-failed and start were called for axi-voice.service
     reset_calls = [a for a in recorded if "reset-failed" in a]
@@ -290,7 +292,7 @@ def test_run_cycle_game_mode_blocks_brains(monkeypatch, tmp_path):
     monkeypatch.setattr(heartbeat.subprocess, "run", fake_run)
     monkeypatch.setattr(heartbeat, "_sd_notify", lambda s: None)
 
-    heartbeat.run_cycle(now=0.0)
+    list(heartbeat.run_cycle(now=0.0))  # consume generator
 
     for call in recorded:
         if "reset-failed" in call or (len(call) > 2 and call[2] == "start"):
@@ -328,7 +330,7 @@ def test_run_cycle_cap_exceeded_alerts_no_revive(monkeypatch):
 
     monkeypatch.setattr(heartbeat.subprocess, "run", recording_run)
 
-    heartbeat.run_cycle(now=0.0)
+    list(heartbeat.run_cycle(now=0.0))  # consume generator
 
     # notify-send must have been called
     assert any("notify-send" in a for a in sp_recorded)
@@ -354,7 +356,7 @@ def test_run_cycle_inactive_not_revived(monkeypatch):
     monkeypatch.setattr(heartbeat, "_game_lock_path", lambda: Path("/nonexistent/game-mode.lock"))
     monkeypatch.setattr(heartbeat, "_sd_notify", lambda s: None)
 
-    heartbeat.run_cycle(now=0.0)
+    list(heartbeat.run_cycle(now=0.0))  # consume generator
 
     for call in recorded:
         assert "reset-failed" not in call
@@ -362,26 +364,111 @@ def test_run_cycle_inactive_not_revived(monkeypatch):
             assert call[2] != "start"
 
 
-def test_watchdog_beat_only_after_clean_cycle(monkeypatch):
-    """When run_cycle raises, _sd_notify(WATCHDOG=1) is NOT called."""
+def test_run_cycle_yields_per_service(monkeypatch):
+    """run_cycle yields once per watched service (generator contract)."""
     from axi import heartbeat
-    import time
+
+    monkeypatch.setattr(heartbeat.subprocess, "run",
+                        lambda argv, **kw: _sp_result("inactive\n", 1))
+    monkeypatch.setattr(heartbeat, "_game_lock_path",
+                        lambda: Path("/nonexistent/game-mode.lock"))
+
+    services = heartbeat.watched_services(game_active=False)
+    yields = list(heartbeat.run_cycle(now=0.0))
+    assert len(yields) == len(services), (
+        f"Expected {len(services)} yields, got {len(yields)}"
+    )
+
+
+def test_run_cycle_exception_stops_yields(monkeypatch):
+    """If processing service N raises, yields for N and after are not emitted."""
+    from axi import heartbeat
+
+    services = heartbeat.watched_services(game_active=False)
+    crash_on = services[2]  # third service
+
+    def fake_run(argv, **kw):
+        if argv[:3] == ["systemctl", "--user", "is-failed"]:
+            svc = argv[3]
+            if svc == crash_on:
+                raise RuntimeError("simulated subprocess hang")
+            return _sp_result("inactive\n", 1)
+        return _sp_result("", 0)
+
+    monkeypatch.setattr(heartbeat.subprocess, "run", fake_run)
+    monkeypatch.setattr(heartbeat, "_game_lock_path",
+                        lambda: Path("/nonexistent/game-mode.lock"))
+
+    yields_before_crash = 0
+    try:
+        for _ in heartbeat.run_cycle(now=0.0):
+            yields_before_crash += 1
+    except RuntimeError:
+        pass
+
+    # Should have yielded for the 2 services processed before the crash
+    assert yields_before_crash == 2, (
+        f"Expected 2 yields before crash, got {yields_before_crash}"
+    )
+
+
+def test_main_beats_per_service(monkeypatch):
+    """main() emits WATCHDOG=1 once per service in a clean cycle."""
+    from axi import heartbeat
+
+    services = heartbeat.watched_services(game_active=False)
+    expected_beats = len(services)
+
+    # run_cycle that yields len(services) times then exits main via SystemExit
+    iteration = [0]
+
+    def fake_run_cycle(now=None):
+        for _ in services:
+            yield
+        iteration[0] += 1
+        if iteration[0] >= 1:
+            raise SystemExit(0)
+
+    sd_calls = []
+    monkeypatch.setattr(heartbeat, "_sd_notify", lambda s: sd_calls.append(s))
+    monkeypatch.setattr(heartbeat, "run_cycle", fake_run_cycle)
+    monkeypatch.setattr(heartbeat.time, "sleep", lambda _: None)
+
+    try:
+        heartbeat.main()
+    except SystemExit:
+        pass
+
+    watchdog_beats = sd_calls.count("WATCHDOG=1")
+    assert watchdog_beats == expected_beats, (
+        f"Expected {expected_beats} WATCHDOG=1 beats, got {watchdog_beats}"
+    )
+
+
+def test_main_no_beat_on_exception(monkeypatch):
+    """When run_cycle raises on first service, WATCHDOG=1 is never emitted."""
+    from axi import heartbeat
 
     def raising_run_cycle(now=None):
         raise RuntimeError("simulated stall")
+        yield  # make it a generator that never yields
 
     sd_calls = []
     monkeypatch.setattr(heartbeat, "_sd_notify", lambda s: sd_calls.append(s))
     monkeypatch.setattr(heartbeat, "run_cycle", raising_run_cycle)
+    monkeypatch.setattr(heartbeat.time, "sleep", lambda _: None)
 
-    # Simulate the main loop body for one iteration
+    # main() should propagate the exception (no swallow)
     try:
-        heartbeat.run_cycle()
-        heartbeat.notify_watchdog()
+        heartbeat.main()
     except RuntimeError:
-        pass  # expected
+        pass
+    except SystemExit:
+        pass
 
-    assert "WATCHDOG=1" not in sd_calls
+    assert "WATCHDOG=1" not in sd_calls, (
+        f"WATCHDOG=1 should not be emitted when run_cycle raises: {sd_calls}"
+    )
 
 
 def test_ready_emitted_once_before_first_cycle(monkeypatch):
@@ -413,6 +500,156 @@ def test_ready_emitted_once_before_first_cycle(monkeypatch):
 
     assert len(ready_indices) == 1, f"READY=1 called {len(ready_indices)} times, expected 1"
     assert ready_indices[0] < cycle_indices[0], "READY=1 must be emitted before first cycle"
+
+
+def test_alert_cap_exceeded_deduplicated(monkeypatch):
+    """notify-send fires once per cap-exceeded episode, not every cycle."""
+    from axi import heartbeat
+
+    svc = "axi-voice.service"
+    # Pre-fill 3 revivals so cap is exceeded from the start
+    for _ in range(3):
+        heartbeat.record_revival(svc, now=0.0)
+
+    def fake_run(argv, **kw):
+        if argv[:3] == ["systemctl", "--user", "is-failed"]:
+            s = argv[3]
+            return _sp_result("failed\n" if s == svc else "inactive\n", 0)
+        return _sp_result("", 0)
+
+    sp_recorded: list[list[str]] = []
+
+    def recording_run(argv, **kw):
+        sp_recorded.append(argv)
+        return fake_run(argv, **kw)
+
+    monkeypatch.setattr(heartbeat.subprocess, "run", recording_run)
+    monkeypatch.setattr(heartbeat, "_game_lock_path", lambda: Path("/nonexistent/game-mode.lock"))
+    monkeypatch.setattr(heartbeat, "_sd_notify", lambda s: None)
+
+    # Run cycle twice — notify-send must fire exactly once
+    list(heartbeat.run_cycle(now=0.0))
+    list(heartbeat.run_cycle(now=1.0))
+
+    notify_calls = [a for a in sp_recorded if "notify-send" in a]
+    assert len(notify_calls) == 1, (
+        f"Expected notify-send once, got {len(notify_calls)} times"
+    )
+
+
+def test_alert_dedup_resets_on_recovery(monkeypatch):
+    """After a capped service recovers, the alert guard resets so it fires again on next cap episode."""
+    from axi import heartbeat
+
+    svc = "axi-voice.service"
+    for _ in range(3):
+        heartbeat.record_revival(svc, now=0.0)
+
+    is_failed_flag = [True]
+
+    def fake_run(argv, **kw):
+        if argv[:3] == ["systemctl", "--user", "is-failed"]:
+            s = argv[3]
+            if s == svc:
+                return _sp_result("failed\n" if is_failed_flag[0] else "inactive\n", 0)
+            return _sp_result("inactive\n", 1)
+        return _sp_result("", 0)
+
+    sp_recorded: list[list[str]] = []
+
+    def recording_run(argv, **kw):
+        sp_recorded.append(argv)
+        return fake_run(argv, **kw)
+
+    monkeypatch.setattr(heartbeat.subprocess, "run", recording_run)
+    monkeypatch.setattr(heartbeat, "_game_lock_path", lambda: Path("/nonexistent/game-mode.lock"))
+    monkeypatch.setattr(heartbeat, "_sd_notify", lambda s: None)
+
+    # Cycle 1: capped → alert fires
+    list(heartbeat.run_cycle(now=0.0))
+    notify_calls_1 = [a for a in sp_recorded if "notify-send" in a]
+    assert len(notify_calls_1) == 1
+
+    # Service recovers: is-failed returns inactive
+    is_failed_flag[0] = False
+    sp_recorded.clear()
+    list(heartbeat.run_cycle(now=1.0))  # recovery cycle
+
+    # Service fails again with fresh window (different svc to avoid reusing old state)
+    # Reset revivals manually and make it fail + capped again
+    is_failed_flag[0] = True
+    heartbeat._revivals.clear()
+    for _ in range(3):
+        heartbeat.record_revival(svc, now=5000.0)
+    sp_recorded.clear()
+    list(heartbeat.run_cycle(now=5001.0))
+
+    notify_calls_2 = [a for a in sp_recorded if "notify-send" in a]
+    assert len(notify_calls_2) == 1, (
+        "Expected alert to fire again after recovery; alert guard not reset"
+    )
+
+
+def test_game_mode_lock_midcycle_blocks_brain_revival(monkeypatch, tmp_path):
+    """Game-mode lock appearing mid-cycle prevents GAME_BRAIN revival.
+
+    game_mode_active() returns False at cycle start (so brains are watched),
+    then True when re-checked immediately before reviving a brain service.
+    The brain must NOT be revived.
+    """
+    from axi import heartbeat
+
+    lock = tmp_path / "game-mode.lock"
+    # Lock does NOT exist at cycle start → brains are included in watchlist
+    monkeypatch.setattr(heartbeat, "_game_lock_path", lambda: lock)
+
+    brain_svc = heartbeat.GAME_BRAINS[0]  # llama-server.service
+    core_svc = heartbeat.HEARTBEAT_SERVICES[0]  # axi-voice.service
+
+    def fake_run(argv, **kw):
+        if argv[:3] == ["systemctl", "--user", "is-failed"]:
+            # Both core and brain service are failed
+            return _sp_result("failed\n", 0)
+        return _sp_result("", 0)
+
+    sp_recorded: list[list[str]] = []
+
+    def recording_run(argv, **kw):
+        sp_recorded.append(argv)
+        return fake_run(argv, **kw)
+
+    monkeypatch.setattr(heartbeat.subprocess, "run", recording_run)
+    monkeypatch.setattr(heartbeat, "_sd_notify", lambda s: None)
+
+    # Game-mode lock appears after cycle starts (mid-cycle) — simulate by
+    # creating the lock file so it exists when brain is about to be processed.
+    # We do this by patching is_failed to create the lock right before the brain call.
+    original_is_failed = heartbeat.is_failed
+    call_count = [0]
+
+    def side_effecting_is_failed(svc):
+        result = original_is_failed(svc)
+        call_count[0] += 1
+        # After processing all core services, game starts → lock appears
+        if call_count[0] >= len(heartbeat.HEARTBEAT_SERVICES):
+            lock.touch()
+        return result
+
+    monkeypatch.setattr(heartbeat, "is_failed", side_effecting_is_failed)
+
+    list(heartbeat.run_cycle(now=0.0))
+
+    revive_calls = [a for a in sp_recorded if "reset-failed" in a or
+                    (len(a) > 2 and a[2] == "start")]
+    revived_svcs = {a[-1] for a in revive_calls}
+
+    assert brain_svc not in revived_svcs, (
+        f"{brain_svc} was revived despite game-mode lock appearing mid-cycle"
+    )
+    # Core service should still have been revived (it was processed before lock appeared)
+    assert core_svc in revived_svcs, (
+        f"{core_svc} should have been revived (processed before game lock)"
+    )
 
 
 # ===========================================================================

--- a/axi/tests/test_heartbeat.py
+++ b/axi/tests/test_heartbeat.py
@@ -1,0 +1,431 @@
+"""Tests for axi.heartbeat — self-healing supervisor (corazon).
+
+Strict TDD: every behavior is proven RED before GREEN.
+No test ever invokes real systemctl, real notify-send, or real sd_notify.
+All subprocess.run calls are monkeypatched.
+"""
+from __future__ import annotations
+
+import types
+from collections import deque
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _sp_result(stdout: str, returncode: int = 0) -> types.SimpleNamespace:
+    """Build a fake subprocess.CompletedProcess-like object."""
+    return types.SimpleNamespace(stdout=stdout, returncode=returncode)
+
+
+# ---------------------------------------------------------------------------
+# Autouse fixture: clear module-level mutable _revivals between tests
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def clear_revivals():
+    """Reset per-service rate-cap state between tests."""
+    from axi import heartbeat
+    heartbeat._revivals.clear()
+    yield
+    heartbeat._revivals.clear()
+
+
+# ===========================================================================
+# Phase 1 — Foundation: constants
+# ===========================================================================
+
+def test_watchlist_membership():
+    """HEARTBEAT_SERVICES contains exactly the 5 core services."""
+    from axi import heartbeat
+
+    expected = {
+        "axi-voice.service",
+        "axi-whisper.service",
+        "ydotoold.service",
+        "axi-tray.service",
+        "axi-dashboard.service",
+    }
+    assert set(heartbeat.HEARTBEAT_SERVICES) == expected
+    assert "axi-translate.service" not in heartbeat.HEARTBEAT_SERVICES
+
+
+def test_watchlist_independence_from_doctor():
+    """HEARTBEAT_SERVICES is NOT the same object as doctor.REQUIRED_SERVICES."""
+    from axi import doctor, heartbeat
+
+    assert heartbeat.HEARTBEAT_SERVICES is not doctor.REQUIRED_SERVICES
+
+
+def test_startup_grace_lt_watchdog():
+    """STARTUP_GRACE_SEC must be strictly less than WatchdogSec (90)."""
+    from axi import heartbeat
+
+    assert heartbeat.STARTUP_GRACE_SEC < 90
+
+
+# ===========================================================================
+# Phase 2 — Core logic: detection, game-mode, rate-cap
+# ===========================================================================
+
+def test_is_failed_true(monkeypatch):
+    """is_failed returns True when systemctl stdout is 'failed'."""
+    from axi import heartbeat
+
+    calls = []
+
+    def fake_run(argv, **kwargs):
+        calls.append(argv)
+        return _sp_result("failed\n", returncode=0)
+
+    monkeypatch.setattr(heartbeat.subprocess, "run", fake_run)
+    assert heartbeat.is_failed("axi-voice.service") is True
+    assert calls[0] == ["systemctl", "--user", "is-failed", "axi-voice.service"]
+
+
+def test_is_failed_false(monkeypatch):
+    """is_failed returns False when systemctl stdout is 'inactive'."""
+    from axi import heartbeat
+
+    monkeypatch.setattr(
+        heartbeat.subprocess, "run",
+        lambda argv, **kw: _sp_result("inactive\n", returncode=1),
+    )
+    assert heartbeat.is_failed("axi-voice.service") is False
+
+
+def test_game_mode_active_true(monkeypatch, tmp_path):
+    """game_mode_active returns True when lock file exists."""
+    from axi import heartbeat
+
+    lock = tmp_path / "game-mode.lock"
+    lock.touch()
+    monkeypatch.setattr(heartbeat, "_game_lock_path", lambda: lock)
+    assert heartbeat.game_mode_active() is True
+
+
+def test_game_mode_active_false(monkeypatch, tmp_path):
+    """game_mode_active returns False when lock file is absent."""
+    from axi import heartbeat
+
+    lock = tmp_path / "game-mode.lock"  # does NOT exist
+    monkeypatch.setattr(heartbeat, "_game_lock_path", lambda: lock)
+    assert heartbeat.game_mode_active() is False
+
+
+def test_watched_services_game_on():
+    """When game is active, watched_services == HEARTBEAT_SERVICES (no GAME_BRAINS)."""
+    from axi import heartbeat
+
+    result = heartbeat.watched_services(game_active=True)
+    assert set(result) == set(heartbeat.HEARTBEAT_SERVICES)
+    for brain in heartbeat.GAME_BRAINS:
+        assert brain not in result
+
+
+def test_watched_services_game_off():
+    """When game is off, watched_services includes HEARTBEAT_SERVICES + GAME_BRAINS."""
+    from axi import heartbeat
+
+    result = heartbeat.watched_services(game_active=False)
+    for svc in heartbeat.HEARTBEAT_SERVICES:
+        assert svc in result
+    for brain in heartbeat.GAME_BRAINS:
+        assert brain in result
+
+
+def test_under_cap_allows_first_three():
+    """under_cap returns True (allowed) for the first 3 revivals, False on 4th."""
+    from axi import heartbeat
+
+    svc = "axi-voice.service"
+    now = 1000.0
+
+    # Three revivals at t=now: all should be under cap
+    assert heartbeat.under_cap(svc, now) is True
+    heartbeat.record_revival(svc, now)
+    assert heartbeat.under_cap(svc, now) is True
+    heartbeat.record_revival(svc, now)
+    assert heartbeat.under_cap(svc, now) is True
+    heartbeat.record_revival(svc, now)
+
+    # 4th check — cap reached
+    assert heartbeat.under_cap(svc, now) is False
+
+
+def test_under_cap_prunes_old():
+    """Revivals outside the 3600s window are pruned; cap resets."""
+    from axi import heartbeat
+
+    svc = "axi-voice.service"
+
+    # Record 3 revivals at t=0
+    for _ in range(3):
+        heartbeat.record_revival(svc, now=0.0)
+
+    # At t=3601 the window has expired → under cap again
+    assert heartbeat.under_cap(svc, now=3601.0) is True
+
+
+# ===========================================================================
+# Phase 3 — Side-effect functions: revive, alert, sd_notify
+# ===========================================================================
+
+def test_revive_calls_reset_failed_then_start(monkeypatch):
+    """revive issues reset-failed then start in order."""
+    from axi import heartbeat
+
+    calls = []
+    monkeypatch.setattr(
+        heartbeat.subprocess, "run",
+        lambda argv, **kw: calls.append(argv) or _sp_result("", 0),
+    )
+    heartbeat.revive("axi-voice.service")
+
+    assert len(calls) == 2
+    assert calls[0] == ["systemctl", "--user", "reset-failed", "axi-voice.service"]
+    assert calls[1] == ["systemctl", "--user", "start", "axi-voice.service"]
+
+
+def test_alert_cap_exceeded_calls_notify_send(monkeypatch):
+    """alert_cap_exceeded calls notify-send with the service name in the message."""
+    from axi import heartbeat
+
+    calls = []
+    monkeypatch.setattr(
+        heartbeat.subprocess, "run",
+        lambda argv, **kw: calls.append(argv) or _sp_result("", 0),
+    )
+    heartbeat.alert_cap_exceeded("llama-server.service")
+
+    assert calls, "notify-send was never called"
+    assert "notify-send" in calls[0]
+    # Service name must appear somewhere in the call arguments
+    full_cmd = " ".join(calls[0])
+    assert "llama-server.service" in full_cmd
+
+
+def test_sd_notify_functions(monkeypatch):
+    """notify_ready calls _sd_notify('READY=1'); notify_watchdog calls _sd_notify('WATCHDOG=1')."""
+    from axi import heartbeat
+
+    received = []
+    monkeypatch.setattr(heartbeat, "_sd_notify", lambda state: received.append(state))
+
+    heartbeat.notify_ready()
+    assert received == ["READY=1"]
+
+    received.clear()
+    heartbeat.notify_watchdog()
+    assert received == ["WATCHDOG=1"]
+
+
+# ===========================================================================
+# Phase 4 — Spine: run_cycle + beat ordering
+# ===========================================================================
+
+def test_run_cycle_revives_failed_service(monkeypatch):
+    """run_cycle revives a failed service; _sd_notify is NOT called by run_cycle itself."""
+    from axi import heartbeat
+
+    # axi-voice.service is-failed → "failed"; others → "inactive"
+    def fake_run(argv, **kw):
+        if argv[:3] == ["systemctl", "--user", "is-failed"]:
+            svc = argv[3]
+            stdout = "failed\n" if svc == "axi-voice.service" else "inactive\n"
+            return _sp_result(stdout, returncode=0 if svc == "axi-voice.service" else 1)
+        return _sp_result("", 0)
+
+    monkeypatch.setattr(heartbeat.subprocess, "run", fake_run)
+
+    sd_calls = []
+    monkeypatch.setattr(heartbeat, "_sd_notify", lambda s: sd_calls.append(s))
+
+    # No game-mode lock
+    monkeypatch.setattr(heartbeat, "_game_lock_path", lambda: Path("/nonexistent/game-mode.lock"))
+
+    sp_calls = []
+    _orig_run = heartbeat.subprocess.run
+
+    recorded = []
+
+    def recording_run(argv, **kw):
+        recorded.append(argv)
+        return fake_run(argv, **kw)
+
+    monkeypatch.setattr(heartbeat.subprocess, "run", recording_run)
+
+    heartbeat.run_cycle(now=0.0)
+
+    # reset-failed and start were called for axi-voice.service
+    reset_calls = [a for a in recorded if "reset-failed" in a]
+    start_calls = [a for a in recorded if a[2:3] == ["start"]]
+    assert any("axi-voice.service" in a for a in reset_calls)
+    assert any("axi-voice.service" in a for a in start_calls)
+
+    # _sd_notify NOT called by run_cycle (beat is caller's responsibility)
+    assert sd_calls == []
+
+
+def test_run_cycle_game_mode_blocks_brains(monkeypatch, tmp_path):
+    """When game-mode.lock exists, llama-server.service is not revived."""
+    from axi import heartbeat
+
+    lock = tmp_path / "game-mode.lock"
+    lock.touch()
+    monkeypatch.setattr(heartbeat, "_game_lock_path", lambda: lock)
+
+    recorded = []
+
+    def fake_run(argv, **kw):
+        recorded.append(argv)
+        if argv[:3] == ["systemctl", "--user", "is-failed"]:
+            return _sp_result("failed\n", 0)
+        return _sp_result("", 0)
+
+    monkeypatch.setattr(heartbeat.subprocess, "run", fake_run)
+    monkeypatch.setattr(heartbeat, "_sd_notify", lambda s: None)
+
+    heartbeat.run_cycle(now=0.0)
+
+    for call in recorded:
+        if "reset-failed" in call or (len(call) > 2 and call[2] == "start"):
+            assert "llama-server.service" not in call
+            assert "llama-nano.service" not in call
+
+
+def test_run_cycle_cap_exceeded_alerts_no_revive(monkeypatch):
+    """When cap is exceeded, alert_cap_exceeded is called and revive is NOT."""
+    from axi import heartbeat
+
+    svc = "axi-voice.service"
+    # Pre-fill 3 revivals inside window
+    for _ in range(3):
+        heartbeat.record_revival(svc, now=0.0)
+
+    def fake_run(argv, **kw):
+        if argv[:3] == ["systemctl", "--user", "is-failed"]:
+            s = argv[3]
+            return _sp_result("failed\n" if s == svc else "inactive\n", 0)
+        return _sp_result("", 0)
+
+    monkeypatch.setattr(heartbeat.subprocess, "run", fake_run)
+    monkeypatch.setattr(heartbeat, "_game_lock_path", lambda: Path("/nonexistent/game-mode.lock"))
+
+    notify_calls = []
+    monkeypatch.setattr(heartbeat, "_sd_notify", lambda s: None)
+
+    # Monkeypatch subprocess.run to record and detect notify-send vs systemctl
+    sp_recorded = []
+
+    def recording_run(argv, **kw):
+        sp_recorded.append(argv)
+        return fake_run(argv, **kw)
+
+    monkeypatch.setattr(heartbeat.subprocess, "run", recording_run)
+
+    heartbeat.run_cycle(now=0.0)
+
+    # notify-send must have been called
+    assert any("notify-send" in a for a in sp_recorded)
+    # reset-failed and start must NOT have been called for the capped service
+    for call in sp_recorded:
+        if "reset-failed" in call or (len(call) > 3 and call[2] == "start"):
+            assert svc not in call, f"revive called for capped service: {call}"
+
+
+def test_run_cycle_inactive_not_revived(monkeypatch):
+    """is_failed returning False → no reset-failed or start."""
+    from axi import heartbeat
+
+    recorded = []
+
+    def fake_run(argv, **kw):
+        recorded.append(argv)
+        if argv[:3] == ["systemctl", "--user", "is-failed"]:
+            return _sp_result("inactive\n", 1)
+        return _sp_result("", 0)
+
+    monkeypatch.setattr(heartbeat.subprocess, "run", fake_run)
+    monkeypatch.setattr(heartbeat, "_game_lock_path", lambda: Path("/nonexistent/game-mode.lock"))
+    monkeypatch.setattr(heartbeat, "_sd_notify", lambda s: None)
+
+    heartbeat.run_cycle(now=0.0)
+
+    for call in recorded:
+        assert "reset-failed" not in call
+        if len(call) > 2:
+            assert call[2] != "start"
+
+
+def test_watchdog_beat_only_after_clean_cycle(monkeypatch):
+    """When run_cycle raises, _sd_notify(WATCHDOG=1) is NOT called."""
+    from axi import heartbeat
+    import time
+
+    def raising_run_cycle(now=None):
+        raise RuntimeError("simulated stall")
+
+    sd_calls = []
+    monkeypatch.setattr(heartbeat, "_sd_notify", lambda s: sd_calls.append(s))
+    monkeypatch.setattr(heartbeat, "run_cycle", raising_run_cycle)
+
+    # Simulate the main loop body for one iteration
+    try:
+        heartbeat.run_cycle()
+        heartbeat.notify_watchdog()
+    except RuntimeError:
+        pass  # expected
+
+    assert "WATCHDOG=1" not in sd_calls
+
+
+def test_ready_emitted_once_before_first_cycle(monkeypatch):
+    """notify_ready is called exactly once, before any run_cycle call."""
+    from axi import heartbeat
+
+    order = []
+    monkeypatch.setattr(heartbeat, "_sd_notify", lambda s: order.append(("notify", s)))
+
+    call_count = [0]
+
+    def counting_run_cycle(now=None):
+        order.append(("cycle", None))
+        call_count[0] += 1
+        if call_count[0] >= 1:
+            raise SystemExit(0)  # break after first cycle
+
+    monkeypatch.setattr(heartbeat, "run_cycle", counting_run_cycle)
+    monkeypatch.setattr(heartbeat.time, "sleep", lambda _: None)
+
+    try:
+        heartbeat.main()
+    except SystemExit:
+        pass
+
+    # READY=1 must appear before the first cycle
+    ready_indices = [i for i, e in enumerate(order) if e == ("notify", "READY=1")]
+    cycle_indices = [i for i, e in enumerate(order) if e[0] == "cycle"]
+
+    assert len(ready_indices) == 1, f"READY=1 called {len(ready_indices)} times, expected 1"
+    assert ready_indices[0] < cycle_indices[0], "READY=1 must be emitted before first cycle"
+
+
+# ===========================================================================
+# Phase 5 — Unit file parse test
+# ===========================================================================
+
+def test_unit_file_has_required_properties():
+    """axi-heartbeat.service must contain all four self-protection properties."""
+    unit_path = Path(__file__).parent.parent / "systemd" / "axi-heartbeat.service"
+    text = unit_path.read_text()
+
+    assert "Type=notify" in text
+    assert "Restart=always" in text
+    assert "StartLimitIntervalSec=0" in text
+    assert "WatchdogSec=90" in text
+    assert "NotifyAccess=main" in text


### PR DESCRIPTION
## El corazón de Axi

Self-healing supervisor that revives FAILED systemd user services. Closes the silent-death gap: systemd's default StartLimit (5 fails / 10s) transitions a service to `failed`, `Restart=` stops firing, and it stays dead with no alert.

### Principio fundacional: existir ≠ latir
A supervisor that is `active (running)` but hung is functionally dead and gives **false security** — the lethal failure mode. So the heart must *prove* it beats:

- **Pulse per healthy step** — `run_cycle()` is a generator that yields after each service is processed; `main()` emits `sd_notify WATCHDOG=1` on each yield. A hung/exception step stops the yields → no beat.
- **systemd watches the pulse** — `WatchdogSec=90` restarts the heart if no beat arrives (catches the hung-but-running case `Restart=always` cannot).
- **Hierarchy of life** — systemd guarantees the heart (`Restart=always` + `StartLimitIntervalSec=0`, infinite retries, never gives up); the heart guarantees everything else (capped 3/hour/service revivals).

### What it does
- Detection via `systemctl --user is-failed` (not `is-active` — never revives intentionally-stopped services).
- Revival = `reset-failed` then `start`.
- Rate cap: 3 revivals / rolling 3600s / service; over cap → skip + `notify-send` (deduped, fires once per episode).
- Game-mode guard: re-checks `game-mode.lock` before reviving `llama-server`/`llama-nano` so it never reclaims VRAM mid-game.
- Dedicated `HEARTBEAT_SERVICES` watchlist (excludes on-demand `axi-translate`).

### Files
- `src/axi/heartbeat.py` — the supervisor
- `tests/test_heartbeat.py` — 27 tests, strict TDD (RED→GREEN), no real `systemctl`/sockets
- `systemd/axi-heartbeat.service` — `Type=notify`, `Restart=always`, `StartLimitIntervalSec=0`, `WatchdogSec=90`
- `INSTALL.md` — install/enable instructions

### Verification
- 550 passed / 6 skipped, 0 regressions.
- Dual review (compliance + adversarial). Adversarial pass caught a CRITICAL watchdog-sizing bug (worst-case cycle > 90s under load) — fixed via per-service beats — plus the TOCTOU game-mode race and a tautological liveness test, all resolved in `267087e`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)