### PR TITLE
feat(avatar): organ hover tooltips + brain vital + mini-brain

### DIFF
--- a/axi/src/axi/dashboard.py
+++ b/axi/src/axi/dashboard.py
@@ -843,10 +843,11 @@ def cmd(name: str):
     return {"ok": True, "response": response}
 
 
-# Senses the user can start/stop from the avatar. Deliberately EXCLUDES
-# axi-heartbeat (the self-healing heart) and the store (memory) — those are
-# vital and must not be toggled off from a casual click.
-_TOGGLEABLE_SERVICES = {"llama-server", "axi-whisper", "ydotoold"}
+# Senses the user can start/stop from the avatar. Deliberately EXCLUDES the
+# VITAL organs — axi-heartbeat (self-healing heart), llama-server (brain /
+# reasoning) and the store (memory) — those must not be toggled off from a
+# casual click.
+_TOGGLEABLE_SERVICES = {"axi-whisper", "ydotoold"}
 
 
 @app.post("/api/service/{action}/{name}")

--- a/axi/src/axi/templates/dashboard.html
+++ b/axi/src/axi/templates/dashboard.html
@@ -55,6 +55,7 @@
 
         <!-- Orejas / branquias = Oído (axi-whisper) -->
         <g id="organ-ears" class="ears" @click="open = open === 'ears' ? null : 'ears'">
+          <title>Oídos (escuchar)</title>
           <use href="#axi-gill" transform="translate(23,32) rotate(-56) scale(0.94)"/>
           <use href="#axi-gill" transform="translate(20,37) rotate(-79) scale(0.95)"/>
           <use href="#axi-gill" transform="translate(22,43) rotate(-95) scale(0.9)"/>
@@ -72,6 +73,7 @@
 
         <!-- Manos = ydotoold -->
         <g id="organ-hands" class="clk" @click="open = open === 'hands' ? null : 'hands'">
+          <title>Manos (actuar)</title>
           <ellipse cx="21" cy="53" rx="3" ry="4.3" fill="#fe8faf" stroke="#241019" stroke-width="0.9" transform="rotate(32 22 53)"/>
           <ellipse cx="43" cy="53" rx="3" ry="4.3" fill="#fe8faf" stroke="#241019" stroke-width="0.9" transform="rotate(-32 42 53)"/>
         </g>
@@ -86,6 +88,7 @@
         <!-- 💾 Memoria = lo que Axi guarda adentro (la pancita-núcleo; el corazón
              vive SOBRE ella). Anillos suaves = capas de recuerdos. Clic = ver. -->
         <g id="organ-memory" class="clk" @click="open = open === 'memory' ? null : 'memory'">
+          <title>Memoria (lo que Axi recuerda)</title>
           <ellipse cx="32" cy="59" rx="7.6" ry="7.8" fill="#FFC2D6" opacity="0.7"/>
           <ellipse cx="32" cy="59" rx="5.4" ry="5.6" fill="none" stroke="#FF6B9D" stroke-width="0.4" opacity="0.3"/>
           <ellipse cx="32" cy="59" rx="3.3" ry="3.5" fill="none" stroke="#FF6B9D" stroke-width="0.4" opacity="0.35"/>
@@ -96,10 +99,12 @@
         <!-- 🧠 Cerebro = llama-server (el modelo que razona), dentro de la cabeza.
              Brillo teal + neuronas en la frente. Clic = modelo / VRAM / estado. -->
         <g id="organ-brain" class="clk" @click="open = open === 'brain' ? null : 'brain'">
-          <ellipse cx="32" cy="30.5" rx="7" ry="3.6" fill="#000000" fill-opacity="0"/>
-          <circle cx="29" cy="31" r="0.6" fill="#FF2D55"/>
-          <circle cx="32" cy="29.8" r="0.7" fill="#FF2D55"/>
-          <circle cx="35" cy="31" r="0.6" fill="#FF2D55"/>
+          <title>Cerebro (el modelo que razona)</title>
+          <ellipse cx="32" cy="30.5" rx="7" ry="3.8" fill="#000000" fill-opacity="0"/>
+          <!-- mini cerebro: óvalo + circunvoluciones -->
+          <ellipse cx="32" cy="30.3" rx="2.7" ry="2" fill="#FFC2D6" stroke="#D94F86" stroke-width="0.35"/>
+          <path d="M29.8 30.3 Q31 29.4 32 30.3 Q33 31.2 34.2 30.3" fill="none" stroke="#D94F86" stroke-width="0.35" stroke-linecap="round" opacity="0.85"/>
+          <path d="M32 28.5 L32 32.1" stroke="#D94F86" stroke-width="0.3" opacity="0.5"/>
         </g>
 
         <!-- Chapitas -->
@@ -108,17 +113,20 @@
 
         <!-- Ojo izquierdo = pantalla (clic captura la pantalla) -->
         <g id="eye-screen" class="eye" @click="captureEye('screen')" style="transform-origin:26px 38px">
+          <title>Ojo · pantalla (clic: captura)</title>
           <circle cx="26" cy="38" r="2.6" fill="#14131F"/>
           <circle cx="26.9" cy="37.2" r="0.9" fill="#FFFFFF"/>
         </g>
         <!-- Ojo derecho = cámara (clic toma una foto) -->
         <g id="eye-webcam" class="eye" @click="captureEye('webcam')" style="transform-origin:38px 38px">
+          <title>Ojo · cámara (clic: foto)</title>
           <circle cx="38" cy="38" r="2.6" fill="#14131F"/>
           <circle cx="38.9" cy="37.2" r="0.9" fill="#FFFFFF"/>
         </g>
 
         <!-- Boca (clic = Axi habla en voz alta) -->
         <g id="organ-mouth" class="clk" @click="speak()">
+          <title>Boca (clic: Axi habla)</title>
           <path d="M26 43 Q32 48 38 43" stroke="#14131F" stroke-width="1" stroke-linecap="round" fill="none"/>
         </g>
 
@@ -127,6 +135,7 @@
         <g id="organ-heart" class="heart"
            :class="($store.snap.services['axi-heartbeat'] === 'active') ? '' : 'stopped'"
            @click="open = open === 'heart' ? null : 'heart'">
+          <title>Corazón (latido vital)</title>
           <circle cx="32.2" cy="55" r="1.45" fill="#FF4D88"/>
           <circle cx="34.8" cy="55" r="1.45" fill="#FF4D88"/>
           <path d="M30.85 55.6 Q33.5 60.5 36.15 55.6" fill="#FF4D88"/>
@@ -137,6 +146,7 @@
         <g id="organ-mind"
            :class="($store.snap.autonomous && $store.snap.autonomous.enabled) ? 'mind-on' : 'mind-off'"
            @click="open = open === 'mind' ? null : 'mind'">
+          <title>Mente autónoma</title>
           <ellipse cx="32" cy="16" rx="13" ry="9" fill="#ffffff" fill-opacity="0"/>
           <ellipse class="mind-aura" cx="32" cy="19" rx="11" ry="4.5" fill="#00D4AA" opacity="0.4" style="filter:blur(2.5px)"/>
           <circle class="mind-spark" cx="25" cy="16" r="1.1" fill="#7FF0E0"/>
@@ -167,9 +177,7 @@
         <div class="muted text-xs">Modelo: <span x-text="($store.snap.models && $store.snap.models.mode) || '—'"></span></div>
         <div class="muted text-xs">VRAM: <span x-text="$store.snap.vram ? (($store.snap.vram.used_mb/1024).toFixed(1) + ' GB') : '—'"></span></div>
         <div class="muted text-xs">Estado: <span x-text="$store.snap.services['llama-server'] || '—'"></span></div>
-        <button class="btn mt-2" style="padding:3px 12px;font-size:0.75rem"
-                @click="toggleService('llama-server', $store.snap.services['llama-server']==='active')"
-                x-text="$store.snap.services['llama-server']==='active' ? 'Desactivar' : 'Activar'"></button>
+        <div class="muted text-xs mt-1">Órgano vital — no se puede apagar.</div>
       </div>
       <div id="popover-memory" x-show="open === 'memory'"
            class="panel2 p-3 text-sm absolute z-50" style="min-width:210px; display:none; top:1rem; right:1rem">


### PR DESCRIPTION
Native SVG title tooltips on each organ (hover shows the name). Brain made vital (no toggle, endpoint 403). Mini-brain forehead glyph replaces the dots.