### PR TITLE
feat(autonomous): routine learning — Axi learns Héctor's rhythm

### DIFF
--- a/lifeos/src/lifeos/autonomous/cron.py
+++ b/lifeos/src/lifeos/autonomous/cron.py
@@ -28,6 +28,7 @@ from zoneinfo import ZoneInfo
 from apscheduler.triggers.cron import CronTrigger
 
 from lifeos.scheduler import get_scheduler
+import lifeos.autonomous.routine as routine
 
 log = logging.getLogger("lifeos.autonomous.cron")
 
@@ -118,6 +119,17 @@ _max_message_chars: int = 120
 _language: str = "es-MX"
 _window_start_hour: int = 8
 _window_end_hour: int = 22
+_routine_path: Path | None = None
+
+
+def _routine_path_default() -> Path:
+    """Path to the routine JSONL file. Mirrors _state_path() convention."""
+    base = Path(
+        os.environ.get("LIFEOS_STATE_DIR")
+        or (Path.home() / ".local" / "state" / "lifeos")
+    )
+    base.mkdir(parents=True, exist_ok=True)
+    return base / "autonomous_routine.jsonl"
 
 
 def configure(
@@ -138,6 +150,7 @@ def configure(
     language: str = "es-MX",
     window_start_hour: int = 8,
     window_end_hour: int = 22,
+    routine_path: Path | None = None,
 ) -> None:
     """Inject all callables. Calling configure() resets state completely."""
     global _brain_ask, _digest_fn, _correlate_fn, _push_fn, _now_fn
@@ -145,6 +158,7 @@ def configure(
     global _perceive_fn
     global _ask_timeout, _max_message_chars, _language
     global _window_start_hour, _window_end_hour
+    global _routine_path
 
     _brain_ask = brain_ask
     _digest_fn = digest_fn
@@ -162,6 +176,7 @@ def configure(
     _language = language
     _window_start_hour = int(window_start_hour)
     _window_end_hour = int(window_end_hour)
+    _routine_path = routine_path
 
 
 # ---------------------------------------------------------------------------
@@ -228,9 +243,27 @@ def run_tick(now: datetime) -> TickResult:
         raise RuntimeError("autonomous cron not configured — call configure() first")
 
     def _log(outcome: Outcome, ctx: PerceptionContext = _NO_PERCEPTION, **extra) -> None:
-        data = {"outcome": outcome, **_perception_log_fields(ctx), **extra}
+        fields = _perception_log_fields(ctx)
+        data = {"outcome": outcome, **fields, **extra}
         if _log_fn is not None:
             _log_fn("autonomous.tick", f"reflection tick: {outcome}", data=data)
+        # Routine record — best-effort, never breaks a tick
+        try:
+            rp = _routine_path or _routine_path_default()
+            routine.write_routine_record(
+                rp,
+                ts=now.timestamp(),
+                weekday=now.weekday(),
+                hour=now.hour,
+                presence=ctx.presence,
+                activity_descriptor=fields["activity_descriptor"],
+                outcome=outcome,
+            )
+            # Once-per-day trim at window start hour (08:00)
+            if now.hour == _window_start_hour:
+                routine.trim_routine_records(rp, days=90)
+        except Exception:  # noqa: BLE001
+            log.warning("autonomous: routine record write failed", exc_info=True)
 
     # Guard: waking window
     if now.hour < _window_start_hour or now.hour >= _window_end_hour:
@@ -267,8 +300,19 @@ def run_tick(now: datetime) -> TickResult:
             log.warning("autonomous: perceive_fn raised; degrading to _NO_PERCEPTION")
             ctx = _NO_PERCEPTION
 
-    # Build enriched prompt (presence text + optional screen instruction)
-    prompt = _build_prompt(now, digest_body, edge_summary, ctx)
+    # Build routine hint (once per tick; degrade silently on any failure)
+    routine_hint: str | None = None
+    try:
+        rp = _routine_path or _routine_path_default()
+        profile = routine.build_presence_profile(rp, days=30, now_ts=now.timestamp())
+        routine_hint = routine.format_routine_hint(
+            profile, now_weekday=now.weekday(), now_hour=now.hour
+        )
+    except Exception:  # noqa: BLE001
+        routine_hint = None
+
+    # Build enriched prompt (presence text + optional screen instruction + routine hint)
+    prompt = _build_prompt(now, digest_body, edge_summary, ctx, routine_hint=routine_hint)
 
     # Reflect: ask brain (with exception guard), pass screen image when available
     try:
@@ -322,11 +366,17 @@ def _build_prompt(
     digest_body: str,
     edge_summary: str,
     ctx: PerceptionContext = _NO_PERCEPTION,
+    routine_hint: str | None = None,
 ) -> str:
     """Build the reflection prompt per design §4 / §6 (perception enrichment).
 
     When ctx is _NO_PERCEPTION (no perceive_fn injected), the prompt is
     functionally identical to the pre-perception version — back-compat preserved.
+
+    When routine_hint is None, the prompt is BYTE-FOR-BYTE identical to the
+    pre-routine-learning format (cold-start zero-regression invariant).
+    When routine_hint is a non-None string, it is injected as its own paragraph
+    BETWEEN the presence_line and the screen_block.
     """
     max_chars = _max_message_chars
 
@@ -351,12 +401,16 @@ def _build_prompt(
             "decide solo con el contexto de vida."
         )
 
+    # Routine hint block: empty string when None → byte-identical to pre-change prompt
+    routine_block = f"\n{routine_hint}\n" if routine_hint else ""
+
     return (
         f"Es {now.strftime('%H:%M')} ({now.strftime('%A')}). "
         "Este es el contexto de vida de Héctor ahora mismo:\n\n"
         f"{digest_body}\n\n"
         f"{edge_summary}\n\n"
         f"{presence_line}\n"
+        f"{routine_block}"
         f"{screen_block}\n\n"
         "Tu tarea: decidir si ESTE es el buen momento para decirle UNA sola cosa, "
         "la MÁS importante que merece su atención. Considera la hora del día.\n"

--- a/lifeos/src/lifeos/autonomous/routine.py
+++ b/lifeos/src/lifeos/autonomous/routine.py
@@ -47,6 +47,17 @@ _PRIVACY_BANNED_KEYS = {
     "digest", "body", "content", "data",
 }
 
+# Allowlist of coarse activity tokens that may be written to the JSONL.
+# Any value NOT in this set is replaced with "other" before writing.
+_ACTIVITY_ALLOWLIST: frozenset[str] = frozenset({
+    "screen+present",
+    "screen+unknown",
+    "screen+away",
+    "no-screen+unknown",
+    "no-screen+present",
+    "no-screen+away",
+})
+
 
 # ---------------------------------------------------------------------------
 # write_routine_record
@@ -69,12 +80,15 @@ def write_routine_record(
     Thread-safety: on Linux, a single write() to an O_APPEND fd with payload
     < PIPE_BUF (~4 096 bytes) is atomic. Records are ~120-160 bytes — safe.
     """
+    # Sanitize at write boundary: only coarse tokens from the allowlist may
+    # be persisted; any free-text value (e.g. a window title) becomes "other".
+    safe_descriptor = activity_descriptor if activity_descriptor in _ACTIVITY_ALLOWLIST else "other"
     rec = {
         "ts": ts,
         "weekday": weekday,
         "hour": hour,
         "presence": presence,
-        "activity_descriptor": activity_descriptor,
+        "activity_descriptor": safe_descriptor,
         "outcome": outcome,
     }
     try:
@@ -234,9 +248,11 @@ def trim_routine_records(
             if float(rec["ts"]) >= cutoff:
                 survivors.append(stripped + "\n")
         except (KeyError, ValueError, TypeError):
-            # Keep corrupt lines (they were written, so preserve them)
-            survivors.append(line if line.endswith("\n") else line + "\n")
+            # Drop corrupt lines: build_presence_profile already ignores them,
+            # so keeping them only lets them accumulate forever.
+            pass
 
+    tmp_name: str | None = None
     try:
         dir_path = path.parent
         with tempfile.NamedTemporaryFile(
@@ -245,8 +261,15 @@ def trim_routine_records(
             tmp_name = tmp.name
             tmp.writelines(survivors)
         os.replace(tmp_name, path)
+        tmp_name = None  # replace succeeded; file was renamed, nothing to clean up
     except OSError:
         log.warning("autonomous: could not write trimmed routine JSONL", exc_info=True)
         return 0
+    finally:
+        if tmp_name is not None:
+            try:
+                os.unlink(tmp_name)
+            except OSError:
+                pass
 
     return len(survivors)

--- a/lifeos/src/lifeos/autonomous/routine.py
+++ b/lifeos/src/lifeos/autonomous/routine.py
@@ -1,0 +1,252 @@
+"""Routine-learning module for the autonomous tick.
+
+Collects one privacy-safe record per tick and aggregates a
+presence-by-(weekday, hour) profile. Provides a learned Spanish hint
+for the brain's timing-decision prompt once sufficient data exists.
+
+Privacy invariant: the JSONL written by this module contains ONLY
+the six scalar fields defined in _RECORD_KEYS. Image bytes, message
+text, names, digests, and any life-domain payload MUST NOT appear.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+import time as _time_module
+from collections import defaultdict
+from pathlib import Path
+
+log = logging.getLogger("lifeos.autonomous.routine")
+
+# ---------------------------------------------------------------------------
+# Named constants (module-level for testability)
+# ---------------------------------------------------------------------------
+
+_MIN_TOTAL_RECORDS = 10
+_MIN_BUCKET_SAMPLES = 4
+_HIGH_RATE = 0.65
+_LOW_RATE = 0.25
+
+_WEEKDAYS_ES = [
+    "lunes",
+    "martes",
+    "miércoles",
+    "jueves",
+    "viernes",
+    "sábado",
+    "domingo",
+]
+
+_RECORD_KEYS = {"ts", "weekday", "hour", "presence", "activity_descriptor", "outcome"}
+
+_PRIVACY_BANNED_KEYS = {
+    "message", "text", "image", "screen", "name",
+    "digest", "body", "content", "data",
+}
+
+
+# ---------------------------------------------------------------------------
+# write_routine_record
+# ---------------------------------------------------------------------------
+
+def write_routine_record(
+    path: Path,
+    *,
+    ts: float,
+    weekday: int,
+    hour: int,
+    presence: str,
+    activity_descriptor: str,
+    outcome: str,
+) -> None:
+    """Append ONE JSON line atomically. Never raises (best-effort; logs on OSError).
+
+    Keyword-only scalar fields → structurally impossible to leak life-data/images.
+
+    Thread-safety: on Linux, a single write() to an O_APPEND fd with payload
+    < PIPE_BUF (~4 096 bytes) is atomic. Records are ~120-160 bytes — safe.
+    """
+    rec = {
+        "ts": ts,
+        "weekday": weekday,
+        "hour": hour,
+        "presence": presence,
+        "activity_descriptor": activity_descriptor,
+        "outcome": outcome,
+    }
+    try:
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "a") as fh:
+            fh.write(json.dumps(rec) + "\n")
+    except OSError:
+        log.warning("autonomous: routine record write failed", exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# build_presence_profile
+# ---------------------------------------------------------------------------
+
+def build_presence_profile(
+    path: Path,
+    *,
+    days: int = 30,
+    now_ts: float | None = None,
+) -> dict[tuple[int, int], tuple[int, int]]:
+    """Pure single-pass aggregation over the JSONL within the rolling ``days`` window.
+
+    Returns ``{(weekday, hour): (present_count, total_count)}``.
+    Missing file / parse errors → ``{}`` (each bad line skipped, never raises).
+    ``now_ts`` defaults to ``time.time()``; injected in tests for deterministic windows.
+    """
+    if now_ts is None:
+        now_ts = _time_module.time()
+    cutoff = now_ts - days * 86400.0
+
+    counts: dict[tuple[int, int], list[int, int]] = defaultdict(lambda: [0, 0])
+
+    try:
+        with open(path) as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                    ts = float(rec["ts"])
+                    if ts < cutoff:
+                        continue
+                    wd = int(rec["weekday"])
+                    h = int(rec["hour"])
+                    pres = rec["presence"]
+                    counts[(wd, h)][1] += 1
+                    if pres == "present":
+                        counts[(wd, h)][0] += 1
+                except (KeyError, ValueError, TypeError):
+                    continue
+    except FileNotFoundError:
+        return {}
+    except OSError:
+        log.warning("autonomous: could not read routine JSONL", exc_info=True)
+        return {}
+
+    return {k: (v[0], v[1]) for k, v in counts.items()}
+
+
+# ---------------------------------------------------------------------------
+# format_routine_hint
+# ---------------------------------------------------------------------------
+
+def format_routine_hint(
+    profile: dict[tuple[int, int], tuple[int, int]],
+    *,
+    now_weekday: int,
+    now_hour: int,
+) -> str | None:
+    """PURE: no I/O, no clock. Returns a 1-2 sentence Spanish hint or None.
+
+    None on cold-start (< _MIN_TOTAL_RECORDS total) / ambiguous signal / absent
+    bucket / insufficient local samples. Never contains life-data.
+
+    Uses ±1h smoothing within the same weekday: aggregates (wd, h-1), (wd, h),
+    (wd, h+1) — clamped to 0..23, no cross-day wrap.
+    """
+    # Global floor: cold-start guard
+    total_all = sum(total for _, total in profile.values())
+    if total_all < _MIN_TOTAL_RECORDS:
+        return None
+
+    # ±1h smoothing within the same weekday
+    neighbor_hours = [h for h in (now_hour - 1, now_hour, now_hour + 1) if 0 <= h <= 23]
+    present_sum = 0
+    total_sum = 0
+    for h in neighbor_hours:
+        bucket = profile.get((now_weekday, h))
+        if bucket is not None:
+            present_sum += bucket[0]
+            total_sum += bucket[1]
+
+    # No samples in smoothed window → None
+    if total_sum < _MIN_BUCKET_SAMPLES:
+        return None
+
+    rate = present_sum / total_sum
+    pct = round(rate * 100)
+    dia = _WEEKDAYS_ES[now_weekday]
+    hh = f"{now_hour:02d}"
+
+    if rate >= _HIGH_RATE:
+        return (
+            f"Patrón habitual: los {dia} alrededor de las {hh}:00 "
+            f"Héctor suele estar presente (~{pct}% de las veces). "
+            "Es una ventana típicamente receptiva."
+        )
+    if rate <= _LOW_RATE:
+        return (
+            f"Patrón habitual: los {dia} alrededor de las {hh}:00 "
+            f"Héctor rara vez está presente (~{pct}% de las veces). "
+            "Probablemente no sea un buen momento."
+        )
+
+    # Middle band — ambiguous, return None
+    return None
+
+
+# ---------------------------------------------------------------------------
+# trim_routine_records
+# ---------------------------------------------------------------------------
+
+def trim_routine_records(
+    path: Path,
+    *,
+    days: int = 90,
+    now_ts: float | None = None,
+) -> int:
+    """Rewrite the JSONL keeping only lines with ts >= now - days*86400.
+
+    Returns count kept. Missing file → 0. Atomic via temp-file + os.replace.
+    Never raises (best-effort; logs on OSError).
+    """
+    if now_ts is None:
+        now_ts = _time_module.time()
+    cutoff = now_ts - days * 86400.0
+    path = Path(path)
+
+    try:
+        with open(path) as fh:
+            lines = fh.readlines()
+    except FileNotFoundError:
+        return 0
+    except OSError:
+        log.warning("autonomous: could not read routine JSONL for trim", exc_info=True)
+        return 0
+
+    survivors = []
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            rec = json.loads(stripped)
+            if float(rec["ts"]) >= cutoff:
+                survivors.append(stripped + "\n")
+        except (KeyError, ValueError, TypeError):
+            # Keep corrupt lines (they were written, so preserve them)
+            survivors.append(line if line.endswith("\n") else line + "\n")
+
+    try:
+        dir_path = path.parent
+        with tempfile.NamedTemporaryFile(
+            mode="w", dir=dir_path, delete=False, suffix=".tmp"
+        ) as tmp:
+            tmp_name = tmp.name
+            tmp.writelines(survivors)
+        os.replace(tmp_name, path)
+    except OSError:
+        log.warning("autonomous: could not write trimmed routine JSONL", exc_info=True)
+        return 0
+
+    return len(survivors)

--- a/lifeos/tests/test_autonomous_cron.py
+++ b/lifeos/tests/test_autonomous_cron.py
@@ -1091,3 +1091,222 @@ def test_no_image_bytes_in_log_data_brain_exception() -> None:
         data_str = str(data)
         assert FAKE_IMAGE not in data_str, "Image bytes must NOT be logged on brain-exception (privacy invariant)"
         assert "screen_b64" not in data
+
+
+# ---------------------------------------------------------------------------
+# axi-routine-learning: Phase 5 — configure() accepts routine_path
+# ---------------------------------------------------------------------------
+
+def test_configure_accepts_routine_path(tmp_path: Path) -> None:
+    """configure(routine_path=...) + run_tick → JSONL at that path has exactly 1 line."""
+    from lifeos.autonomous import cron
+
+    rp = tmp_path / "routine.jsonl"
+    _default_configure(routine_path=rp)
+    cron.run_tick(_now())
+    assert rp.exists(), "routine JSONL was not created"
+    lines = rp.read_text().splitlines()
+    assert len(lines) == 1
+
+
+# ---------------------------------------------------------------------------
+# axi-routine-learning: Phase 6 — _log writes one record per outcome + trim
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("outcome_setup", [
+    {"brain_ask": lambda *a, **kw: "Tienes cita médica mañana."},          # pushed
+    {"brain_ask": lambda *a, **kw: "ESPERAR"},                              # esperar
+    {"brain_ask": lambda *a, **kw: "NADA"},                                 # nada
+    {"digest_fn": lambda: "", "correlate_fn": lambda: ""},                  # skipped-empty
+])
+def test_tick_writes_one_record_per_outcome(tmp_path: Path, outcome_setup: dict) -> None:
+    """Every non-window-skip outcome writes exactly one routine record."""
+    from lifeos.autonomous import cron
+
+    rp = tmp_path / "routine.jsonl"
+    _default_configure(routine_path=rp, **outcome_setup)
+    cron.run_tick(_now())
+    assert rp.exists()
+    lines = rp.read_text().splitlines()
+    assert len(lines) == 1
+    rec = json.loads(lines[0])
+    assert isinstance(rec["weekday"], int)
+    assert isinstance(rec["hour"], int)
+    assert isinstance(rec["presence"], str)
+    assert isinstance(rec["outcome"], str)
+
+
+def test_tick_writes_one_record_skipped_outcomes(tmp_path: Path) -> None:
+    """skipped-outside-window also writes a record."""
+    from lifeos.autonomous import cron
+
+    rp = tmp_path / "routine.jsonl"
+    _default_configure(routine_path=rp)
+    cron.run_tick(_now(hour=6))  # outside window
+    assert rp.exists()
+    lines = rp.read_text().splitlines()
+    assert len(lines) == 1
+    rec = json.loads(lines[0])
+    assert rec["outcome"] == "skipped-outside-window"
+
+
+def test_trim_fires_at_window_start_hour(tmp_path: Path) -> None:
+    """Tick at hour==8 trims old records (>90d) from the routine JSONL."""
+    import json as _json
+
+    from lifeos.autonomous import cron
+
+    rp = tmp_path / "routine.jsonl"
+    _NOW = _now(hour=8)
+    now_ts = _NOW.timestamp()
+    # Pre-seed: one old record (>90d) and one recent record (5d)
+    with open(rp, "w") as fh:
+        fh.write(_json.dumps({"ts": now_ts - 100 * 86400, "weekday": 0, "hour": 9, "presence": "present", "activity_descriptor": "x", "outcome": "pushed"}) + "\n")
+        fh.write(_json.dumps({"ts": now_ts - 5 * 86400,   "weekday": 1, "hour": 10, "presence": "present", "activity_descriptor": "x", "outcome": "pushed"}) + "\n")
+
+    _default_configure(routine_path=rp, brain_ask=lambda *a, **kw: "ESPERAR")
+    cron.run_tick(_NOW)
+
+    # After tick, old record should be gone (trim fired), only recent + new tick record remain
+    remaining = rp.read_text().splitlines()
+    tses = [_json.loads(line)["ts"] for line in remaining]
+    cutoff = now_ts - 90 * 86400
+    assert all(ts >= cutoff for ts in tses), f"Old record not trimmed: {tses}"
+
+
+def test_write_failure_does_not_abort_tick(tmp_path: Path) -> None:
+    """Unwritable routine_path → tick completes normally (graceful degrade)."""
+    from lifeos.autonomous import cron
+
+    # Point to a directory (not writable as a file)
+    bad_rp = tmp_path / "unwritable_dir"
+    bad_rp.mkdir()
+
+    _default_configure(routine_path=bad_rp)
+    # Should NOT raise
+    result = cron.run_tick(_now())
+    assert result.outcome is not None
+
+
+# ---------------------------------------------------------------------------
+# axi-routine-learning: Phase 7 — run_tick reads profile + _build_prompt hint
+# ---------------------------------------------------------------------------
+
+def test_cold_start_prompt_unchanged(tmp_path: Path) -> None:
+    """< 10 records in JSONL → prompt is byte-identical to pre-change format (no 'Patrón' / 'suele')."""
+    from lifeos.autonomous import cron
+
+    rp = tmp_path / "routine.jsonl"
+    # Seed < 10 records
+    import json as _json
+    now_ref = _now(hour=12)
+    now_ts = now_ref.timestamp()
+    with open(rp, "w") as fh:
+        for i in range(5):
+            fh.write(_json.dumps({"ts": now_ts - i * 86400, "weekday": 2, "hour": 12, "presence": "present", "activity_descriptor": "x", "outcome": "pushed"}) + "\n")
+
+    captured_prompts: list[str] = []
+
+    def _spy_brain(prompt: str, **kw: Any) -> str:
+        captured_prompts.append(prompt)
+        return "ESPERAR"
+
+    _default_configure(brain_ask=_spy_brain, routine_path=rp)
+    cron.run_tick(now_ref)
+
+    assert len(captured_prompts) == 1
+    prompt = captured_prompts[0]
+    assert "Patrón" not in prompt
+    assert "suele" not in prompt
+
+
+def test_warm_prompt_contains_hint(tmp_path: Path) -> None:
+    """>=10 records with high presence at current (weekday, hour) → prompt contains hint."""
+    from lifeos.autonomous import cron
+    import json as _json
+
+    rp = tmp_path / "routine.jsonl"
+    now_ref = _now(hour=12)  # Wednesday hour=12, weekday=2 for 2026-06-10
+    now_ts = now_ref.timestamp()
+    now_wd = now_ref.weekday()
+
+    # Seed 15 present records at current (weekday, hour)
+    with open(rp, "w") as fh:
+        for i in range(15):
+            fh.write(_json.dumps({
+                "ts": now_ts - i * 86400,
+                "weekday": now_wd,
+                "hour": 12,
+                "presence": "present",
+                "activity_descriptor": "x",
+                "outcome": "pushed",
+            }) + "\n")
+
+    captured_prompts: list[str] = []
+
+    def _spy_brain(prompt: str, **kw: Any) -> str:
+        captured_prompts.append(prompt)
+        return "ESPERAR"
+
+    _default_configure(brain_ask=_spy_brain, routine_path=rp)
+    cron.run_tick(now_ref)
+
+    assert len(captured_prompts) == 1
+    prompt = captured_prompts[0]
+    assert "Patrón habitual" in prompt
+
+
+def test_corrupt_jsonl_tick_proceeds(tmp_path: Path) -> None:
+    """JSONL with only corrupt lines → tick completes normally, prompt in pre-change format."""
+    from lifeos.autonomous import cron
+
+    rp = tmp_path / "routine.jsonl"
+    rp.write_text("not-json\nalso-not-json\n{broken\n")
+
+    captured_prompts: list[str] = []
+
+    def _spy_brain(prompt: str, **kw: Any) -> str:
+        captured_prompts.append(prompt)
+        return "ESPERAR"
+
+    _default_configure(brain_ask=_spy_brain, routine_path=rp)
+    result = cron.run_tick(_now())
+    assert result.outcome is not None
+    assert len(captured_prompts) == 1
+    prompt = captured_prompts[0]
+    assert "Patrón" not in prompt
+    assert "suele" not in prompt
+
+
+# ---------------------------------------------------------------------------
+# axi-routine-learning: Phase 8 — Privacy integration test
+# ---------------------------------------------------------------------------
+
+def test_privacy_jsonl_never_contains_life_data(tmp_path: Path) -> None:
+    """10 ticks with varied outcomes → every JSONL line has exactly 6 allowed keys, no life-data keys."""
+    from lifeos.autonomous import cron
+
+    rp = tmp_path / "routine.jsonl"
+    BANNED = {"message", "text", "image", "screen", "name", "digest", "body", "content", "data"}
+    ALLOWED = {"ts", "weekday", "hour", "presence", "activity_descriptor", "outcome"}
+
+    setups = [
+        {"brain_ask": lambda *a, **kw: "Tienes cita médica."},  # pushed
+        {"brain_ask": lambda *a, **kw: "ESPERAR"},              # esperar
+        {"brain_ask": lambda *a, **kw: "NADA"},                 # nada
+        {"digest_fn": lambda: "", "correlate_fn": lambda: ""},  # skipped-empty
+        {"alive_fn": lambda: False},                            # skipped-brain-down
+    ]
+    hours = [12, 13, 14, 15, 16, 8, 9, 10, 11, 17]
+
+    for i, (setup, hour) in enumerate(zip(setups * 2, hours)):
+        _default_configure(routine_path=rp, **setup)
+        cron.run_tick(_now(hour=hour))
+
+    lines = rp.read_text().splitlines()
+    assert len(lines) >= 5, f"Expected >= 5 records, got {len(lines)}"
+
+    for line in lines:
+        rec = json.loads(line)
+        assert set(rec.keys()) == ALLOWED, f"Unexpected keys: {set(rec.keys()) - ALLOWED}"
+        assert not BANNED.intersection(rec.keys()), f"Banned keys found: {BANNED.intersection(rec.keys())}"

--- a/lifeos/tests/test_autonomous_routine.py
+++ b/lifeos/tests/test_autonomous_routine.py
@@ -1,0 +1,325 @@
+"""Tests for lifeos.autonomous.routine — the routine-learning module.
+
+Invocation (from repo root): cd /home/hectormr/LifeOS/lifeos/axi && .venv/bin/python -m pytest ../lifeos/tests/test_autonomous_routine.py
+
+Strict TDD: every test was written RED first (stubs raise NotImplementedError),
+then the implementation was added to turn it GREEN.
+
+Privacy invariant: the JSONL written by write_routine_record MUST contain ONLY
+the six scalar fields {ts, weekday, hour, presence, activity_descriptor, outcome}.
+No life-data keys (message, text, image, screen, name, digest, body, content, data)
+may appear in any line.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_NOW_TS = 1_749_600_000.0  # fixed reference timestamp (approx. 2025-06-11 ~12:00 UTC)
+_DAY = 86_400.0
+
+
+def _write_line(path: Path, **fields) -> None:
+    """Helper: append a raw JSONL line to a file (bypasses write_routine_record)."""
+    with open(path, "a") as fh:
+        fh.write(json.dumps(fields) + "\n")
+
+
+def _seed_records(path: Path, records: list[dict]) -> None:
+    """Write multiple raw records to path."""
+    for rec in records:
+        _write_line(path, **rec)
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 — write_routine_record
+# ---------------------------------------------------------------------------
+
+
+def test_write_routine_record_single_append(tmp_path: Path) -> None:
+    """Single call produces exactly 1 line with exact 6-key schema."""
+    from lifeos.autonomous.routine import write_routine_record
+
+    p = tmp_path / "routine.jsonl"
+    write_routine_record(
+        p,
+        ts=1.0,
+        weekday=2,
+        hour=10,
+        presence="present",
+        activity_descriptor="screen+present",
+        outcome="pushed",
+    )
+
+    lines = p.read_text().splitlines()
+    assert len(lines) == 1
+    parsed = json.loads(lines[0])
+    assert set(parsed.keys()) == {"ts", "weekday", "hour", "presence", "activity_descriptor", "outcome"}
+
+
+def test_write_routine_record_privacy(tmp_path: Path) -> None:
+    """Written line contains only the 6 allowed fields — no life-data keys."""
+    from lifeos.autonomous.routine import write_routine_record, _PRIVACY_BANNED_KEYS
+
+    p = tmp_path / "routine.jsonl"
+    write_routine_record(
+        p,
+        ts=1.0,
+        weekday=0,
+        hour=8,
+        presence="unknown",
+        activity_descriptor="no-screen+unknown",
+        outcome="esperar",
+    )
+
+    parsed = json.loads(p.read_text().splitlines()[0])
+    assert set(parsed.keys()) == {"ts", "weekday", "hour", "presence", "activity_descriptor", "outcome"}
+    assert not _PRIVACY_BANNED_KEYS.intersection(parsed.keys()), (
+        f"banned keys found: {_PRIVACY_BANNED_KEYS.intersection(parsed.keys())}"
+    )
+
+
+def test_write_routine_record_n_appends(tmp_path: Path) -> None:
+    """5 sequential calls produce exactly 5 independently parseable lines."""
+    from lifeos.autonomous.routine import write_routine_record
+
+    p = tmp_path / "routine.jsonl"
+    outcomes = ["pushed", "esperar", "nada", "skipped-empty", "skipped-brain-down"]
+    for i, outcome in enumerate(outcomes):
+        write_routine_record(
+            p,
+            ts=float(i),
+            weekday=i % 7,
+            hour=i % 24,
+            presence="present",
+            activity_descriptor="screen+present",
+            outcome=outcome,
+        )
+
+    lines = p.read_text().splitlines()
+    assert len(lines) == 5
+    for line in lines:
+        obj = json.loads(line)
+        assert isinstance(obj, dict)
+
+
+def test_write_routine_record_atomic_20(tmp_path: Path) -> None:
+    """20 sequential calls → every line is a complete parseable JSON object."""
+    from lifeos.autonomous.routine import write_routine_record
+
+    p = tmp_path / "routine.jsonl"
+    for i in range(20):
+        write_routine_record(
+            p,
+            ts=float(i * 100),
+            weekday=i % 7,
+            hour=i % 24,
+            presence="present" if i % 2 == 0 else "unknown",
+            activity_descriptor="screen+present",
+            outcome="esperar",
+        )
+
+    lines = p.read_text().splitlines()
+    assert len(lines) == 20
+    for line in lines:
+        obj = json.loads(line)
+        assert set(obj.keys()) == {"ts", "weekday", "hour", "presence", "activity_descriptor", "outcome"}
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — build_presence_profile
+# ---------------------------------------------------------------------------
+
+
+def test_build_presence_profile_known_rates(tmp_path: Path) -> None:
+    """3 present + 1 away in bucket (1,9) → result[(1,9)] == (3, 4), no other key."""
+    from lifeos.autonomous.routine import build_presence_profile
+
+    p = tmp_path / "routine.jsonl"
+    now_ts = _NOW_TS
+    ts_recent = now_ts - 5 * _DAY  # 5 days ago — within 30d window
+    records = [
+        {"ts": ts_recent, "weekday": 1, "hour": 9, "presence": "present", "activity_descriptor": "x", "outcome": "pushed"},
+        {"ts": ts_recent, "weekday": 1, "hour": 9, "presence": "present", "activity_descriptor": "x", "outcome": "pushed"},
+        {"ts": ts_recent, "weekday": 1, "hour": 9, "presence": "present", "activity_descriptor": "x", "outcome": "pushed"},
+        {"ts": ts_recent, "weekday": 1, "hour": 9, "presence": "away",    "activity_descriptor": "x", "outcome": "esperar"},
+    ]
+    _seed_records(p, records)
+
+    result = build_presence_profile(p, days=30, now_ts=now_ts)
+    assert result == {(1, 9): (3, 4)}
+
+
+def test_build_presence_profile_window_exclusion(tmp_path: Path) -> None:
+    """Record 35d ago is excluded; record 5d ago is kept."""
+    from lifeos.autonomous.routine import build_presence_profile
+
+    p = tmp_path / "routine.jsonl"
+    now_ts = _NOW_TS
+    _seed_records(p, [
+        {"ts": now_ts - 35 * _DAY, "weekday": 3, "hour": 14, "presence": "present", "activity_descriptor": "x", "outcome": "pushed"},
+        {"ts": now_ts - 5 * _DAY,  "weekday": 3, "hour": 14, "presence": "present", "activity_descriptor": "x", "outcome": "pushed"},
+    ])
+
+    result = build_presence_profile(p, days=30, now_ts=now_ts)
+    assert result == {(3, 14): (1, 1)}
+
+
+def test_build_presence_profile_missing_file(tmp_path: Path) -> None:
+    """Non-existent path returns {} without exception."""
+    from lifeos.autonomous.routine import build_presence_profile
+
+    result = build_presence_profile(tmp_path / "does_not_exist.jsonl", days=30, now_ts=_NOW_TS)
+    assert result == {}
+
+
+def test_build_presence_profile_corrupt_line(tmp_path: Path) -> None:
+    """Bad line is skipped; valid in-window line contributes normally."""
+    from lifeos.autonomous.routine import build_presence_profile
+
+    p = tmp_path / "routine.jsonl"
+    now_ts = _NOW_TS
+    # One corrupt line, then one valid record
+    p.write_text(
+        "not-valid-json\n"
+        + json.dumps({"ts": now_ts - 5 * _DAY, "weekday": 0, "hour": 10, "presence": "present", "activity_descriptor": "x", "outcome": "pushed"})
+        + "\n"
+    )
+
+    result = build_presence_profile(p, days=30, now_ts=now_ts)
+    assert result == {(0, 10): (1, 1)}
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — format_routine_hint
+# ---------------------------------------------------------------------------
+
+
+def _make_profile(
+    records: list[tuple[int, int, str]],  # (weekday, hour, presence)
+) -> dict[tuple[int, int], tuple[int, int]]:
+    """Build a profile dict from a flat list of (weekday, hour, presence) tuples."""
+    from collections import defaultdict
+    counts: dict[tuple[int, int], list[int, int]] = defaultdict(lambda: [0, 0])
+    for wd, h, pres in records:
+        counts[(wd, h)][1] += 1
+        if pres == "present":
+            counts[(wd, h)][0] += 1
+    return {k: tuple(v) for k, v in counts.items()}
+
+
+def test_format_routine_hint_cold_start_none() -> None:
+    """< 10 total records → None regardless of local rate."""
+    from lifeos.autonomous.routine import format_routine_hint
+
+    # 8 records total, current bucket (2,10) has high local rate
+    records = [(2, 10, "present")] * 6 + [(2, 10, "away")] * 2  # 8 total
+    profile = _make_profile(records)
+    result = format_routine_hint(profile, now_weekday=2, now_hour=10)
+    assert result is None
+
+
+def test_format_routine_hint_absent_bucket_none() -> None:
+    """Bucket (5,3) absent from profile → None."""
+    from lifeos.autonomous.routine import format_routine_hint
+
+    # 15 records but none in (5,3) — and no neighbors close enough to smooth
+    records = [(2, 10, "present")] * 15
+    profile = _make_profile(records)
+    result = format_routine_hint(profile, now_weekday=5, now_hour=3)
+    assert result is None
+
+
+def test_format_routine_hint_high_presence_hint() -> None:
+    """High-presence bucket (rate >= 0.65, >= 4 local samples) returns Spanish hint."""
+    from lifeos.autonomous.routine import format_routine_hint
+
+    # 20 total records: 18 present at (2,10), 2 away — ensures global >= 10 and local rate high
+    records = [(2, 10, "present")] * 18 + [(2, 10, "away")] * 2
+    profile = _make_profile(records)
+    result = format_routine_hint(profile, now_weekday=2, now_hour=10)
+    assert result is not None
+    assert "suele estar presente" in result
+    # Should contain a percentage figure
+    assert "%" in result
+
+
+def test_format_routine_hint_low_presence() -> None:
+    """Low-presence bucket (rate <= 0.25) returns None or low-phrasing string."""
+    from lifeos.autonomous.routine import format_routine_hint
+
+    # 20 total, only 2 present at (0,22)
+    records = [(0, 22, "present")] * 2 + [(0, 22, "away")] * 18
+    profile = _make_profile(records)
+    result = format_routine_hint(profile, now_weekday=0, now_hour=22)
+    # Acceptable: None OR a string with "rara vez"
+    assert result is None or "rara vez" in result
+
+
+def test_format_routine_hint_ambiguous_mid_band() -> None:
+    """Rate in 0.25 < rate < 0.65 → None (no noisy hint)."""
+    from lifeos.autonomous.routine import format_routine_hint
+
+    # 20 total, 9 present at (1,14) → rate = 0.45
+    records = [(1, 14, "present")] * 9 + [(1, 14, "away")] * 11
+    profile = _make_profile(records)
+    result = format_routine_hint(profile, now_weekday=1, now_hour=14)
+    assert result is None
+
+
+def test_format_routine_hint_smoothing() -> None:
+    """±1h smoothing: current bucket empty but neighbors have high rate → hint returned."""
+    from lifeos.autonomous.routine import format_routine_hint
+
+    # Bucket (2,10) itself: 0 samples
+    # Neighbor (2,9): 5 present, 0 away
+    # Neighbor (2,11): 5 present, 0 away
+    # Total smoothed: 10 present / 10 total = 1.0 → high rate
+    # Plus we need >= 10 global records total
+    records = (
+        [(2, 9, "present")] * 5
+        + [(2, 11, "present")] * 5
+        + [(3, 15, "away")] * 5  # filler for global total
+    )
+    profile = _make_profile(records)
+    result = format_routine_hint(profile, now_weekday=2, now_hour=10)
+    assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 — trim_routine_records
+# ---------------------------------------------------------------------------
+
+
+def test_trim_routine_records_drops_old(tmp_path: Path) -> None:
+    """100d + 60d + 10d records; days=90 → 2 kept (60d and 10d)."""
+    from lifeos.autonomous.routine import trim_routine_records
+
+    p = tmp_path / "routine.jsonl"
+    now_ts = _NOW_TS
+    _seed_records(p, [
+        {"ts": now_ts - 100 * _DAY, "weekday": 0, "hour": 9, "presence": "present", "activity_descriptor": "x", "outcome": "pushed"},
+        {"ts": now_ts - 60 * _DAY,  "weekday": 1, "hour": 10, "presence": "away",    "activity_descriptor": "x", "outcome": "esperar"},
+        {"ts": now_ts - 10 * _DAY,  "weekday": 2, "hour": 11, "presence": "present", "activity_descriptor": "x", "outcome": "nada"},
+    ])
+
+    kept = trim_routine_records(p, days=90, now_ts=now_ts)
+    assert kept == 2
+    lines = p.read_text().splitlines()
+    assert len(lines) == 2
+
+
+def test_trim_routine_records_missing_file_noop(tmp_path: Path) -> None:
+    """Non-existent path → no exception, returns 0."""
+    from lifeos.autonomous.routine import trim_routine_records
+
+    kept = trim_routine_records(tmp_path / "no_file.jsonl", days=90, now_ts=_NOW_TS)
+    assert kept == 0

--- a/lifeos/tests/test_autonomous_routine.py
+++ b/lifeos/tests/test_autonomous_routine.py
@@ -323,3 +323,142 @@ def test_trim_routine_records_missing_file_noop(tmp_path: Path) -> None:
 
     kept = trim_routine_records(tmp_path / "no_file.jsonl", days=90, now_ts=_NOW_TS)
     assert kept == 0
+
+
+# ---------------------------------------------------------------------------
+# Fix 1 — activity_descriptor allowlist sanitization at write boundary
+# ---------------------------------------------------------------------------
+
+_COARSE_ALLOWED = {
+    "screen+present",
+    "screen+unknown",
+    "screen+away",
+    "no-screen+unknown",
+    "no-screen+present",
+    "no-screen+away",
+}
+
+
+def test_write_routine_record_pii_descriptor_replaced_with_other(tmp_path: Path) -> None:
+    """Free-text activity_descriptor is replaced with 'other'; PII string absent from JSONL."""
+    from lifeos.autonomous.routine import write_routine_record
+
+    pii_value = "coding on HealthRecords.py weight 82kg"
+    p = tmp_path / "routine.jsonl"
+    write_routine_record(
+        p,
+        ts=1.0,
+        weekday=2,
+        hour=10,
+        presence="present",
+        activity_descriptor=pii_value,
+        outcome="pushed",
+    )
+
+    raw = p.read_text()
+    assert pii_value not in raw, "PII string must NOT appear in the JSONL"
+    rec = json.loads(raw.splitlines()[0])
+    assert rec["activity_descriptor"] == "other", (
+        f"Expected 'other', got {rec['activity_descriptor']!r}"
+    )
+
+
+def test_write_routine_record_coarse_tokens_pass_through_unchanged(tmp_path: Path) -> None:
+    """All known coarse tokens pass through write_routine_record unchanged."""
+    from lifeos.autonomous.routine import write_routine_record
+
+    p = tmp_path / "routine.jsonl"
+    for token in sorted(_COARSE_ALLOWED):
+        write_routine_record(
+            p,
+            ts=1.0,
+            weekday=0,
+            hour=8,
+            presence="unknown",
+            activity_descriptor=token,
+            outcome="esperar",
+        )
+
+    lines = p.read_text().splitlines()
+    assert len(lines) == len(_COARSE_ALLOWED)
+    written_tokens = {json.loads(line)["activity_descriptor"] for line in lines}
+    assert written_tokens == _COARSE_ALLOWED, (
+        f"Expected {_COARSE_ALLOWED}, got {written_tokens}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fix 2 — cold-start prompt byte-identity
+# ---------------------------------------------------------------------------
+
+
+def test_cold_start_prompt_byte_identity() -> None:
+    """_build_prompt with routine_hint=None is BYTE-FOR-BYTE identical to call without the param."""
+    from datetime import datetime
+    from zoneinfo import ZoneInfo
+    from lifeos.autonomous.cron import _build_prompt, _NO_PERCEPTION
+
+    MX = ZoneInfo("America/Mexico_City")
+    now = datetime(2026, 6, 10, 12, 0, tzinfo=MX)
+    digest = "Héctor corrió 5 km hoy."
+    edge = "Sin correlaciones."
+
+    prompt_explicit_none = _build_prompt(now, digest, edge, _NO_PERCEPTION, routine_hint=None)
+    prompt_no_kwarg = _build_prompt(now, digest, edge, _NO_PERCEPTION)
+    assert prompt_explicit_none == prompt_no_kwarg, (
+        "Prompt with routine_hint=None must be byte-identical to call without routine_hint"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fix 3 — trim must DROP corrupt lines, not keep them
+# ---------------------------------------------------------------------------
+
+
+def test_trim_drops_corrupt_lines(tmp_path: Path) -> None:
+    """Corrupt line + recent valid lines → after trim, corrupt line gone, valid lines kept."""
+    from lifeos.autonomous.routine import trim_routine_records
+
+    p = tmp_path / "routine.jsonl"
+    now_ts = _NOW_TS
+    recent_ts = now_ts - 5 * _DAY
+    corrupt_line = "this-is-not-json\n"
+    valid_rec = {"ts": recent_ts, "weekday": 1, "hour": 9, "presence": "present", "activity_descriptor": "screen+present", "outcome": "pushed"}
+    p.write_text(corrupt_line + json.dumps(valid_rec) + "\n")
+
+    kept = trim_routine_records(p, days=90, now_ts=now_ts)
+    remaining = p.read_text().splitlines()
+
+    assert "this-is-not-json" not in p.read_text(), "Corrupt line must be dropped"
+    # The 1 valid line is kept
+    assert len(remaining) == 1
+    assert json.loads(remaining[0])["ts"] == recent_ts
+    assert kept == 1
+
+
+# ---------------------------------------------------------------------------
+# Fix 4 — trim must not leave orphaned .tmp on os.replace failure
+# ---------------------------------------------------------------------------
+
+
+def test_trim_cleans_tmp_file_on_replace_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """If os.replace raises, no .tmp file is left in the directory."""
+    import os as _os
+    from lifeos.autonomous.routine import trim_routine_records
+
+    p = tmp_path / "routine.jsonl"
+    now_ts = _NOW_TS
+    _write_line(p, ts=now_ts - 5 * _DAY, weekday=0, hour=8, presence="present",
+                activity_descriptor="screen+present", outcome="pushed")
+
+    def _failing_replace(src, dst):
+        raise OSError("simulated replace failure")
+
+    monkeypatch.setattr(_os, "replace", _failing_replace)
+    # Must not raise
+    kept = trim_routine_records(p, days=90, now_ts=now_ts)
+    assert kept == 0  # returns 0 on failure
+
+    # No .tmp files left in tmp_path
+    tmp_files = list(tmp_path.glob("*.tmp"))
+    assert tmp_files == [], f"Orphaned .tmp files found: {tmp_files}"


### PR DESCRIPTION
## Routine learning (idea #5, next slice)

Axi learns Héctor's **presence-by-(weekday,hour)** rhythm from durable, privacy-safe records of each autonomous tick, and injects a learned "Patrón habitual" hint into the brain's "is now the moment?" decision — so over time it gets more attuned to when he's actually around.

### How
- New `lifeos/autonomous/routine.py` (pure): append one privacy-safe JSON line per tick → aggregate a presence-rate profile → format a Spanish hint.
- `cron.py`: records every tick outcome; reads the profile + injects the hint once per tick; trims >90d once/day.
- Store: `~/.local/state/lifeos/autonomous_routine.jsonl`.

### Invariants
- **Privacy**: only 6 coarse fields (ts, weekday, hour, presence, activity_descriptor, outcome) — `activity_descriptor` is **allowlisted** (free text → "other"), so no life-data, message text, images or names can ever land in the file.
- **Cold-start**: hint suppressed until ≥10 records (~7-14 days); the brain prompt is **byte-identical** to today until then (no behavior change).
- **Graceful**: corrupt/missing JSONL → no hint, tick runs unchanged.
- v1 learns from PRESENCE + time only (engagement/click feedback is a future slice).

### Quality
- lifeos 764 + axi 568/6 skipped, 0 regressions.
- Dual review (verify + adversarial). Adversarial pass caught + fixed a latent privacy hole (unsanitized activity label), a hollow cold-start test, and two trim durability bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)