### PR TITLE
fix(whisper): no-VAD retry when VAD strips a whole dictation

### DIFF
--- a/axi/src/axi/whisper_server.py
+++ b/axi/src/axi/whisper_server.py
@@ -149,6 +149,7 @@ def _dispatch_transcription(
     model: WhisperModel,
     pipeline: BatchedInferencePipeline,
     long_audio_samples: int = LONG_AUDIO_SAMPLES,
+    vad: bool = True,
 ):
     """Route transcription to the appropriate backend based on audio length.
 
@@ -162,7 +163,7 @@ def _dispatch_transcription(
         language = params.get("language")
         kwargs: dict = dict(
             batch_size=8,
-            vad_filter=True,
+            vad_filter=vad,
             beam_size=3,
             condition_on_previous_text=True,
         )
@@ -208,6 +209,15 @@ def _handle(conn: socket.socket, model: WhisperModel, pipeline: BatchedInference
                     frac = _progress_fraction(seg.end, info.duration)
                     _write_progress(frac, " ".join(parts)[-200:])
                 text = " ".join(parts).strip()
+                # VAD can over-aggressively strip an entire long dictation (quiet
+                # or fast speech) and leave empty text. Recover by retrying the
+                # same audio once WITHOUT VAD before giving up.
+                if not text:
+                    log.info("long-audio VAD removed all speech; retrying without VAD")
+                    segments, info = _dispatch_transcription(
+                        audio, params, model=model, pipeline=pipeline, vad=False
+                    )
+                    text = " ".join(s.text.strip() for s in segments).strip()
             else:
                 # Short path — eager join, no progress file written.
                 text = " ".join(s.text.strip() for s in segments).strip()

--- a/axi/tests/test_whisper_dispatch.py
+++ b/axi/tests/test_whisper_dispatch.py
@@ -183,6 +183,23 @@ def test_dispatch_at_threshold_uses_pipeline():
     assert len(model.calls) == 0
 
 
+def test_dispatch_long_respects_vad_flag():
+    """The long (batched) path passes vad_filter=vad. Default True; vad=False is
+    the no-VAD retry the server uses to recover when VAD strips a whole
+    dictation (faster_whisper VAD can remove 100% of quiet/fast speech)."""
+    from axi.whisper_server import _dispatch_transcription
+
+    audio = _long_audio()
+
+    p_on = _RecordingPipeline()
+    _dispatch_transcription(audio, {"language": "es"}, model=_RecordingModel(), pipeline=p_on)
+    assert p_on.calls[0]["vad_filter"] is True  # default keeps VAD (meetings)
+
+    p_off = _RecordingPipeline()
+    _dispatch_transcription(audio, {"language": "es"}, model=_RecordingModel(), pipeline=p_off, vad=False)
+    assert p_off.calls[0]["vad_filter"] is False  # fallback disables VAD
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Phase 2.1.4 — both paths return identical (segments, info) shape
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Long audio went through the batched pipeline with vad_filter=True; faster_whisper VAD removed 100% of a long dictation → 0 chars. Now retries once without VAD when the result is empty. Meetings keep VAD.