### PR TITLE
fix(web): send browser User-Agent in fetch.read (real pages returned empty)

### DIFF
--- a/lifeos/src/lifeos/web/fetch.py
+++ b/lifeos/src/lifeos/web/fetch.py
@@ -18,6 +18,15 @@ from lifeos.web.port import FETCH_TIMEOUT, MAX_PAGE_BYTES, MAX_PAGE_CHARS, PageT
 
 log = logging.getLogger("lifeos.web.fetch")
 
+# A realistic desktop User-Agent. Many sites (Wikipedia, python.org, news
+# outlets) serve a block/consent page or 403 to the default "Python-urllib/x.y"
+# agent, which leaves trafilatura nothing to extract. A standard browser UA
+# gets the real article HTML.
+_USER_AGENT = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/124.0 Safari/537.36"
+)
+
 
 def read(
     url: str,
@@ -39,7 +48,7 @@ def read(
         PageText(url, "", ok=False)   on any fetch/extraction failure.
     """
     try:
-        req = urllib.request.Request(url)
+        req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
         with urlopen(req, timeout=timeout) as resp:
             raw = resp.read(max_bytes)
     except (urllib.error.URLError, TimeoutError, OSError) as exc:

--- a/lifeos/tests/test_web_fetch.py
+++ b/lifeos/tests/test_web_fetch.py
@@ -91,6 +91,32 @@ def test_read_non_html_empty_extraction(monkeypatch):
     assert result.text == ""
 
 
+def test_read_sends_browser_user_agent(monkeypatch):
+    """read() must send a real browser User-Agent.
+
+    Many sites (Wikipedia, python.org, news outlets) serve a block/consent
+    page or 403 to the default ``Python-urllib/x.y`` agent, leaving
+    trafilatura nothing to extract. Caught only by real end-to-end fetching;
+    the mocked transport never exercised request headers before.
+    """
+    import lifeos.web.fetch as fetch_mod
+    import trafilatura
+
+    monkeypatch.setattr(trafilatura, "extract", lambda html, **kw: "text")  # noqa: ARG005
+
+    captured: dict[str, str | None] = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["ua"] = req.get_header("User-agent")
+        return _FakeResp(FAKE_HTML)
+
+    fetch_mod.read("http://example.com", urlopen=fake_urlopen)
+
+    ua = captured["ua"]
+    assert ua, "read() sent no User-Agent header"
+    assert "python-urllib" not in ua.lower(), "must not use the default urllib UA"
+
+
 def test_read_size_cap(monkeypatch):
     """H2: resp.read() must be called with max_bytes as its argument (bounded call).
 


### PR DESCRIPTION
End-to-end verification with the live SearXNG showed read() returned ok=False for every real page — the default Python-urllib UA gets blocked, so trafilatura extracted nothing. Mocked tests never sent real headers. Adds a desktop User-Agent + a RED test asserting it. Verified: Wikipedia now extracts 3000 chars; landing pages still degrade to snippets as designed.