### PR TITLE
feat(autonomous): one-click toggle for Axi's mind on /setup

### DIFF
--- a/axi/src/axi/templates/setup.html
+++ b/axi/src/axi/templates/setup.html
@@ -248,9 +248,11 @@
           <div><span class="muted">Idioma:</span> <code x-text="status.config.language"></code></div>
           <div><span class="muted">Timezone:</span> <code x-text="status.config.timezone"></code></div>
           <div><span class="muted">Nombre:</span> <code x-text="status.config.user_name"></code></div>
-          <div>
+          <div class="flex items-center gap-2">
             <span class="muted">🧠 Mente autónoma:</span>
             <span x-text="status.config.autonomous_enabled ? '✅ ON' : '⏸ OFF (opt-in)'"></span>
+            <button class="btn" style="padding:2px 10px;font-size:0.75rem" @click="toggleAutonomous()"
+                    x-text="status.config && status.config.autonomous_enabled ? 'Desactivar' : 'Activar'"></button>
           </div>
           <div>
             <span class="muted">Postura:</span>
@@ -302,6 +304,17 @@ function setupPage() {
         const r = await fetch('/api/setup/status');
         if (r.ok) this.status = await r.json();
       } catch (e) { /* keep */ }
+    },
+    async toggleAutonomous() {
+      const next = !(this.status.config && this.status.config.autonomous_enabled);
+      try {
+        await fetch('/api/config', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ autonomous_enabled: next }),
+        });
+        await this.loadServer();
+      } catch (e) { /* ignore */ }
     },
     async loadBrowser() {
       // Notification permission


### PR DESCRIPTION
Adds an Activar/Desactivar button on /setup next to the autonomous-mind status (POSTs /api/config, live). Reliable path that doesn't depend on /config rendering.