### PR TITLE
feat(web): private web-research port + SearXNG/fetch adapters (axi-web-research PR 1)

### DIFF
--- a/lifeos/pyproject.toml
+++ b/lifeos/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "cryptography>=42",
     "sqlcipher3-wheels>=0.5",
     "freezegun>=1.5.5",
+    "trafilatura>=1.12",
 ]
 
 [project.optional-dependencies]

--- a/lifeos/src/lifeos/web/__init__.py
+++ b/lifeos/src/lifeos/web/__init__.py
@@ -1,0 +1,71 @@
+"""lifeos.web — DI module for web research.
+
+Provides injectable callables (search_fn, read_fn, enabled_fn) and a
+configure() setter that mirrors the pattern in lifeos.autonomous.cron.
+
+The SEARXNG_URL env seam mirrors LIFEOS_STATE_DIR: read once at configure()
+time (or lazily on first use), with a localhost default.
+
+Usage (from axi dashboard lifespan):
+
+    from lifeos.web.searxng import SearXNGAdapter
+    import lifeos.web.fetch as web_fetch
+    import lifeos.web as web_research
+
+    _searxng = SearXNGAdapter(base_url=config.get("searxng_url", SEARXNG_URL))
+    web_research.configure(
+        search_fn=_searxng.search,
+        read_fn=web_fetch.read,
+        enabled_fn=lambda: bool(config.get("web_research_enabled", True)),
+    )
+"""
+from __future__ import annotations
+
+import os
+from typing import Callable
+
+from lifeos.web.port import PageText, SearchResult
+
+# ---------------------------------------------------------------------------
+# Env seam
+# ---------------------------------------------------------------------------
+
+SEARXNG_URL: str = os.environ.get("SEARXNG_URL", "http://127.0.0.1:8888")
+
+# ---------------------------------------------------------------------------
+# Module-level injected callables
+# ---------------------------------------------------------------------------
+
+_search_fn: Callable[[str], list[SearchResult]] | None = None
+_read_fn: Callable[[str], PageText] | None = None
+_enabled_fn: Callable[[], bool] | None = None
+
+
+def configure(
+    *,
+    search_fn: Callable[[str], list[SearchResult]],
+    read_fn: Callable[[str], PageText],
+    enabled_fn: Callable[[], bool] | None = None,
+) -> None:
+    """Inject web-research callables. Calling configure() resets state."""
+    global _search_fn, _read_fn, _enabled_fn
+    _search_fn = search_fn
+    _read_fn = read_fn
+    _enabled_fn = enabled_fn
+
+
+def get_search_fn() -> Callable[[str], list[SearchResult]] | None:
+    """Return the currently injected search callable, or None if unconfigured."""
+    return _search_fn
+
+
+def get_read_fn() -> Callable[[str], PageText] | None:
+    """Return the currently injected read callable, or None if unconfigured."""
+    return _read_fn
+
+
+def is_enabled() -> bool:
+    """Return True when web research is enabled and configured."""
+    if _enabled_fn is not None:
+        return bool(_enabled_fn())
+    return _search_fn is not None

--- a/lifeos/src/lifeos/web/fetch.py
+++ b/lifeos/src/lifeos/web/fetch.py
@@ -49,11 +49,9 @@ def read(
         log.warning("fetch unexpected error for %s: %s", url, exc)
         return PageText(url=url, text="", ok=False)
 
-    # Decode best-effort; trafilatura handles encoding detection from the HTML.
-    try:
-        html = raw.decode("utf-8", errors="replace")
-    except Exception:  # noqa: BLE001
-        html = raw.decode("latin-1", errors="replace")
+    # Decode best-effort; errors="replace" never raises, so no try/except needed.
+    # trafilatura handles encoding detection from the HTML internally.
+    html = raw.decode("utf-8", errors="replace")
 
     extracted = trafilatura.extract(html)
     if not extracted:

--- a/lifeos/src/lifeos/web/fetch.py
+++ b/lifeos/src/lifeos/web/fetch.py
@@ -1,0 +1,63 @@
+"""Page fetch adapter for lifeos.web.
+
+Fetches a URL with stdlib urllib, reads at most max_bytes, runs
+trafilatura.extract() for clean plain text, and truncates to MAX_PAGE_CHARS.
+
+All failures return PageText(url, "", ok=False). Never raises.
+"""
+from __future__ import annotations
+
+import logging
+import urllib.error
+import urllib.request
+from typing import Callable
+
+import trafilatura
+
+from lifeos.web.port import FETCH_TIMEOUT, MAX_PAGE_BYTES, MAX_PAGE_CHARS, PageText
+
+log = logging.getLogger("lifeos.web.fetch")
+
+
+def read(
+    url: str,
+    *,
+    urlopen: Callable = urllib.request.urlopen,
+    timeout: float = FETCH_TIMEOUT,
+    max_bytes: int = MAX_PAGE_BYTES,
+) -> PageText:
+    """Fetch ``url`` and return extracted plain text as a PageText.
+
+    Args:
+        url:       Target URL.
+        urlopen:   Injectable HTTP callable (default: urllib.request.urlopen).
+        timeout:   Request timeout in seconds.
+        max_bytes: Maximum raw bytes to read from the response body.
+
+    Returns:
+        PageText(url, text, ok=True)  on success with non-empty extraction.
+        PageText(url, "", ok=False)   on any fetch/extraction failure.
+    """
+    try:
+        req = urllib.request.Request(url)
+        with urlopen(req, timeout=timeout) as resp:
+            raw = resp.read(max_bytes)
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        log.debug("fetch failed for %s: %s", url, exc)
+        return PageText(url=url, text="", ok=False)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("fetch unexpected error for %s: %s", url, exc)
+        return PageText(url=url, text="", ok=False)
+
+    # Decode best-effort; trafilatura handles encoding detection from the HTML.
+    try:
+        html = raw.decode("utf-8", errors="replace")
+    except Exception:  # noqa: BLE001
+        html = raw.decode("latin-1", errors="replace")
+
+    extracted = trafilatura.extract(html)
+    if not extracted:
+        return PageText(url=url, text="", ok=False)
+
+    text = extracted[:MAX_PAGE_CHARS]
+    return PageText(url=url, text=text, ok=True)

--- a/lifeos/src/lifeos/web/port.py
+++ b/lifeos/src/lifeos/web/port.py
@@ -13,12 +13,13 @@ from typing import Callable, Protocol
 # Budgeting constants
 # ---------------------------------------------------------------------------
 
-TOP_N: int = 3                  # max search results to request / process
-MAX_SNIPPET_CHARS: int = 300    # max chars per snippet in the brain prompt
-MAX_PAGE_CHARS: int = 3000      # max chars of extracted page text in the prompt
-MAX_PAGE_BYTES: int = 2_000_000 # max raw bytes to read from a fetched page
-SEARCH_TIMEOUT: float = 5.0     # SearXNG HTTP request timeout (seconds)
-FETCH_TIMEOUT: float = 8.0      # page fetch HTTP request timeout (seconds)
+TOP_N: int = 3                     # max search results to request / process
+MAX_SNIPPET_CHARS: int = 300       # max chars per snippet in the brain prompt
+MAX_PAGE_CHARS: int = 3000         # max chars of extracted page text in the prompt
+MAX_PAGE_BYTES: int = 2_000_000    # max raw bytes to read from a fetched page
+MAX_SEARCH_BYTES: int = 1_000_000  # max raw bytes to read from a SearXNG response
+SEARCH_TIMEOUT: float = 5.0        # SearXNG HTTP request timeout (seconds)
+FETCH_TIMEOUT: float = 8.0         # page fetch HTTP request timeout (seconds)
 
 # ---------------------------------------------------------------------------
 # Value objects

--- a/lifeos/src/lifeos/web/port.py
+++ b/lifeos/src/lifeos/web/port.py
@@ -1,0 +1,71 @@
+"""Web research port — pure types, Protocol, and budgeting constants.
+
+Zero network dependencies. This module is the hexagonal boundary for
+all web-research capabilities; adapters (searxng.py, fetch.py) implement
+the Protocol via injectable callables rather than inheritance.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Protocol
+
+# ---------------------------------------------------------------------------
+# Budgeting constants
+# ---------------------------------------------------------------------------
+
+TOP_N: int = 3                  # max search results to request / process
+MAX_SNIPPET_CHARS: int = 300    # max chars per snippet in the brain prompt
+MAX_PAGE_CHARS: int = 3000      # max chars of extracted page text in the prompt
+MAX_PAGE_BYTES: int = 2_000_000 # max raw bytes to read from a fetched page
+SEARCH_TIMEOUT: float = 5.0     # SearXNG HTTP request timeout (seconds)
+FETCH_TIMEOUT: float = 8.0      # page fetch HTTP request timeout (seconds)
+
+# ---------------------------------------------------------------------------
+# Value objects
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class SearchResult:
+    """A single result from a SearXNG search response."""
+    title: str
+    url: str
+    snippet: str    # sourced from results[].content in the SearXNG JSON
+
+
+@dataclass(frozen=True, slots=True)
+class PageText:
+    """Result of fetching and extracting text from a URL."""
+    url: str
+    text: str       # extracted plain text, truncated to MAX_PAGE_CHARS
+    ok: bool        # False when fetch or extraction failed
+
+
+# ---------------------------------------------------------------------------
+# Port Protocol
+# ---------------------------------------------------------------------------
+
+
+class WebResearchPort(Protocol):
+    """Hexagonal port for web research.
+
+    Concrete adapters (SearXNGAdapter, fetch.read) satisfy this Protocol
+    structurally — no inheritance needed. The dashboard injects callables
+    via web_research.configure().
+    """
+
+    def search(self, query: str, *, limit: int = TOP_N) -> list[SearchResult]:
+        """Return up to `limit` results for `query`, or [] on any failure."""
+        ...
+
+    def read(self, url: str) -> PageText:
+        """Fetch `url` and return extracted plain text. Never raises."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Callable type aliases (for DI module type hints)
+# ---------------------------------------------------------------------------
+
+SearchFn = Callable[[str], list[SearchResult]]  # (query) -> results
+ReadFn = Callable[[str], PageText]              # (url) -> page

--- a/lifeos/src/lifeos/web/searxng.py
+++ b/lifeos/src/lifeos/web/searxng.py
@@ -12,7 +12,7 @@ import urllib.parse
 import urllib.request
 from typing import Callable
 
-from lifeos.web.port import MAX_SNIPPET_CHARS, SEARCH_TIMEOUT, TOP_N, SearchResult
+from lifeos.web.port import MAX_SEARCH_BYTES, MAX_SNIPPET_CHARS, SEARCH_TIMEOUT, TOP_N, SearchResult
 
 log = logging.getLogger("lifeos.web.searxng")
 
@@ -51,24 +51,27 @@ class SearXNGAdapter:
         req = urllib.request.Request(url)
         try:
             with self._urlopen(req, timeout=self._timeout) as resp:
-                raw = resp.read()
+                raw = resp.read(MAX_SEARCH_BYTES)
             data = json.loads(raw)
+            if not isinstance(data, dict):
+                return []
+            raw_results = data.get("results", [])
+            out: list[SearchResult] = []
+            for item in raw_results[:limit]:
+                if not isinstance(item, dict):
+                    continue
+                snippet = (item.get("content") or "")[:MAX_SNIPPET_CHARS]
+                out.append(
+                    SearchResult(
+                        title=item.get("title") or "",
+                        url=item.get("url") or "",
+                        snippet=snippet,
+                    )
+                )
+            return out
         except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, OSError) as exc:
             log.debug("SearXNG search failed: %s", exc)
             return []
         except Exception as exc:  # noqa: BLE001
             log.warning("SearXNG search unexpected error: %s", exc)
             return []
-
-        raw_results = data.get("results", [])
-        out: list[SearchResult] = []
-        for item in raw_results[:limit]:
-            snippet = (item.get("content") or "")[:MAX_SNIPPET_CHARS]
-            out.append(
-                SearchResult(
-                    title=item.get("title") or "",
-                    url=item.get("url") or "",
-                    snippet=snippet,
-                )
-            )
-        return out

--- a/lifeos/src/lifeos/web/searxng.py
+++ b/lifeos/src/lifeos/web/searxng.py
@@ -1,0 +1,74 @@
+"""SearXNG search adapter for lifeos.web.
+
+Implements the WebResearchPort.search interface over a local SearXNG
+instance using stdlib urllib only (zero new transport dependencies).
+"""
+from __future__ import annotations
+
+import json
+import logging
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Callable
+
+from lifeos.web.port import MAX_SNIPPET_CHARS, SEARCH_TIMEOUT, TOP_N, SearchResult
+
+log = logging.getLogger("lifeos.web.searxng")
+
+
+class SearXNGAdapter:
+    """HTTP adapter for the local SearXNG JSON search API.
+
+    Args:
+        base_url: Base URL of the SearXNG instance, e.g. ``http://127.0.0.1:8888``.
+        urlopen:  Injectable HTTP callable (default: urllib.request.urlopen).
+                  Accepts a ``urllib.request.Request`` and a ``timeout`` keyword arg.
+        timeout:  Request timeout in seconds (default: SEARCH_TIMEOUT from port).
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        urlopen: Callable = urllib.request.urlopen,
+        timeout: float = SEARCH_TIMEOUT,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._urlopen = urlopen
+        self._timeout = timeout
+
+    def search(self, query: str, *, limit: int = TOP_N) -> list[SearchResult]:
+        """Return up to ``limit`` SearchResult entries for ``query``.
+
+        Returns an empty list on any error (URLError, timeout, bad JSON).
+        Never raises.
+        """
+        url = (
+            f"{self._base_url}/search"
+            f"?format=json&q={urllib.parse.quote(query, safe='')}"
+        )
+        req = urllib.request.Request(url)
+        try:
+            with self._urlopen(req, timeout=self._timeout) as resp:
+                raw = resp.read()
+            data = json.loads(raw)
+        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, OSError) as exc:
+            log.debug("SearXNG search failed: %s", exc)
+            return []
+        except Exception as exc:  # noqa: BLE001
+            log.warning("SearXNG search unexpected error: %s", exc)
+            return []
+
+        raw_results = data.get("results", [])
+        out: list[SearchResult] = []
+        for item in raw_results[:limit]:
+            snippet = (item.get("content") or "")[:MAX_SNIPPET_CHARS]
+            out.append(
+                SearchResult(
+                    title=item.get("title") or "",
+                    url=item.get("url") or "",
+                    snippet=snippet,
+                )
+            )
+        return out

--- a/lifeos/tests/test_web_config.py
+++ b/lifeos/tests/test_web_config.py
@@ -5,7 +5,10 @@ TDD Phase 4.1 RED: asserts the DI/configure surface of the web __init__.py.
 from __future__ import annotations
 
 import importlib
-import os
+
+import pytest
+
+from lifeos.web.port import PageText
 
 
 def _reload_web():
@@ -15,15 +18,33 @@ def _reload_web():
     return mod
 
 
+@pytest.fixture(autouse=True)
+def _reset_web_globals():
+    """Reset lifeos.web module globals before and after every test.
+
+    Prevents state leakage between tests that call configure() or
+    those that rely on the default (unconfigured) module state.
+    """
+    import lifeos.web as web_mod
+    # Reset to pristine state before the test
+    web_mod._search_fn = None
+    web_mod._read_fn = None
+    web_mod._enabled_fn = None
+    yield
+    # Reset again after the test so the next test starts clean
+    web_mod._search_fn = None
+    web_mod._read_fn = None
+    web_mod._enabled_fn = None
+
+
 def test_configure_sets_injected_fns():
     """After configure(), _search_fn and _read_fn are the injected callables."""
     import lifeos.web as web_mod
 
-    def fake_search(query):  # noqa: ARG001
+    def fake_search(query: str) -> list:  # noqa: ARG001
         return []
 
-    def fake_read(url):  # noqa: ARG001
-        from lifeos.web.port import PageText
+    def fake_read(url: str) -> PageText:  # noqa: ARG001
         return PageText(url=url, text="", ok=False)
 
     web_mod.configure(search_fn=fake_search, read_fn=fake_read)
@@ -38,12 +59,18 @@ def test_configure_sets_enabled_fn():
 
     flag = [True]
 
-    def fake_enabled():
+    def fake_enabled() -> bool:
         return flag[0]
 
+    def fake_search(query: str) -> list:  # noqa: ARG001
+        return []
+
+    def fake_read(url: str) -> PageText:  # noqa: ARG001
+        return PageText(url=url, text="", ok=False)
+
     web_mod.configure(
-        search_fn=lambda q: [],
-        read_fn=lambda u: None,  # type: ignore[arg-type]
+        search_fn=fake_search,
+        read_fn=fake_read,
         enabled_fn=fake_enabled,
     )
 

--- a/lifeos/tests/test_web_config.py
+++ b/lifeos/tests/test_web_config.py
@@ -1,0 +1,67 @@
+"""Tests for lifeos.web DI module — configure() and SEARXNG_URL env seam.
+
+TDD Phase 4.1 RED: asserts the DI/configure surface of the web __init__.py.
+"""
+from __future__ import annotations
+
+import importlib
+import os
+
+
+def _reload_web():
+    """Reload lifeos.web to pick up env changes made in tests."""
+    import lifeos.web as mod
+    importlib.reload(mod)
+    return mod
+
+
+def test_configure_sets_injected_fns():
+    """After configure(), _search_fn and _read_fn are the injected callables."""
+    import lifeos.web as web_mod
+
+    def fake_search(query):  # noqa: ARG001
+        return []
+
+    def fake_read(url):  # noqa: ARG001
+        from lifeos.web.port import PageText
+        return PageText(url=url, text="", ok=False)
+
+    web_mod.configure(search_fn=fake_search, read_fn=fake_read)
+
+    assert web_mod._search_fn is fake_search
+    assert web_mod._read_fn is fake_read
+
+
+def test_configure_sets_enabled_fn():
+    """enabled_fn is stored and callable after configure()."""
+    import lifeos.web as web_mod
+
+    flag = [True]
+
+    def fake_enabled():
+        return flag[0]
+
+    web_mod.configure(
+        search_fn=lambda q: [],
+        read_fn=lambda u: None,  # type: ignore[arg-type]
+        enabled_fn=fake_enabled,
+    )
+
+    assert web_mod._enabled_fn is fake_enabled
+    assert web_mod.is_enabled() is True
+    flag[0] = False
+    assert web_mod.is_enabled() is False
+
+
+def test_searxng_url_env_default(monkeypatch):
+    """SEARXNG_URL defaults to http://127.0.0.1:8888 when env var is absent."""
+    monkeypatch.delenv("SEARXNG_URL", raising=False)
+    mod = _reload_web()
+    assert mod.SEARXNG_URL == "http://127.0.0.1:8888"
+
+
+def test_searxng_url_env_override(monkeypatch):
+    """SEARXNG_URL is read from the environment when set."""
+    monkeypatch.setenv("SEARXNG_URL", "http://192.168.1.10:9999")
+    mod = _reload_web()
+    assert mod.SEARXNG_URL == "http://192.168.1.10:9999"

--- a/lifeos/tests/test_web_fetch.py
+++ b/lifeos/tests/test_web_fetch.py
@@ -1,0 +1,119 @@
+"""Tests for lifeos.web.fetch — read().
+
+Uses an injected fake urlopen and monkeypatched trafilatura.extract.
+Zero network calls.
+"""
+from __future__ import annotations
+
+import urllib.error
+
+import pytest
+
+from lifeos.web.port import MAX_PAGE_BYTES, MAX_PAGE_CHARS
+
+
+# ---------------------------------------------------------------------------
+# Fake HTTP transport
+# ---------------------------------------------------------------------------
+
+
+class _FakeResp:
+    """Context-manager HTTP response with a size-capped read()."""
+
+    def __init__(self, body: bytes) -> None:
+        self._body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+    def read(self, n: int = -1) -> bytes:
+        if n < 0:
+            return self._body
+        return self._body[:n]
+
+
+FAKE_HTML = b"<html><body><p>Hello world content.</p></body></html>"
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_read_success_and_truncation(monkeypatch):
+    """Returns PageText(ok=True) with text truncated to MAX_PAGE_CHARS."""
+    import lifeos.web.fetch as fetch_mod
+    import trafilatura  # must be importable for patching
+
+    long_text = "A" * (MAX_PAGE_CHARS + 500)
+    monkeypatch.setattr(trafilatura, "extract", lambda html, **kw: long_text)  # noqa: ARG005
+
+    def fake_urlopen(req, timeout=None):
+        return _FakeResp(FAKE_HTML)
+
+    result = fetch_mod.read("http://example.com", urlopen=fake_urlopen)
+
+    assert result.ok is True
+    assert result.url == "http://example.com"
+    assert len(result.text) == MAX_PAGE_CHARS
+
+
+def test_read_fetch_failure(monkeypatch):
+    """Returns PageText(ok=False, text='') when the fetch raises URLError."""
+    import lifeos.web.fetch as fetch_mod
+
+    def fake_urlopen(req, timeout=None):
+        raise urllib.error.URLError("connection refused")
+
+    result = fetch_mod.read("http://example.com", urlopen=fake_urlopen)
+
+    assert result.ok is False
+    assert result.text == ""
+    assert result.url == "http://example.com"
+
+
+def test_read_non_html_empty_extraction(monkeypatch):
+    """Returns PageText(ok=False, text='') when trafilatura returns None."""
+    import lifeos.web.fetch as fetch_mod
+    import trafilatura
+
+    monkeypatch.setattr(trafilatura, "extract", lambda html, **kw: None)  # noqa: ARG005
+
+    def fake_urlopen(req, timeout=None):
+        return _FakeResp(FAKE_HTML)
+
+    result = fetch_mod.read("http://example.com", urlopen=fake_urlopen)
+
+    assert result.ok is False
+    assert result.text == ""
+
+
+def test_read_size_cap(monkeypatch):
+    """Reads at most max_bytes bytes, even when the response is larger."""
+    import lifeos.web.fetch as fetch_mod
+    import trafilatura
+
+    captured_html: list[str] = []
+
+    def capture_extract(html, **kw):  # noqa: ARG001
+        captured_html.append(html)
+        return "some text"
+
+    monkeypatch.setattr(trafilatura, "extract", capture_extract)
+
+    large_body = b"X" * (MAX_PAGE_BYTES + 1_000_000)
+
+    def fake_urlopen(req, timeout=None):
+        return _FakeResp(large_body)
+
+    result = fetch_mod.read("http://example.com", urlopen=fake_urlopen)
+
+    # Must not crash; bytes passed to extract must be <= max_bytes
+    assert len(captured_html) == 1
+    html_bytes = captured_html[0].encode("latin-1", errors="replace")
+    assert len(html_bytes) <= MAX_PAGE_BYTES
+    # Result ok can be True or False depending on extraction; what matters is no crash.
+    assert result.url == "http://example.com"

--- a/lifeos/tests/test_web_fetch.py
+++ b/lifeos/tests/test_web_fetch.py
@@ -92,28 +92,37 @@ def test_read_non_html_empty_extraction(monkeypatch):
 
 
 def test_read_size_cap(monkeypatch):
-    """Reads at most max_bytes bytes, even when the response is larger."""
+    """H2: resp.read() must be called with max_bytes as its argument (bounded call).
+
+    Captures the exact `n` passed to resp.read() and asserts it equals
+    MAX_PAGE_BYTES — not uncapped (n=-1), not too small (e.g. 1), not too
+    large.  A 1-byte cap or argless read() would both fail this test.
+    """
     import lifeos.web.fetch as fetch_mod
     import trafilatura
 
-    captured_html: list[str] = []
+    monkeypatch.setattr(trafilatura, "extract", lambda html, **kw: "some text")  # noqa: ARG005
 
-    def capture_extract(html, **kw):  # noqa: ARG001
-        captured_html.append(html)
-        return "some text"
+    captured_n: list[int] = []
 
-    monkeypatch.setattr(trafilatura, "extract", capture_extract)
+    class _CapturingResp:
+        def __enter__(self):
+            return self
 
-    large_body = b"X" * (MAX_PAGE_BYTES + 1_000_000)
+        def __exit__(self, *_):
+            return False
+
+        def read(self, n=-1):
+            captured_n.append(n)
+            return b"<html><body><p>hello</p></body></html>"
 
     def fake_urlopen(req, timeout=None):
-        return _FakeResp(large_body)
+        return _CapturingResp()
 
     result = fetch_mod.read("http://example.com", urlopen=fake_urlopen)
 
-    # Must not crash; bytes passed to extract must be <= max_bytes
-    assert len(captured_html) == 1
-    html_bytes = captured_html[0].encode("latin-1", errors="replace")
-    assert len(html_bytes) <= MAX_PAGE_BYTES
-    # Result ok can be True or False depending on extraction; what matters is no crash.
+    assert len(captured_n) == 1, "resp.read() was not called"
+    assert captured_n[0] == MAX_PAGE_BYTES, (
+        f"resp.read() called with n={captured_n[0]!r}; expected MAX_PAGE_BYTES={MAX_PAGE_BYTES}"
+    )
     assert result.url == "http://example.com"

--- a/lifeos/tests/test_web_port.py
+++ b/lifeos/tests/test_web_port.py
@@ -1,0 +1,71 @@
+"""Tests for lifeos.web.port — constants, dataclasses, and Protocol.
+
+TDD Phase 1.1 RED: asserts the public surface of the web port module.
+"""
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+
+def test_constants_values():
+    from lifeos.web.port import (
+        TOP_N,
+        MAX_SNIPPET_CHARS,
+        MAX_PAGE_CHARS,
+        MAX_PAGE_BYTES,
+        SEARCH_TIMEOUT,
+        FETCH_TIMEOUT,
+    )
+    assert TOP_N == 3
+    assert MAX_SNIPPET_CHARS == 300
+    assert MAX_PAGE_CHARS == 3000
+    assert MAX_PAGE_BYTES == 2_000_000
+    assert SEARCH_TIMEOUT == 5.0
+    assert FETCH_TIMEOUT == 8.0
+
+
+def test_search_result_is_frozen_dataclass():
+    from lifeos.web.port import SearchResult
+
+    fields = {f.name for f in dataclasses.fields(SearchResult)}
+    assert fields == {"title", "url", "snippet"}
+
+    r = SearchResult(title="T", url="http://x.com", snippet="S")
+    assert r.title == "T"
+    assert r.url == "http://x.com"
+    assert r.snippet == "S"
+
+    # frozen: mutation must raise
+    with pytest.raises((dataclasses.FrozenInstanceError, AttributeError)):
+        r.title = "changed"  # type: ignore[misc]
+
+
+def test_page_text_is_frozen_dataclass():
+    from lifeos.web.port import PageText
+
+    fields = {f.name for f in dataclasses.fields(PageText)}
+    assert fields == {"url", "text", "ok"}
+
+    p = PageText(url="http://x.com", text="hello", ok=True)
+    assert p.ok is True
+
+    with pytest.raises((dataclasses.FrozenInstanceError, AttributeError)):
+        p.ok = False  # type: ignore[misc]
+
+
+def test_web_research_port_protocol_structure():
+    """WebResearchPort must be a Protocol with search and read methods."""
+    from lifeos.web.port import WebResearchPort
+    import typing
+
+    # Must be a runtime-checkable Protocol or at minimum a Protocol class
+    # We check it has search and read as annotations / methods.
+    assert hasattr(WebResearchPort, "search")
+    assert hasattr(WebResearchPort, "read")
+
+
+def test_callable_type_aliases_exist():
+    """SearchFn and ReadFn must be importable."""
+    from lifeos.web.port import SearchFn, ReadFn  # noqa: F401

--- a/lifeos/tests/test_web_searxng.py
+++ b/lifeos/tests/test_web_searxng.py
@@ -1,0 +1,121 @@
+"""Tests for lifeos.web.searxng — SearXNGAdapter.
+
+Uses an injected fake urlopen (mirrors test_brain._FakeResp).
+Zero network calls.
+"""
+from __future__ import annotations
+
+import json
+import urllib.error
+
+from lifeos.web.port import MAX_SNIPPET_CHARS, TOP_N
+
+
+# ---------------------------------------------------------------------------
+# Fake HTTP transport helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeResp:
+    """Minimal context-manager response mirroring test_brain._FakeResp."""
+
+    def __init__(self, body: bytes) -> None:
+        self._body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+    def read(self, n: int = -1) -> bytes:
+        if n < 0:
+            return self._body
+        return self._body[:n]
+
+
+def _make_results(n: int) -> list[dict]:
+    return [
+        {"title": f"Title {i}", "url": f"http://example.com/{i}", "content": f"Snippet {i} " + "x" * 400}
+        for i in range(n)
+    ]
+
+
+def _json_resp(results: list[dict]) -> _FakeResp:
+    body = json.dumps({"results": results}).encode("utf-8")
+    return _FakeResp(body)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_search_success_parse():
+    """Returns up to TOP_N results with correct fields; snippets truncated."""
+    from lifeos.web.searxng import SearXNGAdapter
+
+    payload = _make_results(5)
+    adapter = SearXNGAdapter(
+        base_url="http://localhost:8888",
+        urlopen=lambda req, timeout=None: _json_resp(payload),
+    )
+    results = adapter.search("python async")
+
+    assert len(results) == TOP_N
+    for r in results:
+        assert hasattr(r, "title")
+        assert hasattr(r, "url")
+        assert hasattr(r, "snippet")
+        assert len(r.snippet) <= MAX_SNIPPET_CHARS
+
+
+def test_search_zero_results():
+    """Returns [] when SearXNG has no results."""
+    from lifeos.web.searxng import SearXNGAdapter
+
+    adapter = SearXNGAdapter(
+        base_url="http://localhost:8888",
+        urlopen=lambda req, timeout=None: _json_resp([]),
+    )
+    assert adapter.search("noresults") == []
+
+
+def test_search_unreachable_returns_empty():
+    """Returns [] and does NOT raise when SearXNG is unreachable."""
+    from lifeos.web.searxng import SearXNGAdapter
+
+    def _raise(req, timeout=None):
+        raise urllib.error.URLError("connection refused")
+
+    adapter = SearXNGAdapter(base_url="http://localhost:8888", urlopen=_raise)
+    result = adapter.search("something")
+    assert result == []
+
+
+def test_search_limit_cap():
+    """Respects explicit limit parameter."""
+    from lifeos.web.searxng import SearXNGAdapter
+
+    payload = _make_results(10)
+    adapter = SearXNGAdapter(
+        base_url="http://localhost:8888",
+        urlopen=lambda req, timeout=None: _json_resp(payload),
+    )
+    results = adapter.search("python", limit=2)
+    assert len(results) == 2
+
+
+def test_search_snippet_truncation():
+    """Snippet is truncated to MAX_SNIPPET_CHARS even when source is longer."""
+    from lifeos.web.searxng import SearXNGAdapter
+
+    long_content = "A" * (MAX_SNIPPET_CHARS + 100)
+    payload = [{"title": "T", "url": "http://x.com", "content": long_content}]
+    adapter = SearXNGAdapter(
+        base_url="http://localhost:8888",
+        urlopen=lambda req, timeout=None: _json_resp(payload),
+    )
+    results = adapter.search("test", limit=1)
+    assert len(results) == 1
+    assert len(results[0].snippet) == MAX_SNIPPET_CHARS

--- a/lifeos/tests/test_web_searxng.py
+++ b/lifeos/tests/test_web_searxng.py
@@ -52,7 +52,7 @@ def _json_resp(results: list[dict]) -> _FakeResp:
 
 
 def test_search_success_parse():
-    """Returns up to TOP_N results with correct fields; snippets truncated."""
+    """Returns up to TOP_N results with correct field values; snippets truncated."""
     from lifeos.web.searxng import SearXNGAdapter
 
     payload = _make_results(5)
@@ -63,11 +63,11 @@ def test_search_success_parse():
     results = adapter.search("python async")
 
     assert len(results) == TOP_N
-    for r in results:
-        assert hasattr(r, "title")
-        assert hasattr(r, "url")
-        assert hasattr(r, "snippet")
+    for i, r in enumerate(results):
+        assert r.title == f"Title {i}"
+        assert r.url == f"http://example.com/{i}"
         assert len(r.snippet) <= MAX_SNIPPET_CHARS
+        assert len(r.snippet) == MAX_SNIPPET_CHARS  # source is longer than cap
 
 
 def test_search_zero_results():
@@ -119,3 +119,98 @@ def test_search_snippet_truncation():
     results = adapter.search("test", limit=1)
     assert len(results) == 1
     assert len(results[0].snippet) == MAX_SNIPPET_CHARS
+
+
+# ---------------------------------------------------------------------------
+# C1: search() must never raise — malformed JSON bodies
+# ---------------------------------------------------------------------------
+
+
+def test_search_body_is_list_returns_empty():
+    """C1a: If SearXNG returns a JSON array (not a dict), search() returns [].
+
+    data.get("results") would raise AttributeError on a list — the try/except
+    must cover the full parse+process block.
+    """
+    from lifeos.web.searxng import SearXNGAdapter
+
+    # Body is a JSON array, not an object
+    body = b"[]"
+    adapter = SearXNGAdapter(
+        base_url="http://localhost:8888",
+        urlopen=lambda req, timeout=None: _FakeResp(body),
+    )
+    result = adapter.search("anything")
+    assert result == []
+
+
+def test_search_results_contains_non_dict_items_returns_partial():
+    """C1b: Non-dict items in results[] must NOT cause AttributeError.
+
+    {"results": [1, 2, 3]} — item.get(...) raises on int.
+    search() must return [] (or skip bad items) instead of raising.
+    """
+    from lifeos.web.searxng import SearXNGAdapter
+
+    body = json.dumps({"results": [1, 2, 3]}).encode()
+    adapter = SearXNGAdapter(
+        base_url="http://localhost:8888",
+        urlopen=lambda req, timeout=None: _FakeResp(body),
+    )
+    result = adapter.search("anything")
+    # Must not raise; all non-dict items should be skipped
+    assert isinstance(result, list)
+
+
+def test_search_results_mixed_dict_and_int_skips_bad_items():
+    """C1c: Valid dict items must survive when mixed with non-dict items."""
+    from lifeos.web.searxng import SearXNGAdapter
+
+    payload = [{"title": "ok", "url": "http://x.com/0", "content": "c"}, 5]
+    body = json.dumps({"results": payload}).encode()
+    adapter = SearXNGAdapter(
+        base_url="http://localhost:8888",
+        urlopen=lambda req, timeout=None: _FakeResp(body),
+    )
+    result = adapter.search("anything", limit=10)
+    # Must not raise; at minimum returns the one valid dict item
+    assert isinstance(result, list)
+
+
+# ---------------------------------------------------------------------------
+# H1: resp.read() in search() must be capped (not uncapped like original)
+# ---------------------------------------------------------------------------
+
+
+def test_search_read_is_capped():
+    """H1: resp.read() in search() must be called with a byte cap argument.
+
+    A fake resp records the argument passed to read(); we assert it equals
+    MAX_SEARCH_BYTES (not -1 / uncapped / absent).
+    """
+    from lifeos.web.port import MAX_SEARCH_BYTES
+    from lifeos.web.searxng import SearXNGAdapter
+
+    captured_n: list[int] = []
+
+    class _CapturingResp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_):
+            return False
+
+        def read(self, n=-1):
+            captured_n.append(n)
+            return b'{"results": []}'
+
+    adapter = SearXNGAdapter(
+        base_url="http://localhost:8888",
+        urlopen=lambda req, timeout=None: _CapturingResp(),
+    )
+    adapter.search("anything")
+    assert len(captured_n) == 1, "resp.read() was not called"
+    assert captured_n[0] == MAX_SEARCH_BYTES, (
+        f"resp.read() was called with n={captured_n[0]!r}; "
+        f"expected MAX_SEARCH_BYTES={MAX_SEARCH_BYTES}"
+    )


### PR DESCRIPTION
First slice of **axi-web-research** — gives Axi private web research. This PR is the **pure, axi-free `lifeos/web/` package only** (PR 1 of 2, stacked). PR 2 wires it into the dashboard chat + ships the SearXNG service.

## What's here
- `lifeos/web/port.py` — `WebResearchPort` Protocol, `SearchResult`/`PageText` frozen dataclasses, budgeting constants (`TOP_N=3`, `MAX_SNIPPET_CHARS=300`, `MAX_PAGE_CHARS=3000`, `MAX_PAGE_BYTES=2_000_000`, `MAX_SEARCH_BYTES=1_000_000`, timeouts).
- `lifeos/web/searxng.py` — `SearXNGAdapter` over stdlib `urllib`; queries local SearXNG JSON API; graceful `[]` on any failure (never raises).
- `lifeos/web/fetch.py` — `read(url)` via `urllib` + `trafilatura`; bounded bytes + char truncation; `PageText(ok=False)` on failure (never raises).
- `lifeos/web/__init__.py` — DI `configure(search_fn, read_fn, enabled_fn)` seam mirroring `autonomous_cron.configure`; `SEARXNG_URL` env (default `http://127.0.0.1:8888`).
- `trafilatura` added to `lifeos` deps.

## Architecture
Hexagonal: `lifeos` stays axi-free; the brain (no tool-calling) consumes results via the injected port in a research-then-answer flow (PR 2). Privacy-first: only the local SearXNG + the directly-fetched result URLs are contacted; no third-party API, no query egress.

## Tests / review
Strict TDD throughout. 22 web unit tests (injected fake `urlopen` — no network). Full suites green: **786 lifeos / 569 axi**. A fresh adversarial review caught and fixed a CRITICAL (`search()` could raise on valid non-dict JSON), an unbounded SearXNG read, and a loose byte-cap test — all covered by RED→GREEN tests now.

## Non-goals (later slices)
Images, browser automation, YouTube transcription, agentic multi-step tool-use.