### PR TITLE
feat(avatar): autonomous-mind indicator + toggle inside the SVG

### DIFF
--- a/axi/src/axi/dashboard.py
+++ b/axi/src/axi/dashboard.py
@@ -784,6 +784,12 @@ def snapshot():
         "cpu_pct": _cpu_pct(),
         "models": _models_snapshot(),
         "eyes": _eye_capabilities(),
+        "autonomous": {
+            "enabled": bool(config.get("autonomous_enabled", False)),
+            # actively thinking = enabled AND not suppressed by a recording meeting
+            "active": bool(config.get("autonomous_enabled", False))
+            and not meeting_status.startswith("recording:"),
+        },
         "memory": {
             "conversation_turns": store.conversation_count(),
             "facts_count": _fact_count(),

--- a/axi/src/axi/templates/dashboard.html
+++ b/axi/src/axi/templates/dashboard.html
@@ -36,6 +36,13 @@
           #axi-avatar .heart.stopped { animation: none; filter: grayscale(1) opacity(0.55); }
           #axi-avatar .tail  { animation: tailWag 4.5s ease-in-out infinite; transform-origin: 41px 59px; }
           #axi-avatar .clk   { cursor:pointer; }
+          #axi-avatar #organ-mind { cursor:pointer; transition: opacity .5s; }
+          #axi-avatar #organ-mind.mind-off { opacity: 0.1; }
+          #axi-avatar .mind-spark { transform-box: fill-box; transform-origin: center; }
+          #axi-avatar #organ-mind.mind-on .mind-aura  { animation: mindPulse 2.6s ease-in-out infinite; }
+          #axi-avatar #organ-mind.mind-on .mind-spark { animation: mindSpark 2s ease-in-out infinite; }
+          @keyframes mindPulse { 0%,100%{opacity:.22} 50%{opacity:.5} }
+          @keyframes mindSpark { 0%,100%{opacity:.35;transform:translateY(0) scale(.85)} 50%{opacity:1;transform:translateY(-1px) scale(1.1)} }
           @media (prefers-reduced-motion: reduce){ #axi-avatar * { animation:none !important; } }
         </style>
 
@@ -109,6 +116,18 @@
           <circle cx="34.6" cy="58" r="2.9" fill="#FF4D88"/>
           <path d="M26.7 59.2 Q32 69 37.3 59.2" fill="#FF4D88"/>
         </g>
+
+        <!-- 🧠 Mente autónoma — aura teal + chispitas de pensamiento sobre la
+             cabeza. Brilla y pulsa si está ACTIVADA, tenue si OFF. Clic = toggle. -->
+        <g id="organ-mind"
+           :class="($store.snap.autonomous && $store.snap.autonomous.enabled) ? 'mind-on' : 'mind-off'"
+           @click="toggleAutonomous()">
+          <ellipse cx="32" cy="16" rx="13" ry="9" fill="#ffffff" fill-opacity="0"/>
+          <ellipse class="mind-aura" cx="32" cy="19" rx="11" ry="4.5" fill="#00D4AA" opacity="0.4" style="filter:blur(2.5px)"/>
+          <circle class="mind-spark" cx="25" cy="16" r="1.1" fill="#7FF0E0"/>
+          <circle class="mind-spark" cx="32" cy="12.5" r="1.5" fill="#00D4AA"/>
+          <circle class="mind-spark" cx="39" cy="16" r="1.1" fill="#7FF0E0"/>
+        </g>
       </svg>
 
       <!-- Popovers -->
@@ -117,6 +136,13 @@
         <div class="font-semibold mb-1" style="color:var(--pink)">❤ Corazón (axi-heartbeat)</div>
         <div class="muted text-xs">Late en sincronía con el supervisor real.</div>
         <div class="muted text-xs">Servicio: <span x-text="$store.snap.services['axi-heartbeat'] || '—'"></span></div>
+      </div>
+      <div id="popover-mind" x-show="open === 'mind'"
+           class="panel2 p-3 text-sm absolute z-50" style="min-width:220px; display:none; top:1rem; right:1rem">
+        <div class="font-semibold mb-1" style="color:var(--teal)">🧠 Mente autónoma</div>
+        <div class="text-xs" x-text="($store.snap.autonomous && $store.snap.autonomous.enabled) ? '✅ Activada — Axi piensa solo' : '⏸ Desactivada'"></div>
+        <div class="muted text-xs" x-show="$store.snap.autonomous && $store.snap.autonomous.enabled && !$store.snap.autonomous.active">⏸ En pausa (reunión activa)</div>
+        <div class="muted text-xs mt-1">Clic en el aura 🧠 para activar / desactivar.</div>
       </div>
       <div id="popover-ears" x-show="open === 'ears'"
            class="panel2 p-3 text-sm absolute z-50" style="min-width:200px; display:none; top:1rem; right:1rem">
@@ -643,6 +669,22 @@ function avatarWidget() {
         });
       } catch (e) { /* offline — silent */ }
       finally { this.speaking = false; }
+    },
+
+    /* Mind aura click — toggle Axi's autonomous mind on/off (POST config).
+       The aura glows when ON, dims when OFF; the snapshot poll confirms. */
+    async toggleAutonomous() {
+      const a = this.$store.snap && this.$store.snap.autonomous;
+      const next = !(a && a.enabled);
+      this.open = 'mind';
+      try {
+        await fetch('/api/config', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ autonomous_enabled: next }),
+        });
+        if (a) a.enabled = next;  // optimistic; poll reconciles in ~1s
+      } catch (e) { /* offline — silent */ }
     },
   };
 }


### PR DESCRIPTION
A glowing teal aura + thought sparkles above Axi's head show whether the autonomous mind is on; click toggles it. No need to open /config. Snapshot exposes autonomous {enabled, active}.