### PR TITLE
feat(axi): wire web research into dashboard chat — /busca + /investiga (axi-web-research PR 2)

### DIFF
--- a/axi/src/axi/dashboard.py
+++ b/axi/src/axi/dashboard.py
@@ -99,6 +99,9 @@ from lifeos.posture import store as posture_store
 # P7 — Autonomous reflection tick (proactive thought, disabled by default).
 from lifeos.autonomous import cron as autonomous_cron
 from lifeos.insights import correlate as insights_correlate
+# P8 — Web research (SearXNG + trafilatura; local-only, no cloud APIs).
+import lifeos.web as web_research
+from lifeos.web.port import TOP_N, MAX_SNIPPET_CHARS, MAX_PAGE_CHARS
 # Nano-agents PRD — fast-path instrumentation. Records which stage handled
 # each chat call + latency, so we can decide empirically whether nano-agents
 # are worth building. Stores metadata only (no text content).
@@ -336,6 +339,23 @@ async def lifespan(_app: FastAPI):
         )
     except Exception:  # noqa: BLE001
         log.exception("lifeos autonomous cron failed to start")
+
+    # P8 — Web research: wire SearXNGAdapter + fetch.read into the DI module.
+    # Mirrors the autonomous_cron.configure() pattern above. axi owns config +
+    # wiring; lifeos/web stays axi-free (pure functions / hexagonal port).
+    try:
+        from lifeos.web.searxng import SearXNGAdapter  # noqa: PLC0415
+        import lifeos.web.fetch as _web_fetch         # noqa: PLC0415
+        _searxng_base = str(config.get("searxng_url", web_research.SEARXNG_URL))
+        _searxng = SearXNGAdapter(base_url=_searxng_base)
+        web_research.configure(
+            search_fn=_searxng.search,
+            read_fn=_web_fetch.read,
+            enabled_fn=lambda: bool(config.get("web_research_enabled", True)),
+        )
+        log.info("web research configured: base_url=%s", _searxng_base)
+    except Exception:  # noqa: BLE001
+        log.exception("web research failed to configure — feature disabled")
 
     yield
 
@@ -2350,6 +2370,129 @@ async def api_chat_ask(request: Request):
             )
         except Exception:  # noqa: BLE001
             log.warning("fastpath metric record failed", exc_info=True)
+
+    # ─── Web research fast-path (/busca, /investiga) ────────────────────────
+    # Must run BEFORE any domain parsers — explicit command tokens take
+    # priority over regex classifiers that might misread "busca X" as finance.
+    # Degrades gracefully: SearXNG down → friendly Spanish message (HTTP 200).
+    _WEB_CMD_RE = re.compile(
+        r"^(/busca|/investiga)\s*(.*)", re.IGNORECASE | re.DOTALL
+    )
+    _web_cmd_match = _WEB_CMD_RE.match(text)
+    if _web_cmd_match and not image_b64:
+        _web_query = _web_cmd_match.group(2).strip()
+        if not _web_query:
+            # Empty query — return a friendly prompt instead of crashing.
+            _empty_answer = (
+                "Decime qué querés que busque. "
+                "Ejemplo: /busca python async o /investiga historia del café."
+            )
+            latency_ms = round((time.monotonic() - start) * 1000)
+            try:
+                mem.add(text, _empty_answer, has_screenshot=False)
+            except Exception:  # noqa: BLE001
+                pass
+            stage_holder[0] = "web_research_empty_query"
+            _record_metric()
+            return {"answer": _empty_answer, "latency_ms": latency_ms,
+                    "spoke": False, "audio_b64": None}
+
+        if web_research.is_enabled():
+            try:
+                _search_fn = web_research.get_search_fn()
+                _read_fn = web_research.get_read_fn()
+                _results = _search_fn(_web_query)[:TOP_N] if _search_fn else []
+
+                if not _results:
+                    # SearXNG down or no hits → graceful degraded message.
+                    _degraded = (
+                        "No pude buscar eso ahora mismo — el servicio de búsqueda "
+                        "no está disponible en este momento. Intentalo de nuevo en unos minutos."
+                    )
+                    latency_ms = round((time.monotonic() - start) * 1000)
+                    try:
+                        mem.add(text, _degraded, has_screenshot=False)
+                    except Exception:  # noqa: BLE001
+                        pass
+                    stage_holder[0] = "web_research_degraded"
+                    _record_metric()
+                    return {"answer": _degraded, "latency_ms": latency_ms,
+                            "spoke": False, "audio_b64": None}
+
+                # Build research context block from search results.
+                _research_lines: list[str] = [
+                    f"Resultados de búsqueda para: {_web_query}\n"
+                ]
+                for _i, _r in enumerate(_results, 1):
+                    _snippet = _r.snippet[:MAX_SNIPPET_CHARS]
+                    _research_lines.append(
+                        f"[{_i}] {_r.title}\n"
+                        f"    URL: {_r.url}\n"
+                        f"    Resumen: {_snippet}"
+                    )
+
+                # Attempt to read full text of the top result (best-effort).
+                _page_text = ""
+                if _read_fn and _results:
+                    try:
+                        _page = _read_fn(_results[0].url)
+                        if _page.ok and _page.text:
+                            _page_text = _page.text[:MAX_PAGE_CHARS]
+                    except Exception:  # noqa: BLE001
+                        pass  # page read failure is non-fatal; snippets suffice
+
+                if _page_text:
+                    _research_lines.append(
+                        f"\nContenido completo de [{_results[0].url}]:\n{_page_text}"
+                    )
+
+                _source_urls = [_r.url for _r in _results]
+                _fuentes_block = "\n\nFuentes:\n" + "\n".join(
+                    f"- {_u}" for _u in _source_urls
+                )
+
+                # Enrich the brain prompt with research context.
+                _research_block = "\n".join(_research_lines)
+                _enriched_prompt = (
+                    f"{_research_block}\n\n"
+                    f"Usando los resultados de búsqueda anteriores, "
+                    f"responde la siguiente consulta de forma precisa y cita las URLs fuente:\n"
+                    f"{_web_query}"
+                )
+
+                # Call brain with enriched prompt (same system / history as normal).
+                brain_system = brain.SYSTEM_PROMPT
+                _raw_answer = brain.ask(
+                    _enriched_prompt,
+                    system=brain_system,
+                    history=history,
+                    image_b64=None,
+                )
+                # Deterministically append source citations so they never depend
+                # on model behavior.
+                answer = _raw_answer + _fuentes_block
+
+                # Guardrail: still applies on research answers.
+                if _looks_like_persistence_claim(answer):
+                    log.warning(
+                        "brain hallucinated persistence claim on research text=%r — overriding",
+                        text[:120],
+                    )
+                    answer = _suggested_format_message(text)
+
+                latency_ms = round((time.monotonic() - start) * 1000)
+                try:
+                    mem.add(text, answer, has_screenshot=False)
+                except Exception:  # noqa: BLE001
+                    pass
+                stage_holder[0] = "web_research"
+                _record_metric()
+                return {"answer": answer, "latency_ms": latency_ms,
+                        "spoke": False, "audio_b64": None,
+                        "research": {"urls": _source_urls}}
+            except Exception:  # noqa: BLE001
+                log.exception("web research branch failed — falling through to brain")
+                # Fall through to normal brain path on unexpected errors.
 
     # LifeOS reminder fast-path: if the user said "recordame X mañana a las 9",
     # we handle it deterministically without bothering the brain. Saves ~3s

--- a/axi/src/axi/dashboard.py
+++ b/axi/src/axi/dashboard.py
@@ -413,6 +413,16 @@ _PERSISTENCE_CLAIM_RE = re.compile(
 )
 
 
+# Web research command parser — compiled once at module load.
+# Matches /busca or /investiga followed by whitespace+query OR end-of-string.
+# Requires the command token to end at a word boundary so /buscalo and
+# /investigalo do NOT match (they are different commands, not typos).
+_WEB_CMD_RE = re.compile(
+    r"^(/busca|/investiga)(?:\s+(.+))?$",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
 def _looks_like_persistence_claim(text: str) -> bool:
     """True iff `text` claims data was persisted. Used to detect brain
     hallucinations when the ingestion fast-path actually missed."""
@@ -2375,12 +2385,9 @@ async def api_chat_ask(request: Request):
     # Must run BEFORE any domain parsers — explicit command tokens take
     # priority over regex classifiers that might misread "busca X" as finance.
     # Degrades gracefully: SearXNG down → friendly Spanish message (HTTP 200).
-    _WEB_CMD_RE = re.compile(
-        r"^(/busca|/investiga)\s*(.*)", re.IGNORECASE | re.DOTALL
-    )
     _web_cmd_match = _WEB_CMD_RE.match(text)
     if _web_cmd_match and not image_b64:
-        _web_query = _web_cmd_match.group(2).strip()
+        _web_query = (_web_cmd_match.group(2) or "").strip()
         if not _web_query:
             # Empty query — return a friendly prompt instead of crashing.
             _empty_answer = (
@@ -2452,12 +2459,14 @@ async def api_chat_ask(request: Request):
                 )
 
                 # Enrich the brain prompt with research context.
+                # _research_lines[0] already starts with "Resultados de búsqueda
+                # para: {_web_query}" so the trailing instruction below does NOT
+                # repeat the query — it only adds the answering directive.
                 _research_block = "\n".join(_research_lines)
                 _enriched_prompt = (
                     f"{_research_block}\n\n"
                     f"Usando los resultados de búsqueda anteriores, "
-                    f"responde la siguiente consulta de forma precisa y cita las URLs fuente:\n"
-                    f"{_web_query}"
+                    f"responde la consulta de forma precisa y cita las URLs fuente."
                 )
 
                 # Call brain with enriched prompt (same system / history as normal).
@@ -2472,13 +2481,12 @@ async def api_chat_ask(request: Request):
                 # on model behavior.
                 answer = _raw_answer + _fuentes_block
 
-                # Guardrail: still applies on research answers.
-                if _looks_like_persistence_claim(answer):
-                    log.warning(
-                        "brain hallucinated persistence claim on research text=%r — overriding",
-                        text[:120],
-                    )
-                    answer = _suggested_format_message(text)
+                # NOTE: The persistence-claim guardrail is intentionally NOT applied
+                # here. The research path is read-only — nothing is persisted.
+                # Legitimate research answers about databases, journalism, or logging
+                # may incidentally contain persistence verbs ("anotado", "registrado")
+                # and must NOT be clobbered with the "no se guardó" message.
+                # The guardrail lives on the data-entry brain path (~line 3061) only.
 
                 latency_ms = round((time.monotonic() - start) * 1000)
                 try:

--- a/axi/tests/test_chat_research.py
+++ b/axi/tests/test_chat_research.py
@@ -62,16 +62,6 @@ def _reset_web_research(monkeypatch):
 
 
 @pytest.fixture
-def client(monkeypatch):
-    from axi import dashboard
-    monkeypatch.setattr(dashboard, "_chat_memory", None)
-    monkeypatch.setattr(dashboard, "_chat_memory_lock", None)
-    # Disable nano extractor so tests don't hit real model ports and run fast
-    monkeypatch.setattr(dashboard, "_try_nano_extract", lambda *a, **kw: None)
-    return TestClient(dashboard.app)
-
-
-@pytest.fixture
 def research_client(monkeypatch):
     """Client with web research fully configured (search + read succeed)."""
     from axi import brain, dashboard
@@ -130,7 +120,7 @@ def test_busca_triggers_research(research_client, monkeypatch):
     assert "answer" in body
 
     # The prompt passed to brain.ask must contain search context
-    assert "captured" in captured or "prompt" in captured, "brain.ask was never called"
+    assert "prompt" in captured, "brain.ask was never called"
     enriched = captured.get("prompt", "")
     assert "Python async guide" in enriched or "asyncio" in enriched, (
         f"Enriched prompt missing search content: {enriched[:300]}"
@@ -182,7 +172,7 @@ def test_busca_case_insensitive(research_client, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_empty_query_returns_friendly_message(client, monkeypatch):
+def test_empty_query_returns_friendly_message(monkeypatch):
     """/busca with whitespace-only query → graceful message, search not called."""
     import lifeos.web as web_research
     from axi import brain, dashboard
@@ -223,7 +213,7 @@ def test_empty_query_returns_friendly_message(client, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_searxng_down_degraded_message(client, monkeypatch):
+def test_searxng_down_degraded_message(monkeypatch):
     """search_fn returns [] → degraded message, HTTP 200, no 500."""
     import lifeos.web as web_research
     from axi import brain, dashboard
@@ -258,7 +248,7 @@ def test_searxng_down_degraded_message(client, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_read_failure_falls_back_to_snippets(client, monkeypatch):
+def test_read_failure_falls_back_to_snippets(monkeypatch):
     """read_fn returns ok=False → still enriches from snippets, no crash."""
     import lifeos.web as web_research
     from axi import brain, dashboard
@@ -294,12 +284,21 @@ def test_read_failure_falls_back_to_snippets(client, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Task 5.1e — guardrail still fires on research path
+# Task 5.1e — research path is NOT subject to the persistence guardrail
+# (renamed from test_guardrail_fires_on_research_answer — behavior inverted)
 # ---------------------------------------------------------------------------
 
 
-def test_guardrail_fires_on_research_answer(client, monkeypatch):
-    """If brain returns a persistence claim after research, guardrail still fires."""
+def test_research_answers_not_subject_to_persistence_guardrail(monkeypatch):
+    """Research answer containing a persistence verb must be returned unchanged.
+
+    The persistence guardrail exists to stop the brain from lying about saving
+    data to Axi's memory on the data-entry path. On the research path, nothing
+    is persisted by design — the answer is read-only research. A legitimate
+    answer about databases, journalism, or records that incidentally contains
+    'registré'/'guardé'/'anoté' must NOT be clobbered with the generic
+    'no se guardó' message.
+    """
     import lifeos.web as web_research
     from axi import brain, dashboard
 
@@ -312,17 +311,114 @@ def test_guardrail_fires_on_research_answer(client, monkeypatch):
     monkeypatch.setattr(dashboard, "_chat_memory_lock", None)
     monkeypatch.setattr(dashboard, "_try_nano_extract", lambda *a, **kw: None)
 
-    # Brain claims to have persisted something — guardrail must intercept this
-    monkeypatch.setattr(brain, "ask", lambda p, **kw: "Anotado y registré tu búsqueda en la base de datos.")
+    # Brain returns a research answer that incidentally contains persistence verbs
+    # (e.g., "anotado en el sistema" describes a logging system — legitimate research
+    # content that happens to match the persistence-claim regex).
+    # Under the current (buggy) code this gets clobbered. After the fix it must not.
+    persistence_flavored_answer = "El sistema de logging tiene todo anotado en el sistema de archivos."
+    monkeypatch.setattr(brain, "ask", lambda p, **kw: persistence_flavored_answer)
 
     tc = TestClient(dashboard.app)
     r = tc.post("/api/chat/ask", json={"text": "/busca python"})
     assert r.status_code == 200
     body = r.json()
     answer = body.get("answer", "")
-    # The guardrail must have replaced the persistence-claim answer
-    assert "registré" not in answer or "Anotado" not in answer, (
-        f"Guardrail did NOT fire on research path — answer was: {answer}"
+    # The answer must contain the brain's response (with Fuentes appended),
+    # NOT be replaced by the suggested-format generic message.
+    assert "anotado" in answer, (
+        f"Research answer was clobbered by guardrail — got: {answer!r}"
+    )
+    assert "Fuentes" in answer, (
+        f"Expected Fuentes block appended to research answer, got: {answer!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Task 5.1g — /buscalo / /investigalo do NOT hijack the research command
+# ---------------------------------------------------------------------------
+
+
+def test_buscalo_is_not_a_research_command(monkeypatch):
+    """/buscalo en internet must NOT trigger the research branch.
+
+    The regex '^(/busca|/investiga)\\s*(.*)' (current buggy form) matches
+    '/buscalo en internet' → query='lo en internet'. The fixed regex requires
+    whitespace or end-of-string after the command token, so '/buscalo' falls
+    through to the normal brain path.
+    """
+    import lifeos.web as web_research
+    from axi import brain, dashboard
+
+    search_called = []
+
+    web_research.configure(
+        search_fn=lambda q, **kw: search_called.append(q) or [],
+        read_fn=lambda url: _PAGE_FAIL,
+        enabled_fn=lambda: True,
+    )
+    monkeypatch.setattr(dashboard, "_chat_memory", None)
+    monkeypatch.setattr(dashboard, "_chat_memory_lock", None)
+    monkeypatch.setattr(dashboard, "_try_nano_extract", lambda *a, **kw: None)
+    monkeypatch.setattr(brain, "ask", lambda p, **kw: "respuesta normal")
+
+    tc = TestClient(dashboard.app)
+    r = tc.post("/api/chat/ask", json={"text": "/buscalo en internet"})
+    assert r.status_code == 200
+    assert search_called == [], (
+        f"search_fn was called for /buscalo — it hijacked the command: {search_called}"
+    )
+
+
+def test_investigalo_is_not_a_research_command(monkeypatch):
+    """/investigalo algo must NOT trigger the research branch."""
+    import lifeos.web as web_research
+    from axi import brain, dashboard
+
+    search_called = []
+
+    web_research.configure(
+        search_fn=lambda q, **kw: search_called.append(q) or [],
+        read_fn=lambda url: _PAGE_FAIL,
+        enabled_fn=lambda: True,
+    )
+    monkeypatch.setattr(dashboard, "_chat_memory", None)
+    monkeypatch.setattr(dashboard, "_chat_memory_lock", None)
+    monkeypatch.setattr(dashboard, "_try_nano_extract", lambda *a, **kw: None)
+    monkeypatch.setattr(brain, "ask", lambda p, **kw: "respuesta normal")
+
+    tc = TestClient(dashboard.app)
+    r = tc.post("/api/chat/ask", json={"text": "/investigalo algo"})
+    assert r.status_code == 200
+    assert search_called == [], (
+        f"search_fn was called for /investigalo — it hijacked the command: {search_called}"
+    )
+
+
+def test_busca_alone_returns_friendly_message(monkeypatch):
+    """/busca with no trailing text → friendly 'tell me what to search' message."""
+    import lifeos.web as web_research
+    from axi import brain, dashboard
+
+    search_called = []
+
+    web_research.configure(
+        search_fn=lambda q, **kw: search_called.append(q) or [],
+        read_fn=lambda url: _PAGE_FAIL,
+        enabled_fn=lambda: True,
+    )
+    monkeypatch.setattr(dashboard, "_chat_memory", None)
+    monkeypatch.setattr(dashboard, "_chat_memory_lock", None)
+    monkeypatch.setattr(dashboard, "_try_nano_extract", lambda *a, **kw: None)
+    monkeypatch.setattr(brain, "ask", lambda p, **kw: "fallback")
+
+    tc = TestClient(dashboard.app)
+    r = tc.post("/api/chat/ask", json={"text": "/busca"})
+    assert r.status_code == 200
+    body = r.json()
+    assert search_called == [], f"search_fn called with empty /busca: {search_called}"
+    answer = body.get("answer", "")
+    assert any(word in answer.lower() for word in ["busca", "qué", "que", "consulta"]), (
+        f"Expected friendly prompt for bare /busca, got: {answer}"
     )
 
 
@@ -331,7 +427,7 @@ def test_guardrail_fires_on_research_answer(client, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_non_research_message_unaffected(client, monkeypatch):
+def test_non_research_message_unaffected(monkeypatch):
     """A plain message does NOT trigger search — existing flow unchanged."""
     import lifeos.web as web_research
     from axi import brain, dashboard

--- a/axi/tests/test_chat_research.py
+++ b/axi/tests/test_chat_research.py
@@ -1,0 +1,356 @@
+"""Tests for the web-research branch in /api/chat/ask.
+
+Strict TDD (RED→GREEN). All external services are mocked — NO real
+network, NO real SearXNG, NO real brain / llama-server.
+
+Mocking strategy:
+- `brain.ask` → monkeypatched on the `axi.brain` module (same as test_chat_api.py)
+- `search_fn` / `read_fn` → injected via `lifeos.web.configure()` in each fixture
+- The dashboard module's `_chat_memory` is reset to None so every test gets
+  an isolated in-memory history (mirrors test_chat_api.py fixture pattern).
+
+All tests drive the real FastAPI app via `TestClient` to exercise the full
+handler — no unit-testing the internal helper functions in isolation.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from lifeos.web.port import PageText, SearchResult
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_RESULT_1 = SearchResult(
+    title="Python async guide",
+    url="https://docs.python.org/async",
+    snippet="Python async/await is great for IO-bound tasks.",
+)
+_RESULT_2 = SearchResult(
+    title="asyncio docs",
+    url="https://docs.python.org/asyncio",
+    snippet="The asyncio module provides infrastructure for async I/O.",
+)
+_RESULT_3 = SearchResult(
+    title="PEP 3156",
+    url="https://peps.python.org/pep-3156",
+    snippet="Asynchronous IO support rebooted — the asyncio module.",
+)
+
+_PAGE_TEXT = PageText(
+    url=_RESULT_1.url,
+    text="Python async/await allows writing concurrent code using coroutines. " * 10,
+    ok=True,
+)
+_PAGE_FAIL = PageText(url=_RESULT_1.url, text="", ok=False)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_web_research(monkeypatch):
+    """Reset web_research globals before every test."""
+    import lifeos.web as web_research
+    monkeypatch.setattr(web_research, "_search_fn", None)
+    monkeypatch.setattr(web_research, "_read_fn", None)
+    monkeypatch.setattr(web_research, "_enabled_fn", None)
+
+
+@pytest.fixture
+def client(monkeypatch):
+    from axi import dashboard
+    monkeypatch.setattr(dashboard, "_chat_memory", None)
+    monkeypatch.setattr(dashboard, "_chat_memory_lock", None)
+    # Disable nano extractor so tests don't hit real model ports and run fast
+    monkeypatch.setattr(dashboard, "_try_nano_extract", lambda *a, **kw: None)
+    return TestClient(dashboard.app)
+
+
+@pytest.fixture
+def research_client(monkeypatch):
+    """Client with web research fully configured (search + read succeed)."""
+    from axi import brain, dashboard
+    import lifeos.web as web_research
+
+    monkeypatch.setattr(dashboard, "_chat_memory", None)
+    monkeypatch.setattr(dashboard, "_chat_memory_lock", None)
+    # Disable nano extractor so tests don't hit real model ports and run fast
+    monkeypatch.setattr(dashboard, "_try_nano_extract", lambda *a, **kw: None)
+
+    search_calls: list[str] = []
+    read_calls: list[str] = []
+
+    def fake_search(query: str, **kw) -> list[SearchResult]:
+        search_calls.append(query)
+        return [_RESULT_1, _RESULT_2, _RESULT_3]
+
+    def fake_read(url: str) -> PageText:
+        read_calls.append(url)
+        return _PAGE_TEXT
+
+    web_research.configure(
+        search_fn=fake_search,
+        read_fn=fake_read,
+        enabled_fn=lambda: True,
+    )
+
+    monkeypatch.setattr(brain, "ask", lambda prompt, **kw: "La respuesta del brain.")
+
+    tc = TestClient(dashboard.app)
+    tc._search_calls = search_calls
+    tc._read_calls = read_calls
+    return tc
+
+
+# ---------------------------------------------------------------------------
+# Task 5.1a — command parsing: /busca and /investiga recognized
+# ---------------------------------------------------------------------------
+
+
+def test_busca_triggers_research(research_client, monkeypatch):
+    """POST /busca <query> → research flow fires, brain called with enriched prompt."""
+    from axi import brain
+
+    captured: dict = {}
+
+    def capturing_ask(prompt: str, **kw):
+        captured["prompt"] = prompt
+        return "Respuesta con citas."
+
+    monkeypatch.setattr(brain, "ask", capturing_ask)
+
+    r = research_client.post("/api/chat/ask", json={"text": "/busca python async"})
+    assert r.status_code == 200
+    body = r.json()
+    assert "answer" in body
+
+    # The prompt passed to brain.ask must contain search context
+    assert "captured" in captured or "prompt" in captured, "brain.ask was never called"
+    enriched = captured.get("prompt", "")
+    assert "Python async guide" in enriched or "asyncio" in enriched, (
+        f"Enriched prompt missing search content: {enriched[:300]}"
+    )
+    # Source URLs must appear in the answer (appended deterministically)
+    answer = body["answer"]
+    assert "docs.python.org" in answer or "Fuentes" in answer, (
+        f"Source URLs not in answer: {answer}"
+    )
+
+
+def test_investiga_triggers_research(research_client, monkeypatch):
+    """/investiga prefix is equivalent to /busca."""
+    from axi import brain
+
+    captured: dict = {}
+
+    def capturing_ask(prompt: str, **kw):
+        captured["prompt"] = prompt
+        return "Respuesta de investiga."
+
+    monkeypatch.setattr(brain, "ask", capturing_ask)
+
+    r = research_client.post("/api/chat/ask", json={"text": "/investiga asyncio"})
+    assert r.status_code == 200
+
+    enriched = captured.get("prompt", "")
+    assert "asyncio" in enriched.lower() or "Python" in enriched, (
+        f"Enriched prompt missing search content: {enriched[:300]}"
+    )
+
+
+def test_busca_case_insensitive(research_client, monkeypatch):
+    """/BUSCA (uppercase) is recognized."""
+    from axi import brain
+
+    captured: dict = {}
+    monkeypatch.setattr(brain, "ask", lambda p, **kw: (captured.update({"p": p}), "ok")[1])
+
+    r = research_client.post("/api/chat/ask", json={"text": "/BUSCA python"})
+    assert r.status_code == 200
+    # Verify the research branch fired (prompt enriched or answer has sources)
+    body = r.json()
+    assert "answer" in body
+
+
+# ---------------------------------------------------------------------------
+# Task 5.1b — empty query → friendly message, no search call
+# ---------------------------------------------------------------------------
+
+
+def test_empty_query_returns_friendly_message(client, monkeypatch):
+    """/busca with whitespace-only query → graceful message, search not called."""
+    import lifeos.web as web_research
+    from axi import brain, dashboard
+
+    search_called = []
+
+    def must_not_be_called(query, **kw):  # noqa: ARG001
+        search_called.append(query)
+        return []
+
+    web_research.configure(
+        search_fn=must_not_be_called,
+        read_fn=lambda url: _PAGE_FAIL,
+        enabled_fn=lambda: True,
+    )
+
+    monkeypatch.setattr(dashboard, "_chat_memory", None)
+    monkeypatch.setattr(dashboard, "_chat_memory_lock", None)
+    monkeypatch.setattr(dashboard, "_try_nano_extract", lambda *a, **kw: None)
+    monkeypatch.setattr(brain, "ask", lambda p, **kw: "fallback")
+
+    tc = TestClient(dashboard.app)
+    r = tc.post("/api/chat/ask", json={"text": "/busca   "})
+    assert r.status_code == 200
+    body = r.json()
+    # search must NOT have been called with an empty query
+    assert search_called == [], f"search_fn called with empty query: {search_called}"
+    # Response should contain a friendly prompt
+    answer = body.get("answer", "")
+    assert any(word in answer.lower() for word in ["busca", "query", "consulta", "qué", "que"]), (
+        f"Expected a friendly prompt in answer, got: {answer}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Task 5.1c — SearXNG down → graceful degraded message, HTTP 200, brain NOT
+#             called with research context (or called normally)
+# ---------------------------------------------------------------------------
+
+
+def test_searxng_down_degraded_message(client, monkeypatch):
+    """search_fn returns [] → degraded message, HTTP 200, no 500."""
+    import lifeos.web as web_research
+    from axi import brain, dashboard
+
+    web_research.configure(
+        search_fn=lambda q, **kw: [],
+        read_fn=lambda url: _PAGE_FAIL,
+        enabled_fn=lambda: True,
+    )
+    monkeypatch.setattr(dashboard, "_chat_memory", None)
+    monkeypatch.setattr(dashboard, "_chat_memory_lock", None)
+    monkeypatch.setattr(dashboard, "_try_nano_extract", lambda *a, **kw: None)
+    monkeypatch.setattr(brain, "ask", lambda p, **kw: (_ for _ in ()).throw(AssertionError(
+        "brain.ask must NOT be called with research enrichment when SearXNG is down"
+    )))
+
+    tc = TestClient(dashboard.app)
+    r = tc.post("/api/chat/ask", json={"text": "/busca python"})
+    assert r.status_code == 200, f"Expected 200, got {r.status_code}: {r.text}"
+    body = r.json()
+    answer = body.get("answer", "")
+    # Must be a graceful degraded message, not empty
+    assert len(answer) > 0, "Answer should not be empty on degraded path"
+    # Must mention inability to search (Spanish)
+    assert any(word in answer.lower() for word in [
+        "buscar", "busca", "ahora", "momento", "encontré", "encontr", "servicio"
+    ]), f"Expected degraded message, got: {answer}"
+
+
+# ---------------------------------------------------------------------------
+# Task 5.1d — read failure: PageText(ok=False) → still answers from snippets
+# ---------------------------------------------------------------------------
+
+
+def test_read_failure_falls_back_to_snippets(client, monkeypatch):
+    """read_fn returns ok=False → still enriches from snippets, no crash."""
+    import lifeos.web as web_research
+    from axi import brain, dashboard
+
+    captured: dict = {}
+
+    def capturing_ask(prompt: str, **kw):
+        captured["prompt"] = prompt
+        return "Respuesta con snippets."
+
+    web_research.configure(
+        search_fn=lambda q, **kw: [_RESULT_1, _RESULT_2],
+        read_fn=lambda url: _PAGE_FAIL,   # page read fails
+        enabled_fn=lambda: True,
+    )
+    monkeypatch.setattr(dashboard, "_chat_memory", None)
+    monkeypatch.setattr(dashboard, "_chat_memory_lock", None)
+    monkeypatch.setattr(dashboard, "_try_nano_extract", lambda *a, **kw: None)
+    monkeypatch.setattr(brain, "ask", capturing_ask)
+
+    tc = TestClient(dashboard.app)
+    r = tc.post("/api/chat/ask", json={"text": "/busca python"})
+    assert r.status_code == 200
+    body = r.json()
+    assert "answer" in body
+    # Brain must still have been called — from snippets even if page read failed
+    assert "prompt" in captured, "brain.ask was never called"
+    # Snippets from search results should appear in prompt
+    prompt = captured["prompt"]
+    assert "Python async guide" in prompt or "asyncio" in prompt, (
+        f"Snippets not in prompt when read fails: {prompt[:300]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Task 5.1e — guardrail still fires on research path
+# ---------------------------------------------------------------------------
+
+
+def test_guardrail_fires_on_research_answer(client, monkeypatch):
+    """If brain returns a persistence claim after research, guardrail still fires."""
+    import lifeos.web as web_research
+    from axi import brain, dashboard
+
+    web_research.configure(
+        search_fn=lambda q, **kw: [_RESULT_1],
+        read_fn=lambda url: _PAGE_TEXT,
+        enabled_fn=lambda: True,
+    )
+    monkeypatch.setattr(dashboard, "_chat_memory", None)
+    monkeypatch.setattr(dashboard, "_chat_memory_lock", None)
+    monkeypatch.setattr(dashboard, "_try_nano_extract", lambda *a, **kw: None)
+
+    # Brain claims to have persisted something — guardrail must intercept this
+    monkeypatch.setattr(brain, "ask", lambda p, **kw: "Anotado y registré tu búsqueda en la base de datos.")
+
+    tc = TestClient(dashboard.app)
+    r = tc.post("/api/chat/ask", json={"text": "/busca python"})
+    assert r.status_code == 200
+    body = r.json()
+    answer = body.get("answer", "")
+    # The guardrail must have replaced the persistence-claim answer
+    assert "registré" not in answer or "Anotado" not in answer, (
+        f"Guardrail did NOT fire on research path — answer was: {answer}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Task 5.1f — non-command chat is UNAFFECTED (regression guard)
+# ---------------------------------------------------------------------------
+
+
+def test_non_research_message_unaffected(client, monkeypatch):
+    """A plain message does NOT trigger search — existing flow unchanged."""
+    import lifeos.web as web_research
+    from axi import brain, dashboard
+
+    search_called = []
+
+    web_research.configure(
+        search_fn=lambda q, **kw: search_called.append(q) or [],
+        read_fn=lambda url: _PAGE_FAIL,
+        enabled_fn=lambda: True,
+    )
+    monkeypatch.setattr(dashboard, "_chat_memory", None)
+    monkeypatch.setattr(dashboard, "_chat_memory_lock", None)
+    monkeypatch.setattr(dashboard, "_try_nano_extract", lambda *a, **kw: None)
+    monkeypatch.setattr(brain, "ask", lambda p, **kw: "respuesta normal")
+
+    tc = TestClient(dashboard.app)
+    r = tc.post("/api/chat/ask", json={"text": "hola, ¿cómo estás?"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["answer"] == "respuesta normal"
+    assert search_called == [], f"search_fn was called on a non-research message: {search_called}"


### PR DESCRIPTION
Second slice of **axi-web-research** (PR 2 of 2, stacked on PR 1 #135 which is merged). Wires the pure `lifeos/web/` port into the Axi dashboard chat: a private **research-then-answer** flow.

## What's here
- **Lifespan wiring** (`dashboard.py`): builds `SearXNGAdapter(base_url=SEARXNG_URL)` and calls `lifeos.web.configure(search_fn, read_fn, enabled_fn)`, mirroring `autonomous_cron.configure`. `axi` owns config; `lifeos` stays axi-free.
- **`/busca <query>` and `/investiga <query>`** chat branch (routed at the top of the handler, before domain fast-paths so explicit commands aren't intercepted): search → read top result → enrich the brain prompt with bounded results → brain answers → deterministic **`Fuentes:`** URL list appended.
- Config gate `web_research_enabled`.

## Behavior / safety
- **Never 500**: SearXNG down or no hits → graceful Spanish message, brain not called. Read failure → answers from snippets. Brain failure handled.
- **Privacy-first**: only the local SearXNG + the directly-fetched result URLs are contacted. No third-party API.
- **Guardrail**: the `_looks_like_persistence_claim` data-entry guardrail on the normal chat path is byte-unchanged. It is deliberately NOT applied to research answers (nothing is persisted on `/busca` — applying it caused false-positives, e.g. an answer about databases mentioning "registró" being clobbered).
- Degrades gracefully when SearXNG is not yet installed, so this PR is safe to merge before the service is up.

## Tests / review
Strict TDD. 11 research unit tests (mocked search_fn/read_fn/brain — no network). Full axi suite **580 green**. A fresh adversarial review caught and fixed: a guardrail false-positive on the research path (HIGH), a `/buscalo` command-hijack regex bug (MEDIUM), regex-in-hot-path, and duplicated query in the prompt — all RED→GREEN.

## Remaining follow-up (not in this PR)
Install + run SearXNG as a local service (no AUR helper on the machine yet → needs an install-path decision + sudo). Until then `/busca` returns the graceful degraded message.

## Non-goals (later slices)
Images, browser automation, YouTube transcription, agentic multi-step tool-use.