### PR TITLE
feat(autonomous): UI toggle for Axi's autonomous mind (/config + /setup)

### DIFF
--- a/axi/src/axi/config_schema.py
+++ b/axi/src/axi/config_schema.py
@@ -283,6 +283,14 @@ FIELDS: tuple[ConfigField, ...] = (
         "Puerto del dashboard. Reinicio del dashboard requerido.",
         minimum=1024, maximum=65535,
     ),
+    # ─────── Axi autonomous agent (proactive thought) ───────
+    ConfigField(
+        "autonomous_enabled", "boolean", False,
+        "Master toggle for Axi's autonomous proactive thought: a reflection tick "
+        "that perceives presence (webcam) + activity (screen), decides when to "
+        "surface the one thing that most deserves your attention, and sends at "
+        "most one proactive notification per day. Read-only, opt-in. Live (no restart).",
+    ),
     # ─────── lifeos posture (P6.2) ───────
     ConfigField(
         "posture_enabled", "boolean", False,

--- a/axi/src/axi/dashboard.py
+++ b/axi/src/axi/dashboard.py
@@ -4498,6 +4498,7 @@ def api_setup_status():
             "language": str(config.get("language", "es-MX")),
             "timezone": str(config.get("timezone", "America/Mexico_City")),
             "user_name": str(config.get("user_name", "Héctor")),
+            "autonomous_enabled": bool(config.get("autonomous_enabled", False)),
             "posture_enabled": bool(config.get("posture_enabled", False)),
             "chat_enabled": bool(config.get("chat_enabled", True)),
             "vision_enabled": bool(config.get("vision_enabled", True)),

--- a/axi/src/axi/templates/setup.html
+++ b/axi/src/axi/templates/setup.html
@@ -249,6 +249,10 @@
           <div><span class="muted">Timezone:</span> <code x-text="status.config.timezone"></code></div>
           <div><span class="muted">Nombre:</span> <code x-text="status.config.user_name"></code></div>
           <div>
+            <span class="muted">🧠 Mente autónoma:</span>
+            <span x-text="status.config.autonomous_enabled ? '✅ ON' : '⏸ OFF (opt-in)'"></span>
+          </div>
+          <div>
             <span class="muted">Postura:</span>
             <span x-text="status.config.posture_enabled ? '✅ ON' : '⏸ OFF (opt-in)'"></span>
           </div>


### PR DESCRIPTION
Exposes `autonomous_enabled` as a toggle in /config (next to posture/vision/tts) and a status row on /setup (🧠 Mente autónoma). Live — no restart needed. Defaults off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)