### PR TITLE
fix(heartbeat): honor StartLimitIntervalSec (wrong section ignored it)

### DIFF
--- a/axi/systemd/axi-heartbeat.service
+++ b/axi/systemd/axi-heartbeat.service
@@ -2,15 +2,18 @@
 Description=Axi heartbeat — self-healing supervisor (the corazon of LifeOS)
 After=graphical-session.target
 PartOf=graphical-session.target
+# systemd is the heart's life force: NEVER allowed to give up on itself.
+# StartLimit* belong in [Unit], not [Service] — in [Service] systemd ignores
+# them, leaving the heart subject to the default 5-restarts/10s StartLimit:
+# the exact gap the corazon exists to close.
+StartLimitIntervalSec=0
 
 [Service]
 Type=notify
 NotifyAccess=main
 ExecStart=%h/LifeOS/lifeos/axi/.venv/bin/python -m axi.heartbeat
-# systemd is the heart's life force: NEVER allowed to give up on itself.
 Restart=always
 RestartSec=10
-StartLimitIntervalSec=0
 # Liveness spine: a healthy cycle beats sd_notify(WATCHDOG=1). No beat in 90s
 # (3x the 30s poll interval, > worst-case cycle) => systemd kills+restarts us.
 # This catches the lethal hung-but-running case that Restart=always cannot.


### PR DESCRIPTION
`StartLimitIntervalSec=0` was in `[Service]`, where systemd ignores it (`Unknown key 'StartLimitIntervalSec' in section [Service], ignoring`). The heart's own infinite-restart protection was therefore inactive — it was subject to the default 5-restarts/10s StartLimit, the exact gap the corazón exists to close.

Moved to `[Unit]`. Verified live on the laptop: `StartLimitIntervalUSec=0` now applied, no journal warning, `WatchdogUSec=1min 30s`, `NRestarts=0`.

Caught only by installing and running on the real machine — neither review flagged the wrong section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)