### PR TITLE
feat(autonomous): Axi's first proactive thought — reflection tick + eyes

### DIFF
--- a/axi/src/axi/dashboard.py
+++ b/axi/src/axi/dashboard.py
@@ -253,6 +253,50 @@ async def lifespan(_app: FastAPI):
             except Exception:  # noqa: BLE001
                 return ""
 
+        # P7.1 — Real perceive_fn: compose webcam presence + screen activity.
+        # Swallows ALL capture errors so the tick is never broken by sensor failures.
+        # Images are in-memory only → local brain → discarded; never written to disk.
+        from axi import eyes as _axi_eyes_auto  # noqa: PLC0415
+        from axi import vision as _axi_vision_auto  # noqa: PLC0415
+        from lifeos.autonomous.cron import PerceptionContext  # noqa: PLC0415
+
+        def _auto_perceive() -> PerceptionContext:
+            """Capture webcam presence + active-window screen; return PerceptionContext.
+
+            Contract: MUST NOT raise. All errors degrade to _NO_PERCEPTION fields.
+            Privacy: images are in-memory only, passed to local brain, never logged.
+            """
+            try:
+                _webcam_b64, status = _axi_eyes_auto.capture_b64()
+            except Exception:  # noqa: BLE001
+                status = "failed"
+
+            # Map webcam status to presence enum
+            # busy:<who> means a video call is using the camera — user IS present
+            if status == "ok":
+                presence = "present"
+                webcam_ok = True
+            elif status.startswith("busy:"):
+                presence = "present"   # call IS presence (design §2)
+                webcam_ok = False      # we did not capture a frame ourselves
+            else:
+                # no-device / failed / dark / lid-closed → unknown
+                presence = "unknown"
+                webcam_ok = False
+
+            # Capture active window screen (None on any failure)
+            screen_b64: str | None = None
+            try:
+                screen_b64 = _axi_vision_auto.capture_active_window_b64()
+            except Exception:  # noqa: BLE001
+                screen_b64 = None
+
+            return PerceptionContext(
+                presence=presence,
+                screen_b64=screen_b64,
+                webcam_ok=webcam_ok,
+            )
+
         autonomous_cron.configure(
             brain_ask=_axi_brain_auto.ask,
             digest_fn=_auto_digest,
@@ -264,6 +308,7 @@ async def lifespan(_app: FastAPI):
             spoke_read_fn=autonomous_cron.read_last_pushed,
             spoke_write_fn=autonomous_cron.write_last_pushed,
             log_fn=_axi_events.log_info,
+            perceive_fn=_auto_perceive,
             ask_timeout=float(config.get("autonomous_ask_timeout", 20.0)),
             max_message_chars=int(config.get("autonomous_max_chars", 120)),
             language=str(config.get("language", "es-MX")),

--- a/axi/src/axi/dashboard.py
+++ b/axi/src/axi/dashboard.py
@@ -267,7 +267,7 @@ async def lifespan(_app: FastAPI):
             Privacy: images are in-memory only, passed to local brain, never logged.
             """
             try:
-                _webcam_b64, status = _axi_eyes_auto.capture_b64()
+                _, status = _axi_eyes_auto.capture_b64()
             except Exception:  # noqa: BLE001
                 status = "failed"
 

--- a/axi/src/axi/dashboard.py
+++ b/axi/src/axi/dashboard.py
@@ -96,6 +96,9 @@ from lifeos.insights import patterns as insights_patterns
 from lifeos.posture import cron as posture_cron
 from lifeos.posture import scans as posture_scans
 from lifeos.posture import store as posture_store
+# P7 — Autonomous reflection tick (proactive thought, disabled by default).
+from lifeos.autonomous import cron as autonomous_cron
+from lifeos.insights import correlate as insights_correlate
 # Nano-agents PRD — fast-path instrumentation. Records which stage handled
 # each chat call + latency, so we can decide empirically whether nano-agents
 # are worth building. Stores metadata only (no text content).
@@ -222,6 +225,58 @@ async def lifespan(_app: FastAPI):
         )
     except Exception:  # noqa: BLE001
         log.exception("lifeos posture cron failed to start")
+    try:
+        # P7 — Autonomous reflection tick.
+        # Register-always, fire-time gate via is_enabled_fn (matches posture/insights pattern).
+        # Default: autonomous_enabled=False → ships dark, opt-in only.
+        from axi import brain as _axi_brain_auto
+        from axi import events as _axi_events
+        tz_auto = ZoneInfo("America/Mexico_City")
+
+        def _auto_push(title: str, body: str) -> dict:
+            return lifeos_push.send_to_all(
+                title=title, body=body,
+                url="/insights",
+                tag="lifeos-autonomous",
+                priority="proactive",
+            )
+
+        def _auto_digest() -> str:
+            return insights_digest.compose(cadence="daily").body
+
+        def _auto_correlate() -> str:
+            # build_bundle() is a planned API; until it ships, return empty
+            # (the run_tick empty-digest guard only skips when BOTH digest AND
+            # correlate are empty, so a non-empty digest still proceeds).
+            try:
+                return insights_correlate.render_summary([], [])
+            except Exception:  # noqa: BLE001
+                return ""
+
+        autonomous_cron.configure(
+            brain_ask=_axi_brain_auto.ask,
+            digest_fn=_auto_digest,
+            correlate_fn=_auto_correlate,
+            push_fn=_auto_push,
+            now_fn=lambda: datetime.now(tz_auto),
+            is_enabled_fn=lambda: bool(config.get("autonomous_enabled", False)),
+            alive_fn=_axi_brain_auto.is_alive,
+            spoke_read_fn=autonomous_cron.read_last_pushed,
+            spoke_write_fn=autonomous_cron.write_last_pushed,
+            log_fn=_axi_events.log_info,
+            ask_timeout=float(config.get("autonomous_ask_timeout", 20.0)),
+            max_message_chars=int(config.get("autonomous_max_chars", 120)),
+            language=str(config.get("language", "es-MX")),
+            window_start_hour=int(config.get("autonomous_start_hour", 8)),
+            window_end_hour=int(config.get("autonomous_end_hour", 22)),
+        )
+        autonomous_cron.start_jobs(
+            cadence_minutes=int(config.get("autonomous_cadence_minutes", 45)),
+            start_hour=int(config.get("autonomous_start_hour", 8)),
+            end_hour=int(config.get("autonomous_end_hour", 22)),
+        )
+    except Exception:  # noqa: BLE001
+        log.exception("lifeos autonomous cron failed to start")
 
     yield
 

--- a/lifeos/src/lifeos/autonomous/cron.py
+++ b/lifeos/src/lifeos/autonomous/cron.py
@@ -1,0 +1,360 @@
+"""Autonomous reflection tick for Axi.
+
+Gives Axi its first proactive autonomy: at most once per day it decides WHEN
+to surface the one most important thing from Héctor's life context.
+
+Architecture (two-layer boundary):
+- cron/guardrail layer (run_tick): owns WHEN-bounding — window guard,
+  spoke-today cap, brain-down guard, empty-digest skip, audit log.
+- brain/judgment layer (brain_ask): owns WHAT/whether — given digest +
+  correlations + time, returns a message, ESPERAR, or NADA.
+
+run_tick is PURE — every side effect goes through an injected callable.
+The module is completely lifeos-axi-free: axi callables are injected at
+dashboard wiring time (see axi/dashboard.py lifespan).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Callable, Literal
+from zoneinfo import ZoneInfo
+
+from apscheduler.triggers.cron import CronTrigger
+
+from lifeos.scheduler import get_scheduler
+
+log = logging.getLogger("lifeos.autonomous.cron")
+
+
+# ---------------------------------------------------------------------------
+# Injected callable types
+# ---------------------------------------------------------------------------
+
+BrainAsk     = Callable[..., str]               # axi.brain.ask
+DigestFn     = Callable[[], str]                # () -> digest body text
+CorrelateFn  = Callable[[], str]                # () -> edge_summary text
+PushFn       = Callable[..., dict]              # (title, body, **kw) -> result
+NowFn        = Callable[[], datetime]           # tz-aware now
+EnabledFn    = Callable[[], bool]               # autonomous_enabled gate
+LogFn        = Callable[..., None]              # events.log_info-compatible
+SpokeReadFn  = Callable[[], str | None]         # -> ISO date of last push, or None
+SpokeWriteFn = Callable[[str], None]            # mark spoke-today (ISO date)
+AliveFn      = Callable[[], bool]               # brain.is_alive
+
+Outcome = Literal[
+    "pushed",
+    "esperar",
+    "nada",
+    "skipped-disabled",
+    "skipped-already-spoke",
+    "skipped-empty",
+    "skipped-brain-down",
+    "skipped-outside-window",
+]
+
+SENTINEL_WAIT = "ESPERAR"
+SENTINEL_NONE = "NADA"
+
+
+# ---------------------------------------------------------------------------
+# Result type
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True, slots=True)
+class TickResult:
+    outcome: Outcome
+    message: str | None = None    # the pushed message (only when outcome=="pushed")
+    reason: str | None = None     # human note for the audit log
+
+
+# ---------------------------------------------------------------------------
+# Module-level injected callables (set via configure())
+# ---------------------------------------------------------------------------
+
+_brain_ask: BrainAsk | None = None
+_digest_fn: DigestFn | None = None
+_correlate_fn: CorrelateFn | None = None
+_push_fn: PushFn | None = None
+_now_fn: NowFn | None = None
+_is_enabled_fn: EnabledFn | None = None
+_alive_fn: AliveFn | None = None
+_spoke_read_fn: SpokeReadFn | None = None
+_spoke_write_fn: SpokeWriteFn | None = None
+_log_fn: LogFn | None = None
+_ask_timeout: float = 20.0
+_max_message_chars: int = 120
+_language: str = "es-MX"
+_window_start_hour: int = 8
+_window_end_hour: int = 22
+
+
+def configure(
+    *,
+    brain_ask: BrainAsk,
+    digest_fn: DigestFn,
+    correlate_fn: CorrelateFn,
+    push_fn: PushFn,
+    now_fn: NowFn,
+    is_enabled_fn: EnabledFn,
+    alive_fn: AliveFn,
+    spoke_read_fn: SpokeReadFn,
+    spoke_write_fn: SpokeWriteFn,
+    log_fn: LogFn,
+    ask_timeout: float = 20.0,
+    max_message_chars: int = 120,
+    language: str = "es-MX",
+    window_start_hour: int = 8,
+    window_end_hour: int = 22,
+) -> None:
+    """Inject all callables. Calling configure() resets state completely."""
+    global _brain_ask, _digest_fn, _correlate_fn, _push_fn, _now_fn
+    global _is_enabled_fn, _alive_fn, _spoke_read_fn, _spoke_write_fn, _log_fn
+    global _ask_timeout, _max_message_chars, _language
+    global _window_start_hour, _window_end_hour
+
+    _brain_ask = brain_ask
+    _digest_fn = digest_fn
+    _correlate_fn = correlate_fn
+    _push_fn = push_fn
+    _now_fn = now_fn
+    _is_enabled_fn = is_enabled_fn
+    _alive_fn = alive_fn
+    _spoke_read_fn = spoke_read_fn
+    _spoke_write_fn = spoke_write_fn
+    _log_fn = log_fn
+    _ask_timeout = float(ask_timeout)
+    _max_message_chars = int(max_message_chars)
+    _language = language
+    _window_start_hour = int(window_start_hour)
+    _window_end_hour = int(window_end_hour)
+
+
+# ---------------------------------------------------------------------------
+# Sentinel parser
+# ---------------------------------------------------------------------------
+
+def parse_reply(reply: str, max_chars: int) -> tuple[Literal["msg", "esperar", "nada"], str | None]:
+    """Parse brain reply into a three-way outcome.
+
+    Sentinel detection is WHOLE-STRING equality after trimming and stripping
+    trailing punctuation/quotes. A reply that merely CONTAINS a sentinel word
+    is treated as a real message and pushed.
+    """
+    norm = (reply or "").strip()
+    # Trim trailing punctuation/quotes/spaces for sentinel comparison only
+    upper = norm.upper().strip(" .!¡¿?\"'`")
+    if upper == SENTINEL_WAIT:
+        return ("esperar", None)
+    if upper == SENTINEL_NONE:
+        return ("nada", None)
+    if not norm:
+        return ("nada", None)
+    # Reject brain's own error sentinels (e.g. "[Axi brain no responde…]")
+    if norm.startswith("[") and "brain" in norm.lower():
+        return ("nada", None)
+    return ("msg", norm[:max_chars].rstrip())
+
+
+# ---------------------------------------------------------------------------
+# Pure decision core
+# ---------------------------------------------------------------------------
+
+def run_tick(now: datetime) -> TickResult:
+    """Pure decision core. Order of guards:
+    1. Not configured → RuntimeError (programming error, not a runtime skip)
+    2. Outside waking window → skipped-outside-window
+    3. Already spoke today → skipped-already-spoke
+    4. Brain not alive → skipped-brain-down
+    5. Digest + correlate both empty → skipped-empty
+    6. brain_ask (with exception guard) → 3-way parse → act
+    Every path logs exactly once via log_fn.
+    """
+    if _brain_ask is None:
+        raise RuntimeError("autonomous cron not configured — call configure() first")
+
+    def _log(outcome: Outcome, **extra) -> None:
+        data = {"outcome": outcome, **extra}
+        if _log_fn is not None:
+            _log_fn("autonomous.tick", f"reflection tick: {outcome}", data=data)
+
+    # Guard: waking window
+    if now.hour < _window_start_hour or now.hour >= _window_end_hour:
+        _log("skipped-outside-window")
+        return TickResult("skipped-outside-window")
+
+    # Guard: 1/day cap
+    today_iso = now.date().isoformat()
+    if _spoke_read_fn is not None and _spoke_read_fn() == today_iso:
+        _log("skipped-already-spoke")
+        return TickResult("skipped-already-spoke")
+
+    # Guard: brain liveness
+    if _alive_fn is not None and not _alive_fn():
+        _log("skipped-brain-down")
+        return TickResult("skipped-brain-down")
+
+    # Sense: read digest + correlations
+    digest_body = (_digest_fn() if _digest_fn is not None else "")
+    edge_summary = (_correlate_fn() if _correlate_fn is not None else "")
+
+    # Guard: empty digest (anti-confabulation)
+    if not (digest_body or "").strip() and not (edge_summary or "").strip():
+        _log("skipped-empty")
+        return TickResult("skipped-empty")
+
+    # Build prompt
+    prompt = _build_prompt(now, digest_body, edge_summary)
+
+    # Reflect: ask brain (with exception guard)
+    try:
+        reply = _brain_ask(prompt, max_tokens=150, think=False, timeout=_ask_timeout)
+    except Exception:  # noqa: BLE001
+        log.exception("autonomous: brain_ask raised an exception")
+        _log("skipped-brain-down")
+        return TickResult("skipped-brain-down")
+
+    # Parse
+    verdict, message = parse_reply(reply, _max_message_chars)
+
+    # Act
+    if verdict == "msg" and message:
+        try:
+            if _push_fn is not None:
+                _push_fn("Axi", message)
+        except Exception:  # noqa: BLE001
+            log.exception("autonomous: push_fn raised an exception")
+        if _spoke_write_fn is not None:
+            _spoke_write_fn(today_iso)
+        _log("pushed", message_len=len(message))
+        return TickResult("pushed", message=message)
+
+    if verdict == "nada":
+        # NADA means silent for the rest of the day (Decision B: mark spoke)
+        if _spoke_write_fn is not None:
+            _spoke_write_fn(today_iso)
+        _log("nada")
+        return TickResult("nada")
+
+    # verdict == "esperar": wait for a better moment; don't mark spoke
+    _log("esperar")
+    return TickResult("esperar")
+
+
+def _build_prompt(now: datetime, digest_body: str, edge_summary: str) -> str:
+    """Build the reflection prompt per design §4."""
+    max_chars = _max_message_chars
+    return (
+        f"Es {now.strftime('%H:%M')} ({now.strftime('%A')}). "
+        "Este es el contexto de vida de Héctor ahora mismo:\n\n"
+        f"{digest_body}\n\n"
+        f"{edge_summary}\n\n"
+        "Tu tarea: decidir si ESTE es el buen momento para decirle UNA sola cosa, "
+        "la MÁS importante que merece su atención. Considera la hora del día.\n"
+        f"- Si SÍ es el momento: responde SOLO con esa frase, máx {max_chars} caracteres, "
+        "directa y concreta. Sin preámbulos, sin preguntas.\n"
+        f"- Si es mejor esperar a un momento más oportuno hoy: responde exactamente {SENTINEL_WAIT}.\n"
+        f"- Si hoy no hay nada que de verdad merezca interrumpirlo: responde exactamente {SENTINEL_NONE}.\n"
+        "No inventes urgencia. Si el contexto no da para una frase clara y útil, "
+        f"responde {SENTINEL_WAIT} o {SENTINEL_NONE}."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scheduler wiring
+# ---------------------------------------------------------------------------
+
+def _scheduled_tick() -> None:
+    """apscheduler entry point. Calls run_tick(now_fn()); never raises."""
+    if _is_enabled_fn is None or not _is_enabled_fn():
+        return
+    if _now_fn is None:
+        return
+    try:
+        run_tick(_now_fn())
+    except Exception:  # noqa: BLE001
+        log.exception("scheduled autonomous tick crashed")
+
+
+def run_tick_now(*, source: str = "manual") -> TickResult:
+    """Convenience wrapper: run_tick(now_fn()). Respects enabled gate."""
+    if _now_fn is None:
+        raise RuntimeError("autonomous cron not configured — call configure() first")
+    return run_tick(_now_fn())
+
+
+def start_jobs(
+    *,
+    cadence_minutes: int = 45,
+    start_hour: int = 8,
+    end_hour: int = 22,
+) -> str:
+    """Register the recurring autonomous reflection job. Idempotent.
+
+    Default: every 45 minutes between 08:00-22:00 Mexico City time, every day.
+    Returns the cron expression for display.
+    """
+    sched = get_scheduler()
+    if not sched.running:
+        log.warning("lifeos scheduler not running — skipping autonomous cron registration")
+        return ""
+
+    tz = ZoneInfo("America/Mexico_City")
+    cadence_minutes = max(1, min(int(cadence_minutes), 240))
+    minute_field = f"*/{cadence_minutes}"
+    # hour field: inclusive range, end_hour-1 so last fire is within the window
+    hour_field = f"{start_hour}-{end_hour - 1}" if end_hour > start_hour else str(start_hour)
+
+    trigger = CronTrigger(
+        minute=minute_field,
+        hour=hour_field,
+        timezone=tz,
+    )
+    sched._scheduler.add_job(  # noqa: SLF001
+        func=_scheduled_tick,
+        trigger=trigger,
+        id="lifeos.autonomous.tick",
+        replace_existing=True,
+        misfire_grace_time=300,
+    )
+    cron_str = f"{minute_field} {hour_field} * * *"
+    log.info("autonomous reflection cron registered: %s", cron_str)
+    return cron_str
+
+
+# ---------------------------------------------------------------------------
+# State file helpers (restart-safe spoke-today persistence)
+# ---------------------------------------------------------------------------
+
+def _state_path() -> Path:
+    """Path to the autonomous state JSON file.
+
+    Honors LIFEOS_STATE_DIR env var (same convention as notif_budget/push).
+    """
+    base = Path(
+        os.environ.get("LIFEOS_STATE_DIR")
+        or (Path.home() / ".local" / "state" / "lifeos")
+    )
+    base.mkdir(parents=True, exist_ok=True)
+    return base / "autonomous_last.json"
+
+
+def read_last_pushed() -> str | None:
+    """Read the ISO date of the last proactive push (or None on missing/corrupt file)."""
+    try:
+        return json.loads(_state_path().read_text()).get("last_pushed_date")
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
+
+
+def write_last_pushed(iso_date: str) -> None:
+    """Persist the ISO date of a proactive push (or NADA outcome) to the state file."""
+    try:
+        _state_path().write_text(json.dumps({"last_pushed_date": iso_date}))
+    except OSError:
+        log.warning("autonomous: could not persist spoke-today state")

--- a/lifeos/src/lifeos/autonomous/cron.py
+++ b/lifeos/src/lifeos/autonomous/cron.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import json
 import logging
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import Callable, Literal
@@ -46,6 +46,30 @@ LogFn        = Callable[..., None]              # events.log_info-compatible
 SpokeReadFn  = Callable[[], str | None]         # -> ISO date of last push, or None
 SpokeWriteFn = Callable[[str], None]            # mark spoke-today (ISO date)
 AliveFn      = Callable[[], bool]               # brain.is_alive
+
+# ---------------------------------------------------------------------------
+# Perception types (TASK-P0)
+# ---------------------------------------------------------------------------
+
+# 'away' is reserved for future face-absence detection; v1 emits present/unknown only.
+Presence = Literal["present", "away", "unknown"]
+
+
+@dataclass(frozen=True, slots=True)
+class PerceptionContext:
+    """Result of the perceive_fn() call. All fields have safe defaults so the
+    no-perception path (perceive_fn not injected) is a single shared instance."""
+    presence: Presence = "unknown"
+    screen_b64: str | None = None   # active-window PNG base64, or None on failure
+    webcam_ok: bool = False          # True iff a webcam frame was actually captured
+    activity_hint: str | None = None # optional cheap descriptor; usually None in v1
+
+
+PerceiveFn = Callable[[], "PerceptionContext"]
+
+# Shared sentinel used when no perceive_fn is injected.
+# Single frozen instance → zero allocation, easily assertable in tests.
+_NO_PERCEPTION = PerceptionContext()
 
 Outcome = Literal[
     "pushed",
@@ -87,6 +111,7 @@ _alive_fn: AliveFn | None = None
 _spoke_read_fn: SpokeReadFn | None = None
 _spoke_write_fn: SpokeWriteFn | None = None
 _log_fn: LogFn | None = None
+_perceive_fn: PerceiveFn | None = None
 _ask_timeout: float = 20.0
 _max_message_chars: int = 120
 _language: str = "es-MX"
@@ -106,6 +131,7 @@ def configure(
     spoke_read_fn: SpokeReadFn,
     spoke_write_fn: SpokeWriteFn,
     log_fn: LogFn,
+    perceive_fn: PerceiveFn | None = None,
     ask_timeout: float = 20.0,
     max_message_chars: int = 120,
     language: str = "es-MX",
@@ -115,6 +141,7 @@ def configure(
     """Inject all callables. Calling configure() resets state completely."""
     global _brain_ask, _digest_fn, _correlate_fn, _push_fn, _now_fn
     global _is_enabled_fn, _alive_fn, _spoke_read_fn, _spoke_write_fn, _log_fn
+    global _perceive_fn
     global _ask_timeout, _max_message_chars, _language
     global _window_start_hour, _window_end_hour
 
@@ -128,6 +155,7 @@ def configure(
     _spoke_read_fn = spoke_read_fn
     _spoke_write_fn = spoke_write_fn
     _log_fn = log_fn
+    _perceive_fn = perceive_fn
     _ask_timeout = float(ask_timeout)
     _max_message_chars = int(max_message_chars)
     _language = language
@@ -165,6 +193,25 @@ def parse_reply(reply: str, max_chars: int) -> tuple[Literal["msg", "esperar", "
 # Pure decision core
 # ---------------------------------------------------------------------------
 
+def _perception_log_fields(ctx: PerceptionContext) -> dict:
+    """Build the perception-related fields that are safe to log.
+
+    Privacy invariant: this function MUST NOT include any image bytes.
+    Only derived, scalar context is returned.
+    """
+    activity_descriptor = ctx.activity_hint or (
+        "screen+present" if (ctx.screen_b64 is not None and ctx.presence == "present")
+        else "no-screen+unknown" if ctx.screen_b64 is None
+        else f"screen+{ctx.presence}"
+    )
+    return {
+        "presence": ctx.presence,
+        "webcam_ok": ctx.webcam_ok,
+        "screen_available": ctx.screen_b64 is not None,
+        "activity_descriptor": activity_descriptor,
+    }
+
+
 def run_tick(now: datetime) -> TickResult:
     """Pure decision core. Order of guards:
     1. Not configured → RuntimeError (programming error, not a runtime skip)
@@ -172,14 +219,15 @@ def run_tick(now: datetime) -> TickResult:
     3. Already spoke today → skipped-already-spoke
     4. Brain not alive → skipped-brain-down
     5. Digest + correlate both empty → skipped-empty
-    6. brain_ask (with exception guard) → 3-way parse → act
+    6. perceive_fn() → PerceptionContext (degrade on error)
+    7. brain_ask (with exception guard, image_b64=ctx.screen_b64) → 3-way parse → act
     Every path logs exactly once via log_fn.
     """
     if _brain_ask is None:
         raise RuntimeError("autonomous cron not configured — call configure() first")
 
-    def _log(outcome: Outcome, **extra) -> None:
-        data = {"outcome": outcome, **extra}
+    def _log(outcome: Outcome, ctx: PerceptionContext = _NO_PERCEPTION, **extra) -> None:
+        data = {"outcome": outcome, **_perception_log_fields(ctx), **extra}
         if _log_fn is not None:
             _log_fn("autonomous.tick", f"reflection tick: {outcome}", data=data)
 
@@ -208,15 +256,31 @@ def run_tick(now: datetime) -> TickResult:
         _log("skipped-empty")
         return TickResult("skipped-empty")
 
-    # Build prompt
-    prompt = _build_prompt(now, digest_body, edge_summary)
+    # Perceive: call perceive_fn, degrade gracefully on any error.
+    # perceive_fn contract: MUST NOT raise; but we guard defensively here.
+    ctx: PerceptionContext = _NO_PERCEPTION
+    if _perceive_fn is not None:
+        try:
+            ctx = _perceive_fn()
+        except Exception:  # noqa: BLE001
+            log.warning("autonomous: perceive_fn raised; degrading to _NO_PERCEPTION")
+            ctx = _NO_PERCEPTION
 
-    # Reflect: ask brain (with exception guard)
+    # Build enriched prompt (presence text + optional screen instruction)
+    prompt = _build_prompt(now, digest_body, edge_summary, ctx)
+
+    # Reflect: ask brain (with exception guard), pass screen image when available
     try:
-        reply = _brain_ask(prompt, max_tokens=150, think=False, timeout=_ask_timeout)
+        reply = _brain_ask(
+            prompt,
+            max_tokens=150,
+            think=False,
+            timeout=_ask_timeout,
+            image_b64=ctx.screen_b64,
+        )
     except Exception:  # noqa: BLE001
         log.exception("autonomous: brain_ask raised an exception")
-        _log("skipped-brain-down")
+        _log("skipped-brain-down", ctx)
         return TickResult("skipped-brain-down")
 
     # Parse
@@ -231,29 +295,62 @@ def run_tick(now: datetime) -> TickResult:
             log.exception("autonomous: push_fn raised an exception")
         if _spoke_write_fn is not None:
             _spoke_write_fn(today_iso)
-        _log("pushed", message_len=len(message))
+        _log("pushed", ctx, message_len=len(message))
         return TickResult("pushed", message=message)
 
     if verdict == "nada":
         # NADA means silent for the rest of the day (Decision B: mark spoke)
         if _spoke_write_fn is not None:
             _spoke_write_fn(today_iso)
-        _log("nada")
+        _log("nada", ctx)
         return TickResult("nada")
 
     # verdict == "esperar": wait for a better moment; don't mark spoke
-    _log("esperar")
+    _log("esperar", ctx)
     return TickResult("esperar")
 
 
-def _build_prompt(now: datetime, digest_body: str, edge_summary: str) -> str:
-    """Build the reflection prompt per design §4."""
+def _build_prompt(
+    now: datetime,
+    digest_body: str,
+    edge_summary: str,
+    ctx: PerceptionContext = _NO_PERCEPTION,
+) -> str:
+    """Build the reflection prompt per design §4 / §6 (perception enrichment).
+
+    When ctx is _NO_PERCEPTION (no perceive_fn injected), the prompt is
+    functionally identical to the pre-perception version — back-compat preserved.
+    """
     max_chars = _max_message_chars
+
+    # Perception block: presence line + screen instruction
+    if ctx.presence == "present":
+        presence_line = "Estado de presencia: Héctor está presente frente a la pantalla."
+    else:
+        presence_line = (
+            "Estado de presencia: no se pudo confirmar su presencia "
+            "(cámara ocupada, apagada o bloqueada)."
+        )
+
+    if ctx.screen_b64 is not None:
+        screen_block = (
+            "Abajo va una captura de su pantalla activa. "
+            "Mírala: ¿qué está haciendo? "
+            "¿Es buen momento para interrumpir con UNA cosa, o conviene esperar?"
+        )
+    else:
+        screen_block = (
+            "No hay captura de pantalla disponible; "
+            "decide solo con el contexto de vida."
+        )
+
     return (
         f"Es {now.strftime('%H:%M')} ({now.strftime('%A')}). "
         "Este es el contexto de vida de Héctor ahora mismo:\n\n"
         f"{digest_body}\n\n"
         f"{edge_summary}\n\n"
+        f"{presence_line}\n"
+        f"{screen_block}\n\n"
         "Tu tarea: decidir si ESTE es el buen momento para decirle UNA sola cosa, "
         "la MÁS importante que merece su atención. Considera la hora del día.\n"
         f"- Si SÍ es el momento: responde SOLO con esa frase, máx {max_chars} caracteres, "

--- a/lifeos/src/lifeos/autonomous/cron.py
+++ b/lifeos/src/lifeos/autonomous/cron.py
@@ -73,6 +73,7 @@ _NO_PERCEPTION = PerceptionContext()
 
 Outcome = Literal[
     "pushed",
+    "push-failed",
     "esperar",
     "nada",
     "skipped-disabled",
@@ -288,15 +289,21 @@ def run_tick(now: datetime) -> TickResult:
 
     # Act
     if verdict == "msg" and message:
+        push_ok = True
         try:
             if _push_fn is not None:
                 _push_fn("Axi", message)
         except Exception:  # noqa: BLE001
-            log.exception("autonomous: push_fn raised an exception")
-        if _spoke_write_fn is not None:
-            _spoke_write_fn(today_iso)
-        _log("pushed", ctx, message_len=len(message))
-        return TickResult("pushed", message=message)
+            push_ok = False
+            log.exception("autonomous: push_fn raised an exception — slot NOT burned")
+        if push_ok:
+            if _spoke_write_fn is not None:
+                _spoke_write_fn(today_iso)
+            _log("pushed", ctx, message_len=len(message))
+            return TickResult("pushed", message=message)
+        else:
+            _log("push-failed", ctx, message_len=len(message))
+            return TickResult("push-failed", message=message)
 
     if verdict == "nada":
         # NADA means silent for the rest of the day (Decision B: mark spoke)
@@ -382,6 +389,8 @@ def run_tick_now(*, source: str = "manual") -> TickResult:
     """Convenience wrapper: run_tick(now_fn()). Respects enabled gate."""
     if _now_fn is None:
         raise RuntimeError("autonomous cron not configured — call configure() first")
+    if _is_enabled_fn is not None and not _is_enabled_fn():
+        return TickResult("skipped-disabled", reason=f"disabled (source={source})")
     return run_tick(_now_fn())
 
 

--- a/lifeos/src/lifeos/notif_budget.py
+++ b/lifeos/src/lifeos/notif_budget.py
@@ -19,7 +19,7 @@ import json
 import logging
 import os
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from lifeos import store
@@ -96,7 +96,7 @@ def evaluate(title: str, body: str, priority: str = "ambient") -> Decision:
     if priority == "proactive":
         # 1 guaranteed slot/day, OUTSIDE the 5/day ambient cap.
         # Second proactive push in the same calendar day is suppressed.
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         today = now.date()
         with store.connect() as conn:
             rows = conn.execute(
@@ -117,7 +117,7 @@ def evaluate(title: str, body: str, priority: str = "ambient") -> Decision:
         return Decision("send")
 
     cfg = load_config()
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     window_cutoff = now - timedelta(minutes=cfg.dedup_window_minutes)
     today = now.date()
 
@@ -200,7 +200,7 @@ def record(*, title: str, body: str, priority: str, outcome: str) -> None:
 
 def cleanup_old(days: int = 7) -> int:
     """Delete notif_log rows older than `days` days. Returns count deleted."""
-    cutoff = (datetime.utcnow() - timedelta(days=days)).strftime("%Y-%m-%d %H:%M:%S")
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).strftime("%Y-%m-%d %H:%M:%S")
     with store.connect() as conn:
         cursor = conn.execute(
             "DELETE FROM notif_log WHERE sent_at < ?", (cutoff,)

--- a/lifeos/src/lifeos/notif_budget.py
+++ b/lifeos/src/lifeos/notif_budget.py
@@ -93,6 +93,29 @@ def evaluate(title: str, body: str, priority: str = "ambient") -> Decision:
     if priority == "critical":
         return Decision("send")
 
+    if priority == "proactive":
+        # 1 guaranteed slot/day, OUTSIDE the 5/day ambient cap.
+        # Second proactive push in the same calendar day is suppressed.
+        now = datetime.utcnow()
+        today = now.date()
+        with store.connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT sent_at FROM notif_log
+                WHERE priority = 'proactive'
+                  AND outcome = 'sent'
+                  AND sent_at >= ?
+                """,
+                ((now - timedelta(hours=24)).strftime("%Y-%m-%d %H:%M:%S"),),
+            ).fetchall()
+        spoke = sum(
+            1 for r in rows
+            if datetime.strptime(r["sent_at"], "%Y-%m-%d %H:%M:%S").date() == today
+        )
+        if spoke >= 1:
+            return Decision("suppress", reason="proactive-cap")
+        return Decision("send")
+
     cfg = load_config()
     now = datetime.utcnow()
     window_cutoff = now - timedelta(minutes=cfg.dedup_window_minutes)

--- a/lifeos/tests/test_autonomous_cron.py
+++ b/lifeos/tests/test_autonomous_cron.py
@@ -457,3 +457,402 @@ def test_brain_ask_called_with_expected_prompt_shape() -> None:
     assert "ESPERAR" in prompt
     assert "NADA" in prompt
     assert "120" in prompt  # max chars hint
+
+
+# ---------------------------------------------------------------------------
+# TASK-P0: PerceptionContext types are importable and have correct defaults
+# ---------------------------------------------------------------------------
+
+def test_perception_context_defaults() -> None:
+    """PerceptionContext() defaults: presence=unknown, screen_b64=None, webcam_ok=False."""
+    from lifeos.autonomous.cron import PerceptionContext, _NO_PERCEPTION
+    ctx = PerceptionContext()
+    assert ctx.presence == "unknown"
+    assert ctx.screen_b64 is None
+    assert ctx.webcam_ok is False
+    assert ctx.activity_hint is None
+    # _NO_PERCEPTION is the shared frozen instance
+    assert _NO_PERCEPTION == ctx
+
+
+def test_perception_context_is_frozen() -> None:
+    """PerceptionContext is frozen — mutation raises."""
+    from lifeos.autonomous.cron import PerceptionContext
+    ctx = PerceptionContext(presence="present", webcam_ok=True)
+    with pytest.raises((AttributeError, TypeError)):
+        ctx.presence = "unknown"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# TASK-P1A RED → TASK-P1B GREEN: perceive_fn threading into brain_ask
+# ---------------------------------------------------------------------------
+
+def test_perceive_fn_screen_b64_passed_to_brain_ask() -> None:
+    """configure(perceive_fn=fake) → run_tick passes ctx.screen_b64 as image_b64 to brain_ask."""
+    from lifeos.autonomous import cron
+    from lifeos.autonomous.cron import PerceptionContext
+
+    captured_kwargs: list[dict] = []
+
+    def _spy_brain(prompt: str, **kw: Any) -> str:
+        captured_kwargs.append(kw)
+        return "ESPERAR"
+
+    fake_ctx = PerceptionContext(presence="present", screen_b64="FAKESCREEN64", webcam_ok=True)
+
+    _default_configure(
+        brain_ask=_spy_brain,
+        perceive_fn=lambda: fake_ctx,
+    )
+    cron.run_tick(_now())
+    assert len(captured_kwargs) == 1
+    assert captured_kwargs[0].get("image_b64") == "FAKESCREEN64"
+
+
+def test_no_perceive_fn_brain_ask_image_b64_is_none() -> None:
+    """When perceive_fn is NOT injected, brain_ask receives image_b64=None (back-compat)."""
+    from lifeos.autonomous import cron
+
+    captured_kwargs: list[dict] = []
+
+    def _spy_brain(prompt: str, **kw: Any) -> str:
+        captured_kwargs.append(kw)
+        return "ESPERAR"
+
+    # Do NOT pass perceive_fn
+    _default_configure(brain_ask=_spy_brain)
+    cron.run_tick(_now())
+    assert len(captured_kwargs) == 1
+    # image_b64 should be None (or absent — both mean the same)
+    assert captured_kwargs[0].get("image_b64") is None
+
+
+def test_perceive_fn_with_none_screen_b64_passes_none_to_brain() -> None:
+    """ctx.screen_b64=None → brain_ask still called, image_b64=None (graceful degrade)."""
+    from lifeos.autonomous import cron
+    from lifeos.autonomous.cron import PerceptionContext
+
+    captured_kwargs: list[dict] = []
+
+    def _spy_brain(prompt: str, **kw: Any) -> str:
+        captured_kwargs.append(kw)
+        return "Tienes una cita."
+
+    fake_ctx = PerceptionContext(presence="present", screen_b64=None, webcam_ok=False)
+    _default_configure(
+        brain_ask=_spy_brain,
+        perceive_fn=lambda: fake_ctx,
+    )
+    result = cron.run_tick(_now())
+    assert len(captured_kwargs) == 1
+    assert captured_kwargs[0].get("image_b64") is None
+    # tick must complete — not crash
+    assert result.outcome in ("pushed", "esperar", "nada")
+
+
+# ---------------------------------------------------------------------------
+# TASK-P2A RED → TASK-P2B GREEN: _build_prompt includes perception block
+# ---------------------------------------------------------------------------
+
+def test_build_prompt_includes_presence_present_text() -> None:
+    """Prompt includes presence=present text when ctx.presence=='present'."""
+    from lifeos.autonomous import cron
+    from lifeos.autonomous.cron import PerceptionContext
+
+    captured_prompt: list[str] = []
+
+    def _spy_brain(prompt: str, **kw: Any) -> str:
+        captured_prompt.append(prompt)
+        return "ESPERAR"
+
+    fake_ctx = PerceptionContext(presence="present", screen_b64="FAKEDATA", webcam_ok=True)
+    _default_configure(
+        brain_ask=_spy_brain,
+        perceive_fn=lambda: fake_ctx,
+    )
+    cron.run_tick(_now())
+    assert len(captured_prompt) == 1
+    # Should contain some presence indicator text
+    assert "presente" in captured_prompt[0].lower() or "presencia" in captured_prompt[0].lower()
+
+
+def test_build_prompt_includes_presence_unknown_text() -> None:
+    """Prompt mentions camera/presence uncertainty when ctx.presence=='unknown'."""
+    from lifeos.autonomous import cron
+    from lifeos.autonomous.cron import PerceptionContext
+
+    captured_prompt: list[str] = []
+
+    def _spy_brain(prompt: str, **kw: Any) -> str:
+        captured_prompt.append(prompt)
+        return "ESPERAR"
+
+    fake_ctx = PerceptionContext(presence="unknown", screen_b64=None, webcam_ok=False)
+    _default_configure(
+        brain_ask=_spy_brain,
+        perceive_fn=lambda: fake_ctx,
+    )
+    cron.run_tick(_now())
+    assert len(captured_prompt) == 1
+    prompt = captured_prompt[0]
+    # Should contain uncertainty / no-presence words
+    assert any(kw in prompt.lower() for kw in ("no se pudo", "cámara", "bloqueada", "apagada", "desconocida", "confirm"))
+
+
+def test_build_prompt_includes_screen_instruction_when_screen_present() -> None:
+    """Prompt includes screen-description instruction when screen_b64 is set."""
+    from lifeos.autonomous import cron
+    from lifeos.autonomous.cron import PerceptionContext
+
+    captured_prompt: list[str] = []
+
+    def _spy_brain(prompt: str, **kw: Any) -> str:
+        captured_prompt.append(prompt)
+        return "ESPERAR"
+
+    fake_ctx = PerceptionContext(presence="present", screen_b64="SCREENDATA", webcam_ok=True)
+    _default_configure(
+        brain_ask=_spy_brain,
+        perceive_fn=lambda: fake_ctx,
+    )
+    cron.run_tick(_now())
+    assert len(captured_prompt) == 1
+    prompt = captured_prompt[0]
+    # Should contain an instruction to look at screen / decide if good moment
+    assert any(kw in prompt.lower() for kw in ("pantalla", "mirá", "mira", "captura", "haciendo", "interrumpir"))
+
+
+def test_build_prompt_no_screen_instruction_when_no_screen() -> None:
+    """When screen_b64 is None, prompt says activity is unknown."""
+    from lifeos.autonomous import cron
+    from lifeos.autonomous.cron import PerceptionContext
+
+    captured_prompt: list[str] = []
+
+    def _spy_brain(prompt: str, **kw: Any) -> str:
+        captured_prompt.append(prompt)
+        return "ESPERAR"
+
+    fake_ctx = PerceptionContext(presence="unknown", screen_b64=None, webcam_ok=False)
+    _default_configure(
+        brain_ask=_spy_brain,
+        perceive_fn=lambda: fake_ctx,
+    )
+    cron.run_tick(_now())
+    assert len(captured_prompt) == 1
+    prompt = captured_prompt[0]
+    # Should say no screen / decide with life context only
+    assert any(kw in prompt.lower() for kw in ("no hay captura", "sin captura", "solo con el contexto", "no disponible", "contexto de vida"))
+
+
+# ---------------------------------------------------------------------------
+# TASK-P3A RED → TASK-P3B GREEN: behavior matrix
+# ---------------------------------------------------------------------------
+
+def test_presence_present_receptive_brain_pushes() -> None:
+    """present + receptive brain reply → pushed outcome."""
+    from lifeos.autonomous import cron
+    from lifeos.autonomous.cron import PerceptionContext
+
+    push_spy = MagicMock(return_value={"sent": 1})
+    fake_ctx = PerceptionContext(presence="present", screen_b64="SCREEN", webcam_ok=True)
+    _default_configure(
+        brain_ask=lambda *a, **kw: "Tienes una cita médica mañana a las 10.",
+        push_fn=push_spy,
+        perceive_fn=lambda: fake_ctx,
+    )
+    result = cron.run_tick(_now())
+    assert result.outcome == "pushed"
+    push_spy.assert_called_once()
+
+
+def test_presence_present_brain_esperar_no_push() -> None:
+    """present + brain returns ESPERAR → esperar outcome, no push."""
+    from lifeos.autonomous import cron
+    from lifeos.autonomous.cron import PerceptionContext
+
+    push_spy = MagicMock()
+    fake_ctx = PerceptionContext(presence="present", screen_b64="SCREEN", webcam_ok=True)
+    _default_configure(
+        brain_ask=lambda *a, **kw: "ESPERAR",
+        push_fn=push_spy,
+        perceive_fn=lambda: fake_ctx,
+    )
+    result = cron.run_tick(_now())
+    assert result.outcome == "esperar"
+    push_spy.assert_not_called()
+
+
+def test_presence_unknown_brain_esperar_no_push() -> None:
+    """unknown presence + brain returns ESPERAR → esperar outcome, no push."""
+    from lifeos.autonomous import cron
+    from lifeos.autonomous.cron import PerceptionContext
+
+    push_spy = MagicMock()
+    fake_ctx = PerceptionContext(presence="unknown", screen_b64=None, webcam_ok=False)
+    _default_configure(
+        brain_ask=lambda *a, **kw: "ESPERAR",
+        push_fn=push_spy,
+        perceive_fn=lambda: fake_ctx,
+    )
+    result = cron.run_tick(_now())
+    assert result.outcome == "esperar"
+    push_spy.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# TASK-P4A RED → TASK-P4B GREEN: capture-failure degradation
+# ---------------------------------------------------------------------------
+
+def test_screen_capture_failure_tick_completes_text_only() -> None:
+    """ctx.screen_b64=None → tick completes normally; image_b64=None to brain."""
+    from lifeos.autonomous import cron
+    from lifeos.autonomous.cron import PerceptionContext
+
+    captured_kwargs: list[dict] = []
+
+    def _spy_brain(prompt: str, **kw: Any) -> str:
+        captured_kwargs.append(kw)
+        return "Algo importante."
+
+    # Screen capture failed → screen_b64=None
+    fake_ctx = PerceptionContext(presence="present", screen_b64=None, webcam_ok=True)
+    _default_configure(
+        brain_ask=_spy_brain,
+        perceive_fn=lambda: fake_ctx,
+    )
+    result = cron.run_tick(_now())
+    assert len(captured_kwargs) == 1
+    assert captured_kwargs[0].get("image_b64") is None
+    # Tick must complete successfully (pushed/esperar/nada, not a crash)
+    assert result.outcome in ("pushed", "esperar", "nada")
+
+
+def test_perceive_fn_raising_does_not_break_tick() -> None:
+    """perceive_fn that raises must not break the tick (handled outside run_tick per design).
+
+    NOTE: per design, perceive_fn MUST NOT raise. This test documents the expected
+    behavior at the run_tick level — if someone passes a buggy perceive_fn that
+    does raise, run_tick should degrade to _NO_PERCEPTION (or the dashboard wiring
+    should swallow errors). This test verifies run_tick-level safety."""
+    from lifeos.autonomous import cron
+
+    captured_results: list = []
+
+    def _bad_perceive():
+        raise OSError("camera exploded")
+
+    push_spy = MagicMock(return_value={"sent": 1})
+    _default_configure(
+        brain_ask=lambda *a, **kw: "Tienes cita.",
+        push_fn=push_spy,
+        perceive_fn=_bad_perceive,
+    )
+    # run_tick must NOT raise; it should degrade and complete
+    result = cron.run_tick(_now())
+    assert result.outcome in ("pushed", "esperar", "nada", "skipped-brain-down")
+
+
+# ---------------------------------------------------------------------------
+# TASK-P6A RED → TASK-P6B GREEN: log enrichment with perception fields
+# ---------------------------------------------------------------------------
+
+def test_log_enriched_with_perception_fields_on_push() -> None:
+    """On 'pushed' outcome, log data includes presence, webcam_ok, screen_available, activity_descriptor."""
+    from lifeos.autonomous import cron
+    from lifeos.autonomous.cron import PerceptionContext
+
+    log_spy = MagicMock()
+    fake_ctx = PerceptionContext(
+        presence="present",
+        screen_b64="SCREENDATA",
+        webcam_ok=True,
+        activity_hint="coding",
+    )
+    _default_configure(
+        brain_ask=lambda *a, **kw: "Tienes una cita médica mañana.",
+        log_fn=log_spy,
+        perceive_fn=lambda: fake_ctx,
+    )
+    cron.run_tick(_now())
+    assert log_spy.call_count == 1
+    data = log_spy.call_args[1]["data"]
+    assert data["outcome"] == "pushed"
+    assert data["presence"] == "present"
+    assert data["webcam_ok"] is True
+    assert data["screen_available"] is True
+    assert "activity_descriptor" in data
+
+
+def test_log_enriched_on_esperar() -> None:
+    """On 'esperar' outcome, log data includes perception fields."""
+    from lifeos.autonomous import cron
+    from lifeos.autonomous.cron import PerceptionContext
+
+    log_spy = MagicMock()
+    fake_ctx = PerceptionContext(presence="unknown", screen_b64=None, webcam_ok=False)
+    _default_configure(
+        brain_ask=lambda *a, **kw: "ESPERAR",
+        log_fn=log_spy,
+        perceive_fn=lambda: fake_ctx,
+    )
+    cron.run_tick(_now())
+    assert log_spy.call_count == 1
+    data = log_spy.call_args[1]["data"]
+    assert data["outcome"] == "esperar"
+    assert data["presence"] == "unknown"
+    assert data["webcam_ok"] is False
+    assert data["screen_available"] is False
+    assert "activity_descriptor" in data
+
+
+def test_log_enriched_on_nada() -> None:
+    """On 'nada' outcome, log data includes perception fields."""
+    from lifeos.autonomous import cron
+    from lifeos.autonomous.cron import PerceptionContext
+
+    log_spy = MagicMock()
+    fake_ctx = PerceptionContext(presence="present", screen_b64="SCREEN", webcam_ok=True)
+    _default_configure(
+        brain_ask=lambda *a, **kw: "NADA",
+        log_fn=log_spy,
+        perceive_fn=lambda: fake_ctx,
+    )
+    cron.run_tick(_now())
+    assert log_spy.call_count == 1
+    data = log_spy.call_args[1]["data"]
+    assert data["outcome"] == "nada"
+    assert data["presence"] == "present"
+    assert "activity_descriptor" in data
+
+
+def test_no_image_bytes_in_log_data() -> None:
+    """Privacy invariant: log data must NOT contain image bytes (screen_b64 or webcam b64)."""
+    from lifeos.autonomous import cron
+    from lifeos.autonomous.cron import PerceptionContext
+
+    all_log_calls: list[dict] = []
+
+    def _capturing_log(event: str, msg: str, *, data: dict) -> None:
+        all_log_calls.append(data)
+
+    FAKE_IMAGE = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwADhQGAWjR9awAAAABJRU5ErkJggg=="
+    fake_ctx = PerceptionContext(
+        presence="present",
+        screen_b64=FAKE_IMAGE,
+        webcam_ok=True,
+    )
+    _default_configure(
+        brain_ask=lambda *a, **kw: "Tienes una cita.",
+        log_fn=_capturing_log,
+        perceive_fn=lambda: fake_ctx,
+    )
+    cron.run_tick(_now())
+
+    assert len(all_log_calls) == 1
+    data = all_log_calls[0]
+    # Serialize as string and assert the image payload is not in it
+    data_str = str(data)
+    assert FAKE_IMAGE not in data_str, "Image bytes must NOT be logged (privacy invariant)"
+    # Also assert screen_b64 key itself is not in logged data
+    assert "screen_b64" not in data

--- a/lifeos/tests/test_autonomous_cron.py
+++ b/lifeos/tests/test_autonomous_cron.py
@@ -1,0 +1,459 @@
+"""Tests for lifeos.autonomous.cron — the Axi reflection tick.
+
+Strict TDD: tests written first per the RED→GREEN task checklist.
+All dependencies are injected fakes — no real brain, push, scheduler, or I/O.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, date
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, call
+from zoneinfo import ZoneInfo
+
+import pytest
+
+MX = ZoneInfo("America/Mexico_City")
+
+
+def _now(hour: int = 12, minute: int = 0, day: int = 10) -> datetime:
+    """Return a timezone-aware datetime in America/Mexico_City."""
+    return datetime(2026, 6, day, hour, minute, tzinfo=MX)
+
+
+def _today(day: int = 10) -> str:
+    return f"2026-06-{day:02d}"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _isolated_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Isolate LIFEOS_STATE_DIR for every test."""
+    monkeypatch.setenv("LIFEOS_STATE_DIR", str(tmp_path / "state"))
+    yield
+
+
+def _default_configure(**overrides):
+    """Call configure() with sensible defaults. Overrides replace any key."""
+    from lifeos.autonomous import cron
+    defaults: dict[str, Any] = dict(
+        brain_ask=lambda prompt, **kw: "Tienes una cita médica mañana.",
+        digest_fn=lambda: "Héctor corrió 5 km hoy.",
+        correlate_fn=lambda: "Sin correlaciones relevantes.",
+        push_fn=MagicMock(return_value={"sent": 1}),
+        now_fn=lambda: _now(),
+        is_enabled_fn=lambda: True,
+        alive_fn=lambda: True,
+        spoke_read_fn=lambda: None,
+        spoke_write_fn=MagicMock(),
+        log_fn=MagicMock(),
+        window_start_hour=8,
+        window_end_hour=22,
+    )
+    defaults.update(overrides)
+    cron.configure(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# TASK-2: configure() + TickResult smoke
+# ---------------------------------------------------------------------------
+
+def test_configure_resets_state() -> None:
+    """configure() wires all callables; run_tick no longer raises RuntimeError."""
+    from lifeos.autonomous import cron
+    _default_configure()
+    result = cron.run_tick(_now())
+    # Should NOT raise; outcome can be anything valid
+    assert result.outcome is not None
+
+
+# ---------------------------------------------------------------------------
+# TASK-3: Waking-window guard
+# ---------------------------------------------------------------------------
+
+def test_tick_outside_window_returns_skipped_outside_window() -> None:
+    """run_tick at 06:00 (below window_start_hour=8) → skipped-outside-window."""
+    from lifeos.autonomous import cron
+    push_spy = MagicMock()
+    log_spy = MagicMock()
+    _default_configure(
+        push_fn=push_spy,
+        log_fn=log_spy,
+        now_fn=lambda: _now(hour=6),
+    )
+    result = cron.run_tick(_now(hour=6))
+    assert result.outcome == "skipped-outside-window"
+    push_spy.assert_not_called()
+    log_spy.assert_called_once()
+    assert log_spy.call_args[1]["data"]["outcome"] == "skipped-outside-window"
+
+
+def test_tick_at_end_of_window_boundary_is_skipped() -> None:
+    """run_tick at hour == window_end_hour (22) → skipped-outside-window."""
+    from lifeos.autonomous import cron
+    _default_configure(window_end_hour=22)
+    result = cron.run_tick(_now(hour=22))
+    assert result.outcome == "skipped-outside-window"
+
+
+def test_tick_inside_window_proceeds() -> None:
+    """run_tick at 14:00 (inside 8-22 window) → not skipped-outside-window."""
+    from lifeos.autonomous import cron
+    _default_configure()
+    result = cron.run_tick(_now(hour=14))
+    assert result.outcome != "skipped-outside-window"
+
+
+# ---------------------------------------------------------------------------
+# TASK-4: 1/Day cap — spoke-today guard
+# ---------------------------------------------------------------------------
+
+def test_tick_skips_when_already_spoke_today() -> None:
+    """spoke_read_fn returns today's date → skipped-already-spoke; brain not called."""
+    from lifeos.autonomous import cron
+    brain_spy = MagicMock(return_value="whatever")
+    push_spy = MagicMock()
+    log_spy = MagicMock()
+    _default_configure(
+        brain_ask=brain_spy,
+        push_fn=push_spy,
+        log_fn=log_spy,
+        spoke_read_fn=lambda: _today(),
+    )
+    result = cron.run_tick(_now())
+    assert result.outcome == "skipped-already-spoke"
+    brain_spy.assert_not_called()
+    push_spy.assert_not_called()
+    log_spy.assert_called_once()
+    assert log_spy.call_args[1]["data"]["outcome"] == "skipped-already-spoke"
+
+
+def test_tick_proceeds_when_spoke_yesterday() -> None:
+    """spoke_read_fn returns yesterday → brain IS called (returns a message)."""
+    from lifeos.autonomous import cron
+    brain_spy = MagicMock(return_value="Tienes cita mañana a las 10.")
+    _default_configure(
+        brain_ask=brain_spy,
+        spoke_read_fn=lambda: _today(day=9),  # yesterday
+    )
+    result = cron.run_tick(_now())
+    brain_spy.assert_called_once()
+    assert result.outcome == "pushed"
+
+
+# ---------------------------------------------------------------------------
+# TASK-5: Brain-down guard
+# ---------------------------------------------------------------------------
+
+def test_tick_skips_when_brain_not_alive() -> None:
+    """alive_fn returns False → skipped-brain-down; brain_ask NOT called."""
+    from lifeos.autonomous import cron
+    brain_spy = MagicMock()
+    push_spy = MagicMock()
+    log_spy = MagicMock()
+    _default_configure(
+        brain_ask=brain_spy,
+        push_fn=push_spy,
+        log_fn=log_spy,
+        alive_fn=lambda: False,
+    )
+    result = cron.run_tick(_now())
+    assert result.outcome == "skipped-brain-down"
+    brain_spy.assert_not_called()
+    push_spy.assert_not_called()
+    log_spy.assert_called_once()
+    assert log_spy.call_args[1]["data"]["outcome"] == "skipped-brain-down"
+
+
+def test_tick_skips_when_brain_ask_raises() -> None:
+    """brain_ask raises → skipped-brain-down; brain_ask WAS called (liveness passed)."""
+    from lifeos.autonomous import cron
+    def _bad_brain(*a, **kw):
+        raise RuntimeError("llama died")
+    push_spy = MagicMock()
+    log_spy = MagicMock()
+    _default_configure(
+        brain_ask=_bad_brain,
+        push_fn=push_spy,
+        log_fn=log_spy,
+        alive_fn=lambda: True,
+    )
+    result = cron.run_tick(_now())
+    assert result.outcome == "skipped-brain-down"
+    push_spy.assert_not_called()
+    log_spy.assert_called_once()
+    assert log_spy.call_args[1]["data"]["outcome"] == "skipped-brain-down"
+
+
+# ---------------------------------------------------------------------------
+# TASK-6: Empty-digest skip
+# ---------------------------------------------------------------------------
+
+def test_tick_skips_empty_digest() -> None:
+    """Both digest and correlate empty → skipped-empty; brain NOT called."""
+    from lifeos.autonomous import cron
+    brain_spy = MagicMock()
+    _default_configure(
+        brain_ask=brain_spy,
+        digest_fn=lambda: "",
+        correlate_fn=lambda: "",
+    )
+    result = cron.run_tick(_now())
+    assert result.outcome == "skipped-empty"
+    brain_spy.assert_not_called()
+
+
+def test_tick_skips_whitespace_only_digest() -> None:
+    """Whitespace-only digest+correlate → skipped-empty."""
+    from lifeos.autonomous import cron
+    brain_spy = MagicMock()
+    _default_configure(
+        brain_ask=brain_spy,
+        digest_fn=lambda: "   ",
+        correlate_fn=lambda: "   ",
+    )
+    result = cron.run_tick(_now())
+    assert result.outcome == "skipped-empty"
+    brain_spy.assert_not_called()
+
+
+def test_tick_proceeds_when_digest_has_content() -> None:
+    """Non-empty digest → brain IS called."""
+    from lifeos.autonomous import cron
+    brain_spy = MagicMock(return_value="Tienes una cita médica mañana.")
+    _default_configure(brain_ask=brain_spy)
+    result = cron.run_tick(_now())
+    brain_spy.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# TASK-7: Sentinel parser — three-way outcome
+# ---------------------------------------------------------------------------
+
+def test_parse_reply_exact_esperar_any_casing_whitespace() -> None:
+    """'  esperar  ' → outcome esperar; push NOT called; spoke_write NOT called."""
+    from lifeos.autonomous import cron
+    push_spy = MagicMock()
+    spoke_write_spy = MagicMock()
+    log_spy = MagicMock()
+    _default_configure(
+        brain_ask=lambda *a, **kw: "  esperar  ",
+        push_fn=push_spy,
+        spoke_write_fn=spoke_write_spy,
+        log_fn=log_spy,
+    )
+    result = cron.run_tick(_now())
+    assert result.outcome == "esperar"
+    push_spy.assert_not_called()
+    spoke_write_spy.assert_not_called()
+    log_spy.assert_called_once()
+    assert log_spy.call_args[1]["data"]["outcome"] == "esperar"
+
+
+def test_parse_reply_exact_nada() -> None:
+    """'NADA' → outcome nada; push NOT called; spoke_write CALLED (Decision B)."""
+    from lifeos.autonomous import cron
+    push_spy = MagicMock()
+    spoke_write_spy = MagicMock()
+    _default_configure(
+        brain_ask=lambda *a, **kw: "NADA",
+        push_fn=push_spy,
+        spoke_write_fn=spoke_write_spy,
+    )
+    result = cron.run_tick(_now())
+    assert result.outcome == "nada"
+    push_spy.assert_not_called()
+    spoke_write_spy.assert_called_once_with(_today())
+
+
+def test_parse_reply_real_message_pushes() -> None:
+    """Real message → outcome pushed; push called once; spoke_write called."""
+    from lifeos.autonomous import cron
+    push_spy = MagicMock(return_value={"sent": 1})
+    spoke_write_spy = MagicMock()
+    _default_configure(
+        brain_ask=lambda *a, **kw: "Tienes cita médica mañana a las 10.",
+        push_fn=push_spy,
+        spoke_write_fn=spoke_write_spy,
+    )
+    result = cron.run_tick(_now())
+    assert result.outcome == "pushed"
+    push_spy.assert_called_once()
+    spoke_write_spy.assert_called_once_with(_today())
+
+
+def test_parse_reply_message_containing_esperar_pushes() -> None:
+    """'Hay que esperar resultados...' is a real message, NOT a sentinel → pushed."""
+    from lifeos.autonomous import cron
+    push_spy = MagicMock(return_value={"sent": 1})
+    _default_configure(
+        brain_ask=lambda *a, **kw: "Hay que esperar resultados del médico mañana.",
+        push_fn=push_spy,
+    )
+    result = cron.run_tick(_now())
+    assert result.outcome == "pushed"
+    push_spy.assert_called_once()
+
+
+def test_parse_reply_empty_string_becomes_nada() -> None:
+    """Empty reply → nada (nothing to say)."""
+    from lifeos.autonomous import cron
+    push_spy = MagicMock()
+    _default_configure(
+        brain_ask=lambda *a, **kw: "",
+        push_fn=push_spy,
+    )
+    result = cron.run_tick(_now())
+    assert result.outcome == "nada"
+    push_spy.assert_not_called()
+
+
+def test_parse_reply_brain_error_sentinel_becomes_nada() -> None:
+    """Brain error sentinel '[Axi brain no responde…]' → nada."""
+    from lifeos.autonomous import cron
+    push_spy = MagicMock()
+    _default_configure(
+        brain_ask=lambda *a, **kw: "[Axi brain no responde…]",
+        push_fn=push_spy,
+    )
+    result = cron.run_tick(_now())
+    assert result.outcome == "nada"
+    push_spy.assert_not_called()
+
+
+def test_message_is_capped_at_max_chars() -> None:
+    """Brain reply longer than max_message_chars is truncated before push."""
+    from lifeos.autonomous import cron
+    long_msg = "x" * 200
+    captured: list[Any] = []
+    _default_configure(
+        brain_ask=lambda *a, **kw: long_msg,
+        push_fn=lambda title, body, **kw: captured.append(body) or {"sent": 1},
+        max_message_chars=120,
+    )
+    cron.run_tick(_now())
+    assert len(captured) == 1
+    assert len(captured[0]) <= 120
+
+
+# ---------------------------------------------------------------------------
+# TASK-8: Full audit log coverage (every outcome logs exactly once)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("outcome,setup", [
+    ("pushed",               {"brain_ask": lambda *a, **kw: "Tienes cita médica mañana."}),
+    ("esperar",              {"brain_ask": lambda *a, **kw: "ESPERAR"}),
+    ("nada",                 {"brain_ask": lambda *a, **kw: "NADA"}),
+    ("skipped-empty",        {"digest_fn": lambda: "", "correlate_fn": lambda: ""}),
+    ("skipped-brain-down",   {"alive_fn": lambda: False}),
+    ("skipped-already-spoke",{"spoke_read_fn": lambda: _today()}),
+    ("skipped-outside-window", {"now_fn": lambda: _now(hour=6)}),
+])
+def test_every_outcome_logs_exactly_once(outcome: str, setup: dict) -> None:
+    """Every terminal outcome logs exactly once with the right outcome string."""
+    from lifeos.autonomous import cron
+    log_spy = MagicMock()
+    _default_configure(log_fn=log_spy, **setup)
+    now = setup.get("now_fn", lambda: _now())()
+    cron.run_tick(now)
+    assert log_spy.call_count == 1
+    kwargs = log_spy.call_args[1]
+    assert "autonomous.tick" in log_spy.call_args[0] or log_spy.call_args[0][0] == "autonomous.tick"
+    assert kwargs["data"]["outcome"] == outcome
+
+
+# ---------------------------------------------------------------------------
+# TASK-9: Read-only invariant
+# ---------------------------------------------------------------------------
+
+def test_no_domain_write_called_on_any_tick_path() -> None:
+    """No domain store writes happen on any tick path."""
+    from lifeos.autonomous import cron
+
+    entries_spy = MagicMock()
+    interactions_spy = MagicMock()
+    reminders_spy = MagicMock()
+
+    outcomes_setups = [
+        {},  # normal push
+        {"brain_ask": lambda *a, **kw: "ESPERAR"},
+        {"brain_ask": lambda *a, **kw: "NADA"},
+        {"digest_fn": lambda: "", "correlate_fn": lambda: ""},
+        {"alive_fn": lambda: False},
+        {"spoke_read_fn": lambda: _today()},
+        {"now_fn": lambda: _now(hour=6)},
+    ]
+
+    for setup in outcomes_setups:
+        _default_configure(**setup)
+        now = setup.get("now_fn", lambda: _now())()
+        cron.run_tick(now)
+        entries_spy.assert_not_called()
+        interactions_spy.assert_not_called()
+        reminders_spy.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# TASK-10: State file helpers
+# ---------------------------------------------------------------------------
+
+def test_read_last_pushed_returns_none_when_file_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LIFEOS_STATE_DIR", str(tmp_path / "empty_state"))
+    from lifeos.autonomous import cron
+    result = cron.read_last_pushed()
+    assert result is None
+
+
+def test_write_then_read_roundtrip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LIFEOS_STATE_DIR", str(tmp_path / "state"))
+    from lifeos.autonomous import cron
+    import importlib
+    importlib.reload(cron)  # ensure fresh state path uses new env
+    cron.write_last_pushed("2026-06-10")
+    assert cron.read_last_pushed() == "2026-06-10"
+
+
+def test_read_last_pushed_tolerates_corrupt_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    state_dir = tmp_path / "corrupt_state"
+    state_dir.mkdir(parents=True)
+    monkeypatch.setenv("LIFEOS_STATE_DIR", str(state_dir))
+    from lifeos.autonomous import cron
+    (state_dir / "autonomous_last.json").write_text("not-valid-json{{{{")
+    result = cron.read_last_pushed()
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# TASK-11: Prompt builder — brain called with expected shape
+# ---------------------------------------------------------------------------
+
+def test_brain_ask_called_with_expected_prompt_shape() -> None:
+    """brain_ask receives a prompt containing time, digest body, edge summary, sentinels."""
+    from lifeos.autonomous import cron
+    captured_prompt: list[str] = []
+
+    def _spy_brain(prompt: str, **kw: Any) -> str:
+        captured_prompt.append(prompt)
+        return "ESPERAR"
+
+    _default_configure(
+        brain_ask=_spy_brain,
+        digest_fn=lambda: "Entreno en gym.",
+        correlate_fn=lambda: "Sin correlaciones.",
+        now_fn=lambda: _now(hour=14, minute=30),
+    )
+    cron.run_tick(_now(hour=14, minute=30))
+    assert len(captured_prompt) == 1
+    prompt = captured_prompt[0]
+    assert "14:30" in prompt
+    assert "Entreno en gym." in prompt
+    assert "Sin correlaciones." in prompt
+    assert "ESPERAR" in prompt
+    assert "NADA" in prompt
+    assert "120" in prompt  # max chars hint

--- a/lifeos/tests/test_autonomous_cron.py
+++ b/lifeos/tests/test_autonomous_cron.py
@@ -856,3 +856,238 @@ def test_no_image_bytes_in_log_data() -> None:
     assert FAKE_IMAGE not in data_str, "Image bytes must NOT be logged (privacy invariant)"
     # Also assert screen_b64 key itself is not in logged data
     assert "screen_b64" not in data
+
+
+# ---------------------------------------------------------------------------
+# FIX-H2: Push failure must NOT burn the day's slot
+# ---------------------------------------------------------------------------
+
+def test_push_failure_does_not_mark_spoke() -> None:
+    """push_fn raises → spoke_write_fn NOT called; outcome reflects push failure."""
+    from lifeos.autonomous import cron
+
+    spoke_write_spy = MagicMock()
+    log_spy = MagicMock()
+
+    def _failing_push(title: str, body: str, **kw):
+        raise OSError("push service down")
+
+    _default_configure(
+        brain_ask=lambda *a, **kw: "Tienes una cita médica mañana.",
+        push_fn=_failing_push,
+        spoke_write_fn=spoke_write_spy,
+        log_fn=log_spy,
+    )
+    result = cron.run_tick(_now())
+    # Slot must NOT be burned on push failure
+    spoke_write_spy.assert_not_called()
+    # Outcome should reflect the failure (push-failed)
+    assert result.outcome == "push-failed"
+
+
+def test_push_failure_allows_retry_on_next_tick() -> None:
+    """After push_fn raises, subsequent tick (same day) can push again."""
+    from lifeos.autonomous import cron
+
+    call_count = 0
+
+    def _push_that_fails_first(*a, **kw):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise OSError("transient failure")
+        return {"sent": 1}
+
+    spoke_write_spy = MagicMock()
+    _default_configure(
+        brain_ask=lambda *a, **kw: "Tienes una cita médica mañana.",
+        push_fn=_push_that_fails_first,
+        spoke_write_fn=spoke_write_spy,
+    )
+    # First tick: push fails, slot NOT burned
+    result1 = cron.run_tick(_now())
+    assert result1.outcome == "push-failed"
+    spoke_write_spy.assert_not_called()
+
+    # Second tick (same day): push succeeds, slot IS burned
+    result2 = cron.run_tick(_now())
+    assert result2.outcome == "pushed"
+    spoke_write_spy.assert_called_once_with(_today())
+
+
+# ---------------------------------------------------------------------------
+# FIX-H1: run_tick_now must respect the enabled gate
+# ---------------------------------------------------------------------------
+
+def test_run_tick_now_respects_disabled_gate() -> None:
+    """run_tick_now when is_enabled_fn returns False → no brain call, no push, outcome skipped-disabled."""
+    from lifeos.autonomous import cron
+
+    brain_spy = MagicMock()
+    push_spy = MagicMock()
+
+    _default_configure(
+        brain_ask=brain_spy,
+        push_fn=push_spy,
+        is_enabled_fn=lambda: False,
+    )
+    result = cron.run_tick_now()
+    assert result.outcome == "skipped-disabled"
+    brain_spy.assert_not_called()
+    push_spy.assert_not_called()
+
+
+def test_run_tick_now_proceeds_when_enabled() -> None:
+    """run_tick_now when is_enabled_fn returns True → tick runs normally."""
+    from lifeos.autonomous import cron
+
+    brain_spy = MagicMock(return_value="Tienes una cita.")
+    _default_configure(
+        brain_ask=brain_spy,
+        is_enabled_fn=lambda: True,
+    )
+    result = cron.run_tick_now()
+    # run_tick proceeds; brain is called
+    brain_spy.assert_called_once()
+    assert result.outcome in ("pushed", "esperar", "nada", "skipped-already-spoke", "skipped-brain-down", "skipped-empty", "skipped-outside-window")
+
+
+# ---------------------------------------------------------------------------
+# FIX-W1/L1: Read-only invariant test — REAL enforcement
+# ---------------------------------------------------------------------------
+
+def test_no_domain_write_called_on_any_tick_path_real() -> None:
+    """No domain store writes happen on any tick path — enforced via import analysis.
+
+    cron.py must not import any domain-write module: health.entries, finance.entries,
+    relationships.interactions, learning.entries, events.entries, spirituality.entries,
+    exercise.sessions, reminders (write path), lifeos.store (write path).
+    """
+    import ast
+    import importlib.util
+    from pathlib import Path as _Path
+
+    # Find cron.py source
+    spec = importlib.util.find_spec("lifeos.autonomous.cron")
+    assert spec is not None, "lifeos.autonomous.cron not found"
+    assert spec.origin is not None
+    source = _Path(spec.origin).read_text()
+    tree = ast.parse(source)
+
+    # Collect all imported module names (top-level and from-imports)
+    imported_names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imported_names.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module:
+                imported_names.add(node.module)
+
+    # Domain-write surfaces: any import of these would be a violation
+    forbidden_write_modules = {
+        "lifeos.health.entries",
+        "lifeos.finance.entries",
+        "lifeos.finance.ingestion",
+        "lifeos.relationships.interactions",
+        "lifeos.learning.entries",
+        "lifeos.events.entries",
+        "lifeos.spirituality.entries",
+        "lifeos.exercise.sessions",
+        "lifeos.reminders",
+        "lifeos.store",
+    }
+
+    violations = imported_names & forbidden_write_modules
+    assert not violations, (
+        f"cron.py imports domain-write module(s): {violations}. "
+        "The tick must be read-only — no domain writes allowed."
+    )
+
+
+# ---------------------------------------------------------------------------
+# FIX-L2: Privacy invariant extended across all outcomes
+# ---------------------------------------------------------------------------
+
+def test_no_image_bytes_in_log_data_esperar() -> None:
+    """Privacy invariant: no image bytes in log data on 'esperar' outcome."""
+    from lifeos.autonomous import cron
+    from lifeos.autonomous.cron import PerceptionContext
+
+    all_log_calls: list[dict] = []
+
+    def _capturing_log(event: str, msg: str, *, data: dict) -> None:
+        all_log_calls.append(data)
+
+    FAKE_IMAGE = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwADhQGAWjR9awAAAABJRU5ErkJggg=="
+    fake_ctx = PerceptionContext(presence="present", screen_b64=FAKE_IMAGE, webcam_ok=True)
+
+    _default_configure(
+        brain_ask=lambda *a, **kw: "ESPERAR",
+        log_fn=_capturing_log,
+        perceive_fn=lambda: fake_ctx,
+    )
+    cron.run_tick(_now())
+
+    assert len(all_log_calls) >= 1
+    for data in all_log_calls:
+        data_str = str(data)
+        assert FAKE_IMAGE not in data_str, "Image bytes must NOT be logged on esperar (privacy invariant)"
+        assert "screen_b64" not in data
+
+
+def test_no_image_bytes_in_log_data_nada() -> None:
+    """Privacy invariant: no image bytes in log data on 'nada' outcome."""
+    from lifeos.autonomous import cron
+    from lifeos.autonomous.cron import PerceptionContext
+
+    all_log_calls: list[dict] = []
+
+    def _capturing_log(event: str, msg: str, *, data: dict) -> None:
+        all_log_calls.append(data)
+
+    FAKE_IMAGE = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwADhQGAWjR9awAAAABJRU5ErkJggg=="
+    fake_ctx = PerceptionContext(presence="present", screen_b64=FAKE_IMAGE, webcam_ok=True)
+
+    _default_configure(
+        brain_ask=lambda *a, **kw: "NADA",
+        log_fn=_capturing_log,
+        perceive_fn=lambda: fake_ctx,
+    )
+    cron.run_tick(_now())
+
+    assert len(all_log_calls) >= 1
+    for data in all_log_calls:
+        data_str = str(data)
+        assert FAKE_IMAGE not in data_str, "Image bytes must NOT be logged on nada (privacy invariant)"
+        assert "screen_b64" not in data
+
+
+def test_no_image_bytes_in_log_data_brain_exception() -> None:
+    """Privacy invariant: no image bytes in log data when brain_ask raises (brain-exception path)."""
+    from lifeos.autonomous import cron
+    from lifeos.autonomous.cron import PerceptionContext
+
+    all_log_calls: list[dict] = []
+
+    def _capturing_log(event: str, msg: str, *, data: dict) -> None:
+        all_log_calls.append(data)
+
+    def _bad_brain(*a, **kw):
+        raise RuntimeError("brain exploded")
+
+    FAKE_IMAGE = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwADhQGAWjR9awAAAABJRU5ErkJggg=="
+    fake_ctx = PerceptionContext(presence="present", screen_b64=FAKE_IMAGE, webcam_ok=True)
+
+    _default_configure(
+        brain_ask=_bad_brain,
+        log_fn=_capturing_log,
+        perceive_fn=lambda: fake_ctx,
+    )
+    cron.run_tick(_now())
+
+    assert len(all_log_calls) >= 1
+    for data in all_log_calls:
+        data_str = str(data)
+        assert FAKE_IMAGE not in data_str, "Image bytes must NOT be logged on brain-exception (privacy invariant)"
+        assert "screen_b64" not in data

--- a/lifeos/tests/test_notif_budget.py
+++ b/lifeos/tests/test_notif_budget.py
@@ -340,6 +340,97 @@ def test_critical_still_bypasses_all() -> None:
 
 
 # ---------------------------------------------------------------------------
+# FIX-H3: proactive 1/day uses local-date semantics, not UTC date
+# ---------------------------------------------------------------------------
+
+def test_proactive_suppressed_uses_local_date_not_utc() -> None:
+    """The proactive cap must count rows by local calendar day, not UTC.
+
+    We insert a row with a sent_at that is 'today' in UTC but 'yesterday'
+    in a hypothetical local timezone. The proactive budget must NOT suppress
+    when the local date is different from the UTC date of the stored row.
+
+    We simulate this by inserting a row timestamped at UTC midnight minus 1
+    second — which is 'today UTC' but potentially 'yesterday' locally.
+    The key assertion: evaluate() uses local-date semantics.
+
+    Since the actual DB stores naive UTC timestamps and the evaluate()
+    function previously used datetime.utcnow().date() for 'today', this
+    test documents the correct contract: both the check in cron.py and
+    the check in notif_budget.py must use the same calendar-day basis.
+
+    Here we verify the function does NOT use a deprecated datetime.utcnow()
+    call and that importing the module does not raise a DeprecationWarning.
+    """
+    import ast
+    import importlib.util
+    from pathlib import Path as _Path
+
+    spec = importlib.util.find_spec("lifeos.notif_budget")
+    assert spec is not None
+    assert spec.origin is not None
+    source = _Path(spec.origin).read_text()
+
+    # Assert no deprecated datetime.utcnow() calls remain in notif_budget.py
+    assert "datetime.utcnow()" not in source, (
+        "notif_budget.py still uses deprecated datetime.utcnow(). "
+        "Replace with datetime.now(timezone.utc) for correctness."
+    )
+
+
+def test_proactive_cap_date_basis_local_day() -> None:
+    """evaluate('proactive') uses local calendar day for the 1/day count.
+
+    We patch 'now' to just past midnight UTC so that UTC-date == today,
+    and verify the proactive check correctly references local-time date.
+    The concrete assertion: a row inserted in a previous UTC day (but same
+    local day) should still be seen as 'today' by evaluate.
+
+    Simpler approach: verify the DB query window (24h lookback) combined
+    with the date-comparison uses a consistent timezone-aware approach.
+    """
+    from lifeos.notif_budget import evaluate, record
+    from lifeos import store
+    from datetime import datetime, timezone, timedelta
+
+    # Insert a proactive 'sent' row with sent_at = now (UTC) — same calendar
+    # day regardless of local timezone for a straightforward same-day test.
+    now_utc = datetime.now(timezone.utc)
+    ts_str = now_utc.strftime("%Y-%m-%d %H:%M:%S")
+    with store.connect() as conn:
+        conn.execute(
+            "INSERT INTO notif_log(sent_at, hash, priority, outcome) VALUES (?, 'aaa', 'proactive', 'sent')",
+            (ts_str,),
+        )
+
+    # Second proactive push same day → must be suppressed
+    d = evaluate("Axi", "Another proactive msg.", priority="proactive")
+    assert d.action == "suppress"
+    assert d.reason == "proactive-cap"
+
+
+def test_write_last_pushed_failure_does_not_swallow_silently() -> None:
+    """write_last_pushed() write failure must be logged distinctly, not swallowed."""
+    import logging
+    from unittest.mock import patch, MagicMock
+
+    from lifeos.autonomous import cron
+
+    # Make the file write fail
+    with patch("lifeos.autonomous.cron._state_path") as mock_path_fn:
+        mock_path = MagicMock()
+        mock_path.write_text.side_effect = OSError("disk full")
+        mock_path_fn.return_value = mock_path
+
+        with patch.object(cron.log, "warning") as warn_spy:
+            cron.write_last_pushed("2026-06-10")
+            # Must have logged a warning (not silently swallowed)
+            warn_spy.assert_called_once()
+            # Warning message should be distinctly about the write failure
+            assert "persist" in warn_spy.call_args[0][0].lower() or "state" in warn_spy.call_args[0][0].lower()
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 

--- a/lifeos/tests/test_notif_budget.py
+++ b/lifeos/tests/test_notif_budget.py
@@ -287,6 +287,59 @@ def test_send_to_all_budget_integration(monkeypatch: pytest.MonkeyPatch) -> None
 
 
 # ---------------------------------------------------------------------------
+# evaluate — proactive priority (TASK-1A + TASK-1B)
+# ---------------------------------------------------------------------------
+
+def test_proactive_allowed_when_ambient_cap_full() -> None:
+    """5 ambient 'sent' rows for today → proactive evaluate still returns send."""
+    from lifeos.notif_budget import evaluate, record
+
+    for i in range(5):
+        record(title=f"T{i}", body=f"B{i}", priority="ambient", outcome="sent")
+
+    d = evaluate("Axi", "Tienes cita mañana.", priority="proactive")
+    assert d.action == "send"
+
+
+def test_proactive_suppressed_after_one_today() -> None:
+    """1 proactive 'sent' row for today → second proactive returns suppressed."""
+    from lifeos.notif_budget import evaluate, record
+
+    record(title="Axi", body="Cita médica mañana.", priority="proactive", outcome="sent")
+
+    d = evaluate("Axi", "Otro mensaje proactivo.", priority="proactive")
+    assert d.action == "suppress"
+    assert d.reason == "proactive-cap"
+
+
+def test_proactive_rows_do_not_inflate_ambient_count() -> None:
+    """1 proactive 'sent' + 4 ambient 'sent' → 5th ambient is still allowed."""
+    from lifeos.notif_budget import evaluate, record
+
+    record(title="Axi", body="Proactive msg", priority="proactive", outcome="sent")
+    for i in range(4):
+        record(title=f"T{i}", body=f"B{i}", priority="ambient", outcome="sent")
+
+    # 5th ambient slot should still be free (proactive row doesn't count toward ambient)
+    d = evaluate("T4", "B4", priority="ambient")
+    assert d.action == "send"
+
+
+def test_critical_still_bypasses_all() -> None:
+    """Critical priority always returns send regardless of proactive/ambient state."""
+    from lifeos.notif_budget import evaluate, record
+
+    # Fill proactive cap
+    record(title="Axi", body="Proactive msg", priority="proactive", outcome="sent")
+    # Fill ambient cap
+    for i in range(5):
+        record(title=f"T{i}", body=f"B{i}", priority="ambient", outcome="sent")
+
+    d = evaluate("URGENT", "Critical!", priority="critical")
+    assert d.action == "send"
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Axi's first autonomous thought

A reflection tick ("cognitive heartbeat", built on the corazón substrate) that lets Axi decide WHEN to surface the one thing that most deserves Héctor's attention — and reaches him only when it's a good moment.

### What it does
- Runs ~every 45 min in a waking window (08:00–22:00 MX), at most **one effective proactive push per day**.
- Reads a **read-only** life digest, then **perceives** via Axi's eyes: webcam (are you present?) + screen (what are you doing?).
- Asks the local multimodal brain: "is THIS the moment?" → pushes the message, ESPERAR (wait), or NADA (silent for the day).

### Hard invariants (verified + adversarially reviewed)
- **READ-ONLY** — never writes life-data (only the state file, notif_log, events).
- **PRIVACY** — webcam/screen images are in-memory only → local brain → discarded; only derived context (presence/activity/outcome) is logged, never image bytes.
- **1 proactive push/day** — restart-safe state file + a new `proactive` notif_budget slot (outside the 5/day ambient cap).
- **Disabled by default** (`autonomous_enabled=False`) — no tick fires until opted in.
- Graceful degrade: brain down / camera busy / screen capture fails → logs + skips or falls back to text-only; never breaks.

### Quality
- lifeos 731 passed · axi 568 passed / 6 skipped · 0 regressions.
- Dual review (compliance verify + fresh adversarial). Adversarial pass caught + fixed: push-failure burning the day's slot (H2), run_tick_now bypassing the enabled gate (H1), MX/UTC date basis (H3, improved), and two vacuous tests (read-only + privacy now real).

### Next slice (not in this PR)
Routine learning — Axi mines the logged context (time + presence + activity + outcome) to refine its timing over time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)