### PR TITLE
feat(chat): logging-mode toggle — separate data-entry from conversation

### DIFF
--- a/axi/src/axi/dashboard.py
+++ b/axi/src/axi/dashboard.py
@@ -396,23 +396,6 @@ if STATIC_DIR.exists():
 # tells the model not to claim, this code GUARANTEES it doesn't matter
 # if the model still does.
 
-# Phrases that indicate the brain is claiming it persisted something.
-# Curated from observed hallucinations in chat memory.
-_PERSISTENCE_CLAIM_RE = re.compile(
-    r"\b("
-    r"anotad[oa]s?|anot[éeé]|anotando|"
-    r"registrad[oa]s?|registr[éeé]|registrando|"
-    r"guardad[oa]s?|guard[éeé]|guardando|"
-    r"agregad[oa]s?|agregu[ée]|agregando|añadid[oa]s?|añad[íi]|"
-    r"apuntad[oa]s?|apunt[éeé]|apuntando|"
-    r"ya\s+est[áa]\s+(?:en|guardad|registrad|anotad)|"
-    r"lo\s+(?:guard[éeé]|registr[éeé]|anot[éeé]|apunt[éeé]|met[íi]|agregu[éeé])|"
-    r"queda(?:ron)?\s+(?:guardad|registrad|anotad)"
-    r")\b",
-    re.IGNORECASE,
-)
-
-
 # Web research command parser — compiled once at module load.
 # Matches /busca or /investiga followed by whitespace+query OR end-of-string.
 # Requires the command token to end at a word boundary so /buscalo and
@@ -421,14 +404,6 @@ _WEB_CMD_RE = re.compile(
     r"^(/busca|/investiga)(?:\s+(.+))?$",
     re.IGNORECASE | re.DOTALL,
 )
-
-
-def _looks_like_persistence_claim(text: str) -> bool:
-    """True iff `text` claims data was persisted. Used to detect brain
-    hallucinations when the ingestion fast-path actually missed."""
-    if not text:
-        return False
-    return bool(_PERSISTENCE_CLAIM_RE.search(text))
 
 
 # Map of keywords → suggested format. When the user's message contains
@@ -2307,7 +2282,11 @@ async def api_chat_ask(request: Request):
     # When False (default) the big brain converses freely with internet access
     # and WITHOUT the persistence guardrail. Unambiguous regex fast-paths always
     # auto-save regardless of this flag.
-    logging_mode: bool = bool(body.get("logging_mode", False))
+    # F4: only a real JSON boolean True activates logging mode. String "true"
+    # and any other non-bool value are treated as False to prevent the
+    # bool("true") == True footgun (any non-empty string is truthy in Python).
+    _lm = body.get("logging_mode", False)
+    logging_mode: bool = _lm if isinstance(_lm, bool) else False
     # PWA optional fields — captured by the chat UI when the user toggles
     # the corresponding affordances. None when absent. We log them and pass
     # to the relevant domain create() as ad-hoc tag/data fields.
@@ -2392,6 +2371,24 @@ async def api_chat_ask(request: Request):
     # priority over regex classifiers that might misread "busca X" as finance.
     # Degrades gracefully: SearXNG down → friendly Spanish message (HTTP 200).
     _web_cmd_match = _WEB_CMD_RE.match(text)
+    # F3: When logging_mode=True and the user types /busca, return a clear
+    # "internet disabled" message immediately — BEFORE the nano path. Without
+    # this gate, /busca falls through to nano which returns the "couldn't save"
+    # format hint, which is nonsensical for a search command.
+    if _web_cmd_match and not image_b64 and logging_mode:
+        _disabled_msg = (
+            "La búsqueda en internet está deshabilitada en modo registro. "
+            "Cambiá a modo charla (💬) para buscar."
+        )
+        latency_ms = round((time.monotonic() - start) * 1000)
+        try:
+            mem.add(text, _disabled_msg, has_screenshot=False)
+        except Exception:  # noqa: BLE001
+            pass
+        stage_holder[0] = "web_cmd_logging_mode_disabled"
+        _record_metric()
+        return {"answer": _disabled_msg, "latency_ms": latency_ms,
+                "spoke": False, "audio_b64": None}
     # Web research is only available outside logging mode. In logging mode the
     # user is in data-entry mode: no internet, nano agents handle the text.
     if _web_cmd_match and not image_b64 and not logging_mode:
@@ -2518,11 +2515,15 @@ async def api_chat_ask(request: Request):
         # consult using finance history + impulse classification. MUST run
         # BEFORE finance ingestion or "comprar" gets misread as a purchase
         # log.
+        # F2: gate on `not logging_mode` — purchase-consult calls brain.ask
+        # internally (via build_bundle + decide_purchase.consult), which
+        # violates the invariant "brain NOT called in logging mode". In
+        # logging mode the text falls through to the nano/logging path instead.
         try:
             qi = decide_query_parser.parse_query(parse_text)
         except Exception:  # noqa: BLE001
             qi = None
-        if isinstance(qi, decide_query_parser.PurchaseConsultIntent):
+        if isinstance(qi, decide_query_parser.PurchaseConsultIntent) and not logging_mode:
             try:
                 from axi import brain as _brain
                 from lifeos.insights.correlate import build_bundle  # noqa: PLC0415
@@ -3095,12 +3096,13 @@ async def api_chat_ask(request: Request):
                 except (TypeError, ValueError):
                     pass
             answer = brain.ask(text, system=brain_system, history=history, image_b64=image_b64)
-            # NOTE: The persistence guardrail (_looks_like_persistence_claim) is
-            # intentionally NOT applied here. In conversation mode the brain
-            # answers freely and may legitimately use persistence verbs without
-            # having saved anything (e.g., "ya tenés anotado ese plan"). The
-            # guardrail now lives exclusively in the logging_mode=True path where
-            # it serves as the honest "couldn't parse" reply — not a clobber.
+            # NOTE: No persistence guardrail is applied here. In conversation
+            # mode the brain answers freely and may legitimately use words like
+            # "anotado" or "guardé" without having saved anything. The old
+            # guardrail (_looks_like_persistence_claim) has been removed because
+            # it is no longer called anywhere — the logging_mode=True path
+            # returns _suggested_format_message() directly as the honest
+            # "couldn't parse" reply, not a clobber of the brain's answer.
         except Exception as e:  # noqa: BLE001
             log.exception("chat ask failed")
             try:

--- a/axi/src/axi/dashboard.py
+++ b/axi/src/axi/dashboard.py
@@ -2302,6 +2302,12 @@ async def api_chat_ask(request: Request):
     text = (body.get("text") or "").strip()
     image_b64 = body.get("image_b64") or None
     want_speak = bool(body.get("speak", False))
+    # logging_mode: when True the user is in data-entry mode (nano extractor,
+    # no internet, guardrail as honest "couldn't parse" reply).
+    # When False (default) the big brain converses freely with internet access
+    # and WITHOUT the persistence guardrail. Unambiguous regex fast-paths always
+    # auto-save regardless of this flag.
+    logging_mode: bool = bool(body.get("logging_mode", False))
     # PWA optional fields — captured by the chat UI when the user toggles
     # the corresponding affordances. None when absent. We log them and pass
     # to the relevant domain create() as ad-hoc tag/data fields.
@@ -2386,7 +2392,9 @@ async def api_chat_ask(request: Request):
     # priority over regex classifiers that might misread "busca X" as finance.
     # Degrades gracefully: SearXNG down → friendly Spanish message (HTTP 200).
     _web_cmd_match = _WEB_CMD_RE.match(text)
-    if _web_cmd_match and not image_b64:
+    # Web research is only available outside logging mode. In logging mode the
+    # user is in data-entry mode: no internet, nano agents handle the text.
+    if _web_cmd_match and not image_b64 and not logging_mode:
         _web_query = (_web_cmd_match.group(2) or "").strip()
         if not _web_query:
             # Empty query — return a friendly prompt instead of crashing.
@@ -2995,24 +3003,36 @@ async def api_chat_ask(request: Request):
             except Exception as e:  # noqa: BLE001
                 log.warning("lifeos reminder fast-path failed: %s — falling back to brain", e)
 
-    # ─── Nano-agent fallback (BEFORE the main brain) ────────────────
-    # All regex parsers missed. Try the entity extractor (Qwen3.5-0.8B
-    # on port 8090). If it identifies a domain and we successfully
-    # persist, return that. Otherwise fall through to the main brain.
-    # Min-length guard: very short inputs (<12 chars) have no structure
-    # for the extractor to recover and trigger spurious classifications
-    # (the model defaults to "spirituality" on near-empty text). Skip
-    # straight to the brain instead of burning ~4s on noise.
-    if not image_b64 and len(parse_text.strip()) >= 12:
-        try:
-            nano_out = _try_nano_extract(
-                parse_text, location_tag,
-                entry_when=entry_when,
-                original_text=text,
-            )
-        except Exception as e:  # noqa: BLE001
-            log.exception("nano-extract wrapper failed: %s", e)
-            nano_out = None
+    # ─── Fallback routing (logging_mode controls the path) ─────────────
+    #
+    # logging_mode=True  → DATA-ENTRY path: nano extractor first. If nano
+    #   saves something, return that. If nano can't parse, return the honest
+    #   _suggested_format_message (the guardrail is now the legit "couldn't
+    #   parse" reply, not a clobber). Brain is NOT called. No internet.
+    #
+    # logging_mode=False → CONVERSATION path (default): skip nano auto-save,
+    #   go to brain.ask for free conversation. The persistence guardrail is
+    #   NOT applied here — the brain answers freely. Internet is available.
+    #
+    # Invariant: unambiguous regex fast-paths above this block always save
+    # regardless of logging_mode (so Héctor never loses a vital by forgetting
+    # to flip the toggle).
+
+    if logging_mode:
+        # ── Logging mode: nano extractor ──────────────────────────────────
+        # Min-length guard: very short inputs (<12 chars) have no structure
+        # for the extractor to recover and trigger spurious classifications.
+        nano_out = None
+        if not image_b64 and len(parse_text.strip()) >= 12:
+            try:
+                nano_out = _try_nano_extract(
+                    parse_text, location_tag,
+                    entry_when=entry_when,
+                    original_text=text,
+                )
+            except Exception as e:  # noqa: BLE001
+                log.exception("nano-extract wrapper failed: %s", e)
+                nano_out = None
         if nano_out is not None:
             latency_ms = round((time.monotonic() - start) * 1000)
             try:
@@ -3028,57 +3048,66 @@ async def api_chat_ask(request: Request):
                 "nano_domain": nano_out["domain"],
                 "entry_ids": nano_out.get("entry_ids", []),
             }
-
-    try:
-        # If the PWA captured GPS at send time, inject it into the system
-        # prompt so the brain "sees" it instead of denying knowledge. We
-        # only mention it (no reverse-geocoding) — coordinates are private
-        # data and the user can interpret them.
-        brain_system = brain.SYSTEM_PROMPT
-        if raw_location:
-            try:
-                _lat = float(raw_location.get("lat"))
-                _lng = float(raw_location.get("lng"))
-                _acc = raw_location.get("accuracy_m")
-                acc_str = f", precisión ≈{int(_acc)}m" if _acc else ""
-                brain_system = (
-                    brain_system
-                    + f"\n\n--- CONTEXTO EN VIVO (importante) ---\n"
-                    + f"El usuario compartió SU UBICACIÓN ACTUAL desde el dispositivo "
-                    + f"vía GPS del navegador: lat={_lat:.5f}, lng={_lng:.5f}{acc_str}.\n"
-                    + f"Esta información VIENE DIRECTAMENTE del GPS de su dispositivo "
-                    + f"en este momento. NO digas que no tenés acceso — SÍ lo tenés. "
-                    + f"Si te pregunta dónde está, mencioná las coordenadas o decile "
-                    + f"que no podés convertirlas a un nombre de lugar todavía."
-                )
-                log.info("brain: injecting location context (lat=%.5f, lng=%.5f)", _lat, _lng)
-            except (TypeError, ValueError):
-                pass
-        answer = brain.ask(text, system=brain_system, history=history, image_b64=image_b64)
-        # ─── Anti-hallucination guardrail (two-step verification) ──────
-        #
-        # Reaching this code path means NONE of the fast-path ingestion
-        # branches matched. So NOTHING was actually persisted. If the
-        # brain's response nonetheless claims persistence ("anotado",
-        # "registré", "guardé", etc.) it's hallucinating — confusing the
-        # user into thinking data was saved when it wasn't.
-        #
-        # The system prompt already instructs the brain not to do this,
-        # but small models hallucinate anyway. This is the deterministic
-        # guardrail that ALWAYS works regardless of model behavior.
-        if _looks_like_persistence_claim(answer):
-            log.warning(
-                "brain hallucinated persistence claim on text=%r — overriding",
-                text[:120],
-            )
-            answer = _suggested_format_message(text)
-    except Exception as e:  # noqa: BLE001
-        log.exception("chat ask failed")
+        # Nano could not parse anything. Return the honest format hint — this
+        # is now the legitimate logging-mode "couldn't parse" response, not a
+        # guardrail clobber. Brain is NOT called in logging mode.
+        log.info("logging_mode: nano extract returned None for text=%r — returning format hint", text[:80])
+        answer = _suggested_format_message(text)
+        latency_ms = round((time.monotonic() - start) * 1000)
         try:
-            events.log_error("chat", f"brain.ask failed: {e}")
-        except Exception:  # noqa: BLE001
-            pass
-        raise HTTPException(502, f"brain error: {e}")
+            mem.add(text, answer, has_screenshot=False)
+        except Exception as e:  # noqa: BLE001
+            log.warning("chat memory.add failed: %s", e)
+        stage_holder[0] = "logging_mode_no_parse"
+        _record_metric()
+        return {"answer": answer, "latency_ms": latency_ms, "spoke": False, "audio_b64": None}
+
+    else:
+        # ── Conversation mode: brain.ask (no guardrail) ───────────────────
+        # The nano extractor is intentionally skipped here. The user is in
+        # free-conversation mode — routing to nano would silently save data
+        # when the user is only talking, which is the original problem.
+        # The persistence guardrail is also skipped: the brain may incidentally
+        # use words like "anotado"/"registré" in a legitimate conversational
+        # answer (e.g., "ya tenés anotado ese plan de gym"). Clobbering those
+        # answers was the false-positive that motivated this feature.
+        try:
+            # If the PWA captured GPS at send time, inject it into the system
+            # prompt so the brain "sees" it instead of denying knowledge.
+            brain_system = brain.SYSTEM_PROMPT
+            if raw_location:
+                try:
+                    _lat = float(raw_location.get("lat"))
+                    _lng = float(raw_location.get("lng"))
+                    _acc = raw_location.get("accuracy_m")
+                    acc_str = f", precisión ≈{int(_acc)}m" if _acc else ""
+                    brain_system = (
+                        brain_system
+                        + f"\n\n--- CONTEXTO EN VIVO (importante) ---\n"
+                        + f"El usuario compartió SU UBICACIÓN ACTUAL desde el dispositivo "
+                        + f"vía GPS del navegador: lat={_lat:.5f}, lng={_lng:.5f}{acc_str}.\n"
+                        + f"Esta información VIENE DIRECTAMENTE del GPS de su dispositivo "
+                        + f"en este momento. NO digas que no tenés acceso — SÍ lo tenés. "
+                        + f"Si te pregunta dónde está, mencioná las coordenadas o decile "
+                        + f"que no podés convertirlas a un nombre de lugar todavía."
+                    )
+                    log.info("brain: injecting location context (lat=%.5f, lng=%.5f)", _lat, _lng)
+                except (TypeError, ValueError):
+                    pass
+            answer = brain.ask(text, system=brain_system, history=history, image_b64=image_b64)
+            # NOTE: The persistence guardrail (_looks_like_persistence_claim) is
+            # intentionally NOT applied here. In conversation mode the brain
+            # answers freely and may legitimately use persistence verbs without
+            # having saved anything (e.g., "ya tenés anotado ese plan"). The
+            # guardrail now lives exclusively in the logging_mode=True path where
+            # it serves as the honest "couldn't parse" reply — not a clobber.
+        except Exception as e:  # noqa: BLE001
+            log.exception("chat ask failed")
+            try:
+                events.log_error("chat", f"brain.ask failed: {e}")
+            except Exception:  # noqa: BLE001
+                pass
+            raise HTTPException(502, f"brain error: {e}")
     latency_ms = round((time.monotonic() - start) * 1000)
     try:
         # Tag the stored user turn so history rendering can show the image

--- a/axi/src/axi/templates/chat.html
+++ b/axi/src/axi/templates/chat.html
@@ -237,6 +237,28 @@
       >
         <span x-text="speakOn ? '🔊' : '🔇'"></span>
       </button>
+      <!-- Logging mode toggle. ON = data-entry (nano agents, no internet).
+           OFF (default) = free conversation with the big brain. -->
+      <button
+        type="button"
+        @click="toggleLoggingMode()"
+        :disabled="pending"
+        class="btn"
+        :style="loggingMode
+          ? 'min-height: 2.5rem; min-width: 2.75rem; background: rgba(255,107,157,0.2); border-color: var(--pink, #ff6b9d);'
+          : 'min-height: 2.5rem; min-width: 2.75rem;'"
+        :title="loggingMode
+          ? 'Modo registro ON — guardando datos (nano). Clic para cambiar a charla.'
+          : 'Modo charla — hablando con Axi. Clic para cambiar a registro de datos.'"
+      >
+        <span x-text="loggingMode ? '💾' : '💬'"></span>
+      </button>
+    </div>
+    <!-- Mode hint strip -->
+    <div x-show="loggingMode" x-cloak
+         class="text-xs muted mb-1 px-1"
+         style="color: var(--pink, #ff6b9d);">
+      Modo registro — los nano-agentes guardan tus datos. Sin internet.
     </div>
 
     <form @submit.prevent="send()" class="flex gap-2 items-end">
@@ -273,6 +295,7 @@ function chatApp() {
     loading: true,
     error: null,
     lastLatencyMs: null,
+    loggingMode: false,   // true = registro de datos; false = charla libre
 
     // Multimodal state
     pendingImage: null,    // base64 PNG to attach to next /api/chat/ask
@@ -300,6 +323,8 @@ function chatApp() {
         this.speakOn = stored === '1';
         const locStored = localStorage.getItem('axi_chat_location');
         this.locationOn = locStored === '1';
+        const logStored = localStorage.getItem('axi_chat_logging_mode');
+        this.loggingMode = logStored === '1';
       } catch (e) { /* private mode etc. */ }
       await this.loadHistory();
       // CRITICAL: restore any pending/error items from IDB queue as
@@ -633,6 +658,12 @@ function chatApp() {
       try { localStorage.setItem('axi_chat_speak', this.speakOn ? '1' : '0'); } catch (e) {}
     },
 
+    toggleLoggingMode() {
+      this.loggingMode = !this.loggingMode;
+      try { localStorage.setItem('axi_chat_logging_mode', this.loggingMode ? '1' : '0'); } catch (e) {}
+      if (navigator.vibrate) navigator.vibrate(30);
+    },
+
     async captureScreen() {
       if (this.capturing) return;
       this.capturing = 'screen';
@@ -826,6 +857,7 @@ function chatApp() {
             speak: this.speakOn,
             location: location || undefined,
             client_ts: new Date().toISOString(),
+            logging_mode: this.loggingMode,
           }),
         });
         if (!r.ok) {

--- a/axi/src/axi/templates/chat.html
+++ b/axi/src/axi/templates/chat.html
@@ -238,7 +238,9 @@
         <span x-text="speakOn ? '🔊' : '🔇'"></span>
       </button>
       <!-- Logging mode toggle. ON = data-entry (nano agents, no internet).
-           OFF (default) = free conversation with the big brain. -->
+           OFF (default) = free conversation with the big brain.
+           F1: tooltips and hint strip clearly explain what each mode does and
+           what data is (or is not) saved automatically. -->
       <button
         type="button"
         @click="toggleLoggingMode()"
@@ -248,17 +250,22 @@
           ? 'min-height: 2.5rem; min-width: 2.75rem; background: rgba(255,107,157,0.2); border-color: var(--pink, #ff6b9d);'
           : 'min-height: 2.5rem; min-width: 2.75rem;'"
         :title="loggingMode
-          ? 'Modo registro ON — guardando datos (nano). Clic para cambiar a charla.'
-          : 'Modo charla — hablando con Axi. Clic para cambiar a registro de datos.'"
+          ? '💾 Modo registro activo — Sin internet · nano-agentes guardan tus datos estructurados. Clic para volver a modo charla (💬).'
+          : '💬 Modo charla — hablás con Axi (con internet). Solo datos con formato claro (presión 120/80, glucosa 95) se guardan solos. Para registrar otros datos activá 💾 Modo registro.'"
       >
         <span x-text="loggingMode ? '💾' : '💬'"></span>
       </button>
     </div>
-    <!-- Mode hint strip -->
+    <!-- Mode hint strip: shown in charla mode (default) to explain the design;
+         also shown in registro mode to confirm the active state. -->
     <div x-show="loggingMode" x-cloak
-         class="text-xs muted mb-1 px-1"
+         class="text-xs mb-1 px-1"
          style="color: var(--pink, #ff6b9d);">
-      Modo registro — los nano-agentes guardan tus datos. Sin internet.
+      💾 Modo registro — nano-agentes guardan tus datos. Sin internet. Clic en 💾 para volver a charla.
+    </div>
+    <div x-show="!loggingMode" x-cloak
+         class="text-xs muted mb-1 px-1">
+      💬 Modo charla — hablás con Axi con internet. Solo datos con formato claro (ej: presión 120/80, glucosa 95) se guardan automáticamente. Para registrar otros datos, activá 💾.
     </div>
 
     <form @submit.prevent="send()" class="flex gap-2 items-end">
@@ -323,8 +330,11 @@ function chatApp() {
         this.speakOn = stored === '1';
         const locStored = localStorage.getItem('axi_chat_location');
         this.locationOn = locStored === '1';
-        const logStored = localStorage.getItem('axi_chat_logging_mode');
-        this.loggingMode = logStored === '1';
+        // F5: logging mode is intentionally NOT restored from localStorage.
+        // It defaults to OFF (charla) on every fresh page load. This prevents
+        // the "zombie logging mode" problem where the user forgets they left it
+        // ON and every future conversation gets routed to nano instead of brain.
+        // Logging mode is a deliberate per-session opt-in gesture.
       } catch (e) { /* private mode etc. */ }
       await this.loadHistory();
       // CRITICAL: restore any pending/error items from IDB queue as
@@ -660,7 +670,8 @@ function chatApp() {
 
     toggleLoggingMode() {
       this.loggingMode = !this.loggingMode;
-      try { localStorage.setItem('axi_chat_logging_mode', this.loggingMode ? '1' : '0'); } catch (e) {}
+      // F5: logging mode is kept in-memory only (not persisted to localStorage).
+      // Every page load starts in charla mode (OFF) — intentional per-session opt-in.
       if (navigator.vibrate) navigator.vibrate(30);
     },
 

--- a/axi/tests/test_health_api.py
+++ b/axi/tests/test_health_api.py
@@ -567,6 +567,8 @@ def test_chat_ask_client_ts_persists_as_entry_when(client, monkeypatch, health_i
     r = client.post("/api/chat/ask", json={
         "text": "glucosa en 95 esta mañana",
         "client_ts": past_ts,
+        # Nano extractor only runs in logging_mode=True (data-entry mode).
+        "logging_mode": True,
     })
     assert r.status_code == 200
 
@@ -603,6 +605,8 @@ def test_chat_ask_client_ts_future_is_rejected(client, monkeypatch, health_isola
     r = client.post("/api/chat/ask", json={
         "text": "glucosa en 80 esta mañana",
         "client_ts": future_ts,
+        # Nano extractor only runs in logging_mode=True.
+        "logging_mode": True,
     })
     assert r.status_code == 200
 

--- a/axi/tests/test_logging_mode_toggle.py
+++ b/axi/tests/test_logging_mode_toggle.py
@@ -7,6 +7,10 @@ Behavioral contract under test:
 - logging_mode True → logging mode (nano extractor first, guardrail as honest reply)
 - Unambiguous regex fast-paths always save regardless of toggle
 - Web research (/busca) only available when logging_mode is False
+- Purchase-consult fast-path must NOT call brain.ask when logging_mode=True (F2)
+- /busca in logging_mode=True returns a clear disabled message (F3)
+- logging_mode coercion: only JSON bool True counts as True (F4)
+- Regex fast-path actually persists an entry in the DB (F6)
 """
 from __future__ import annotations
 
@@ -343,4 +347,261 @@ def test_logging_mode_absent_defaults_to_conversation(monkeypatch):
     assert body["answer"] == answer_with_persistence_verb, (
         f"Absent logging_mode should default to conversation (no guardrail). "
         f"Got: {body['answer']!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# F2 — Purchase-consult fast-path must NOT call brain in logging_mode=True
+# ---------------------------------------------------------------------------
+
+
+def test_purchase_consult_skipped_in_logging_mode(monkeypatch):
+    """logging_mode=True + purchase-consult query → brain.ask NOT called.
+
+    F2 fix: the purchase-consult branch must be gated on `not logging_mode`.
+    """
+    from axi import brain, dashboard
+    import lifeos.web as web_research
+
+    monkeypatch.setattr(dashboard, "_chat_memory", None)
+    monkeypatch.setattr(dashboard, "_chat_memory_lock", None)
+    monkeypatch.setattr(dashboard, "_try_nano_extract", lambda *a, **kw: None)
+    monkeypatch.setattr(web_research, "_search_fn", None)
+    monkeypatch.setattr(web_research, "_read_fn", None)
+    monkeypatch.setattr(web_research, "_enabled_fn", None)
+
+    brain_called = []
+    consult_called = []
+
+    monkeypatch.setattr(brain, "ask", lambda p, **kw: (brain_called.append(p), "brain")[1])
+
+    # Also patch decide_purchase.consult so we can track it independently
+    from lifeos.decide import purchase as decide_purchase
+    real_consult = decide_purchase.consult
+
+    def tracking_consult(*a, **kw):
+        consult_called.append(a)
+        return real_consult(*a, **kw)
+
+    monkeypatch.setattr(decide_purchase, "consult", tracking_consult)
+
+    tc = TestClient(dashboard.app)
+    r = tc.post("/api/chat/ask", json={
+        "text": "¿puedo comprar una bici?",
+        "logging_mode": True,
+    })
+    assert r.status_code == 200
+    assert not brain_called, (
+        f"brain.ask was called in logging_mode=True for purchase query — must NOT be. "
+        f"Prompts: {brain_called[:1]}"
+    )
+    assert not consult_called, (
+        f"decide_purchase.consult was called in logging_mode=True — must NOT be."
+    )
+
+
+def test_purchase_consult_works_in_conversation_mode(monkeypatch):
+    """logging_mode=False + purchase-consult query → consult STILL works (unchanged).
+
+    F2 fix regression guard: gating on logging_mode must not break conv mode.
+    """
+    from axi import brain, dashboard
+    import lifeos.web as web_research
+    from lifeos.decide import purchase as decide_purchase
+    from lifeos.decide.purchase import PurchaseConsultResult, PurchaseContext
+
+    monkeypatch.setattr(dashboard, "_chat_memory", None)
+    monkeypatch.setattr(dashboard, "_chat_memory_lock", None)
+    monkeypatch.setattr(dashboard, "_try_nano_extract", lambda *a, **kw: None)
+    monkeypatch.setattr(web_research, "_search_fn", None)
+    monkeypatch.setattr(web_research, "_read_fn", None)
+    monkeypatch.setattr(web_research, "_enabled_fn", None)
+
+    consult_called = []
+
+    def fake_consult(item, brain_ask, language, bundle=None):
+        consult_called.append(item)
+        return PurchaseConsultResult(
+            answer="Parece una compra planeada. Adelante.",
+            citations=[],
+            context=PurchaseContext(
+                item=item, summary_30d={},
+                impulsive_ratio=0.1, classified_total=5,
+            ),
+        )
+
+    monkeypatch.setattr(decide_purchase, "consult", fake_consult)
+    monkeypatch.setattr(brain, "ask", lambda p, **kw: "brain fallback")
+
+    tc = TestClient(dashboard.app)
+    r = tc.post("/api/chat/ask", json={
+        "text": "¿puedo comprar una bici?",
+        "logging_mode": False,
+    })
+    assert r.status_code == 200
+    # consult may or may not be called depending on parse_query result —
+    # what matters is the response is 200 and the brain path is not broken.
+    # If parse_query doesn't classify it as PurchaseConsultIntent, consult
+    # won't be called, but we verify the REQUEST succeeds and brain is available.
+    body = r.json()
+    assert "answer" in body
+
+
+# ---------------------------------------------------------------------------
+# F3 — /busca in logging_mode=True returns clear "disabled" message
+# ---------------------------------------------------------------------------
+
+
+def test_busca_in_logging_mode_returns_disabled_message(monkeypatch):
+    """logging_mode=True + /busca → returns explicit disabled message; search NOT called.
+
+    F3 fix: add early return before nano path for web commands in logging mode.
+    """
+    from axi import brain, dashboard
+    import lifeos.web as web_research
+
+    monkeypatch.setattr(dashboard, "_chat_memory", None)
+    monkeypatch.setattr(dashboard, "_chat_memory_lock", None)
+    monkeypatch.setattr(dashboard, "_try_nano_extract", lambda *a, **kw: None)
+
+    search_called = []
+    web_research.configure(
+        search_fn=lambda q, **kw: (search_called.append(q), []),
+        read_fn=lambda url: __import__("lifeos.web.port", fromlist=["PageText"]).PageText(
+            url=url, text="", ok=False
+        ),
+        enabled_fn=lambda: True,
+    )
+
+    brain_called = []
+    monkeypatch.setattr(brain, "ask", lambda p, **kw: (brain_called.append(p), "brain")[1])
+
+    tc = TestClient(dashboard.app)
+    r = tc.post("/api/chat/ask", json={
+        "text": "/busca noticias",
+        "logging_mode": True,
+    })
+    assert r.status_code == 200
+    body = r.json()
+    assert not search_called, "search_fn must NOT be called in logging mode"
+    assert not brain_called, "brain.ask must NOT be called in logging mode"
+    answer = body.get("answer", "")
+    # Must contain the clear disabled message (not the nano format-hint fallback)
+    assert "búsqueda" in answer.lower() or "busca" in answer.lower() or "internet" in answer.lower(), (
+        f"Expected internet-disabled message for /busca in logging mode, got: {answer!r}"
+    )
+    assert "modo registro" in answer.lower() or "registro" in answer.lower(), (
+        f"Expected mention of logging mode in disabled message, got: {answer!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# F4 — logging_mode coercion: string "true" must NOT be treated as True
+# ---------------------------------------------------------------------------
+
+
+def test_logging_mode_string_true_treated_as_false(monkeypatch):
+    """body with logging_mode='true' (string) → conversation mode (treated as False).
+
+    F4 fix: use isinstance check instead of bool() coercion.
+    """
+    from axi import brain, dashboard
+    import lifeos.web as web_research
+
+    monkeypatch.setattr(dashboard, "_chat_memory", None)
+    monkeypatch.setattr(dashboard, "_chat_memory_lock", None)
+    monkeypatch.setattr(dashboard, "_try_nano_extract", lambda *a, **kw: None)
+    monkeypatch.setattr(web_research, "_search_fn", None)
+    monkeypatch.setattr(web_research, "_read_fn", None)
+    monkeypatch.setattr(web_research, "_enabled_fn", None)
+
+    brain_called = []
+    monkeypatch.setattr(brain, "ask", lambda p, **kw: (brain_called.append(p), "from brain")[1])
+
+    tc = TestClient(dashboard.app)
+    # logging_mode is a STRING "true" — must be treated as False (conversation)
+    r = tc.post("/api/chat/ask", json={
+        "text": "me siento cansado hoy",
+        "logging_mode": "true",
+    })
+    assert r.status_code == 200
+    # Brain must be called because string "true" → False (conversation mode)
+    assert brain_called, (
+        "String 'true' for logging_mode must be coerced to False (conversation). "
+        "brain.ask should have been called."
+    )
+
+
+def test_logging_mode_bool_true_activates_logging(monkeypatch):
+    """body with logging_mode=true (JSON bool) → logging mode active.
+
+    F4 fix regression guard: real JSON bool True still works correctly.
+    """
+    from axi import brain, dashboard
+    import lifeos.web as web_research
+
+    monkeypatch.setattr(dashboard, "_chat_memory", None)
+    monkeypatch.setattr(dashboard, "_chat_memory_lock", None)
+    monkeypatch.setattr(dashboard, "_try_nano_extract", lambda *a, **kw: None)
+    monkeypatch.setattr(web_research, "_search_fn", None)
+    monkeypatch.setattr(web_research, "_read_fn", None)
+    monkeypatch.setattr(web_research, "_enabled_fn", None)
+
+    brain_called = []
+    monkeypatch.setattr(brain, "ask", lambda p, **kw: (brain_called.append(p), "from brain")[1])
+
+    tc = TestClient(dashboard.app)
+    r = tc.post("/api/chat/ask", json={
+        "text": "me siento cansado hoy en el trabajo y en casa también vivo así",
+        "logging_mode": True,  # JSON bool True
+    })
+    assert r.status_code == 200
+    # Brain must NOT be called in logging mode with a real bool True
+    assert not brain_called, (
+        "JSON bool True for logging_mode must activate logging mode. "
+        "brain.ask must NOT be called."
+    )
+
+
+# ---------------------------------------------------------------------------
+# F6 — Regex fast-path actually writes a DB entry (not just returns text)
+# ---------------------------------------------------------------------------
+
+
+def test_health_regex_fastpath_persists_entry(monkeypatch, tmp_path):
+    """logging_mode=False + 'presión 120/80' → a health entry is actually created.
+
+    F6 fix: harden the hollow test to verify the store write happened.
+    """
+    from axi import brain, dashboard
+
+    # Isolate the health DB
+    db_path = tmp_path / "health-test-f6.db"
+    key_path = tmp_path / "health-test-f6.key"
+    monkeypatch.setenv("LIFEOS_HEALTH_DB_PATH", str(db_path))
+    monkeypatch.setenv("LIFEOS_HEALTH_KEY_PATH", str(key_path))
+    from lifeos.health import store as health_store
+    health_store.apply_migrations()
+
+    monkeypatch.setattr(dashboard, "_chat_memory", None)
+    monkeypatch.setattr(dashboard, "_chat_memory_lock", None)
+    monkeypatch.setattr(dashboard, "_try_nano_extract", lambda *a, **kw: None)
+
+    brain_called = []
+    monkeypatch.setattr(brain, "ask", lambda p, **kw: (brain_called.append(p), "fallback")[1])
+
+    tc = TestClient(dashboard.app)
+    r = tc.post("/api/chat/ask", json={
+        "text": "presión 120/80",
+        "logging_mode": False,
+    })
+    assert r.status_code == 200
+    assert not brain_called, "brain.ask must NOT be called for 'presión 120/80' regex fast-path"
+
+    # Verify the entry was actually persisted
+    from lifeos.health import entries as health_entries
+    recent = health_entries.list_recent(days=1)
+    assert len(recent) >= 1, (
+        f"Expected at least one health entry after 'presión 120/80', got {len(recent)}. "
+        "The regex fast-path must actually persist to the DB."
     )

--- a/axi/tests/test_logging_mode_toggle.py
+++ b/axi/tests/test_logging_mode_toggle.py
@@ -1,0 +1,346 @@
+"""Tests for the logging_mode toggle in /api/chat/ask.
+
+Strict TDD (RED→GREEN). All external services are mocked.
+
+Behavioral contract under test:
+- logging_mode absent or False → conversation mode (brain.ask free, no guardrail)
+- logging_mode True → logging mode (nano extractor first, guardrail as honest reply)
+- Unambiguous regex fast-paths always save regardless of toggle
+- Web research (/busca) only available when logging_mode is False
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def client_base(monkeypatch):
+    """Base client with memory/lock reset and nano extractor disabled."""
+    from axi import dashboard
+
+    monkeypatch.setattr(dashboard, "_chat_memory", None)
+    monkeypatch.setattr(dashboard, "_chat_memory_lock", None)
+    # Disable nano by default; individual tests override as needed.
+    monkeypatch.setattr(dashboard, "_try_nano_extract", lambda *a, **kw: None)
+    return monkeypatch
+
+
+@pytest.fixture
+def conv_client(client_base, monkeypatch):
+    """TestClient for conversation-mode tests. Brain is mocked."""
+    from axi import brain, dashboard
+    import lifeos.web as web_research
+
+    # Reset web research so it doesn't accidentally gate
+    monkeypatch.setattr(web_research, "_search_fn", None)
+    monkeypatch.setattr(web_research, "_read_fn", None)
+    monkeypatch.setattr(web_research, "_enabled_fn", None)
+
+    monkeypatch.setattr(brain, "ask", lambda prompt, **kw: "respuesta libre del brain")
+    return TestClient(dashboard.app)
+
+
+# ---------------------------------------------------------------------------
+# T1 — logging_mode=False (default): brain answers freely, no guardrail
+# ---------------------------------------------------------------------------
+
+
+def test_conversation_mode_brain_returns_persistence_word_unchanged(conv_client, monkeypatch):
+    """logging_mode=False + brain returns 'anotado' → answer NOT clobbered.
+
+    This is the exact regression: Héctor asked for a gym routine; the brain
+    non-deterministically used 'anotado' and the guardrail replaced it with
+    the canned 'no pude registrar' message.
+    """
+    from axi import brain
+
+    gym_answer = (
+        "Te recomiendo este plan de gym: Lunes pecho, martes espalda. "
+        "Ya lo tenés anotado como referencia."
+    )
+    monkeypatch.setattr(brain, "ask", lambda prompt, **kw: gym_answer)
+
+    r = conv_client.post("/api/chat/ask", json={
+        "text": "dame una rutina de gym",
+        "logging_mode": False,
+    })
+    assert r.status_code == 200
+    body = r.json()
+    # The full brain answer must be returned unchanged — guardrail must NOT fire.
+    assert body["answer"] == gym_answer, (
+        f"Guardrail fired in conversation mode — clobbered answer.\n"
+        f"Expected: {gym_answer!r}\nGot: {body['answer']!r}"
+    )
+
+
+def test_conversation_mode_default_no_logging_mode_field(conv_client, monkeypatch):
+    """logging_mode absent in body → defaults to False (conversation mode).
+
+    Guardrail must NOT fire even if brain answer contains persistence words.
+    """
+    from axi import brain
+
+    answer_with_persistence = "Guardé esto en mi memoria para futuras consultas."
+    monkeypatch.setattr(brain, "ask", lambda prompt, **kw: answer_with_persistence)
+
+    r = conv_client.post("/api/chat/ask", json={
+        "text": "recuerda que prefiero el gym los lunes",
+    })
+    assert r.status_code == 200
+    body = r.json()
+    assert body["answer"] == answer_with_persistence, (
+        f"Default mode should be conversation (no guardrail). Got: {body['answer']!r}"
+    )
+
+
+def test_conversation_mode_brain_is_called(conv_client, monkeypatch):
+    """logging_mode=False → brain.ask MUST be called for ambiguous messages."""
+    from axi import brain
+
+    brain_called = []
+
+    def tracking_brain(prompt, **kw):
+        brain_called.append(prompt)
+        return "ok"
+
+    monkeypatch.setattr(brain, "ask", tracking_brain)
+
+    r = conv_client.post("/api/chat/ask", json={
+        "text": "cuéntame sobre machine learning",
+        "logging_mode": False,
+    })
+    assert r.status_code == 200
+    assert brain_called, "brain.ask was NOT called in conversation mode"
+
+
+# ---------------------------------------------------------------------------
+# T2 — logging_mode=False: regex fast-path still auto-saves (always-on rule)
+# ---------------------------------------------------------------------------
+
+
+def test_conversation_mode_health_regex_still_saves(monkeypatch):
+    """logging_mode=False + 'presión 120/80' → regex fast-path fires, saved.
+
+    Unambiguous structured input ALWAYS auto-saves regardless of toggle.
+    """
+    from axi import brain, dashboard
+
+    brain_called = []
+    monkeypatch.setattr(dashboard, "_chat_memory", None)
+    monkeypatch.setattr(dashboard, "_chat_memory_lock", None)
+    monkeypatch.setattr(dashboard, "_try_nano_extract", lambda *a, **kw: None)
+    monkeypatch.setattr(brain, "ask", lambda p, **kw: (brain_called.append(p), "fallback")[1])
+
+    tc = TestClient(dashboard.app)
+    r = tc.post("/api/chat/ask", json={
+        "text": "presión 120/80",
+        "logging_mode": False,
+    })
+    # The regex fast-path should have handled this (health domain)
+    assert r.status_code == 200
+    body = r.json()
+    # Health fast-path returns an "anotado" confirmation — brain NOT called
+    assert not brain_called, (
+        f"brain.ask called for 'presión 120/80' — should have been handled by regex fast-path. "
+        f"brain prompts: {brain_called[:1]}"
+    )
+    # The answer should be a health confirmation, not a conversation answer
+    answer = body.get("answer", "")
+    assert any(w in answer.lower() for w in ["salud", "vital", "anotado", "pressure", "presión"]), (
+        f"Regex fast-path answer expected for 'presión 120/80', got: {answer!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# T3 — logging_mode=False: /busca triggers web research
+# ---------------------------------------------------------------------------
+
+
+def test_conversation_mode_busca_triggers_web_research(monkeypatch):
+    """logging_mode=False + /busca → web research IS available."""
+    from axi import brain, dashboard
+    import lifeos.web as web_research
+    from lifeos.web.port import SearchResult
+
+    monkeypatch.setattr(dashboard, "_chat_memory", None)
+    monkeypatch.setattr(dashboard, "_chat_memory_lock", None)
+    monkeypatch.setattr(dashboard, "_try_nano_extract", lambda *a, **kw: None)
+
+    search_called = []
+
+    web_research.configure(
+        search_fn=lambda q, **kw: (search_called.append(q), [
+            SearchResult(title="Python docs", url="https://docs.python.org", snippet="Python docs.")
+        ])[1],
+        read_fn=lambda url: __import__("lifeos.web.port", fromlist=["PageText"]).PageText(
+            url=url, text="", ok=False
+        ),
+        enabled_fn=lambda: True,
+    )
+    monkeypatch.setattr(brain, "ask", lambda p, **kw: "respuesta con fuente")
+
+    tc = TestClient(dashboard.app)
+    r = tc.post("/api/chat/ask", json={
+        "text": "/busca python async",
+        "logging_mode": False,
+    })
+    assert r.status_code == 200
+    assert search_called, "search_fn NOT called — web research unavailable in conversation mode"
+
+
+# ---------------------------------------------------------------------------
+# T4 — logging_mode=True: ambiguous message + nano can't parse → honest reply
+# ---------------------------------------------------------------------------
+
+
+def test_logging_mode_nano_fails_returns_format_message(monkeypatch):
+    """logging_mode=True + nano extractor returns None → _suggested_format_message returned.
+
+    The brain must NOT be called for conversation.
+    """
+    from axi import brain, dashboard
+
+    monkeypatch.setattr(dashboard, "_chat_memory", None)
+    monkeypatch.setattr(dashboard, "_chat_memory_lock", None)
+    # Nano returns None → nothing was parsed/saved
+    monkeypatch.setattr(dashboard, "_try_nano_extract", lambda *a, **kw: None)
+
+    brain_called = []
+    monkeypatch.setattr(brain, "ask", lambda p, **kw: (brain_called.append(p), "SHOULD NOT APPEAR")[1])
+
+    tc = TestClient(dashboard.app)
+    r = tc.post("/api/chat/ask", json={
+        "text": "esto es algo que no parece un dato estructurado en lo absoluto",
+        "logging_mode": True,
+    })
+    assert r.status_code == 200
+    body = r.json()
+    # Brain must NOT be called for conversation in logging mode
+    assert not brain_called, (
+        f"brain.ask was called in logging mode — should NOT be. Prompts: {brain_called[:1]}"
+    )
+    # The response should be the honest "couldn't parse" format message
+    answer = body.get("answer", "")
+    assert len(answer) > 0, "Answer is empty in logging mode nano-fail path"
+    # It should be the format hint message (not a conversational brain answer)
+    assert "SHOULD NOT APPEAR" not in answer, (
+        "Brain answer leaked into logging mode nano-fail response"
+    )
+
+
+def test_logging_mode_nano_saves_returns_nano_answer(monkeypatch):
+    """logging_mode=True + nano extractor succeeds → nano answer returned, brain NOT called.
+
+    Uses text that does NOT match any regex fast-path (no digits, no recognized
+    keywords) so it falls through to the nano extractor.
+    """
+    from axi import brain, dashboard
+
+    monkeypatch.setattr(dashboard, "_chat_memory", None)
+    monkeypatch.setattr(dashboard, "_chat_memory_lock", None)
+
+    nano_answer = "Anotado: nota de salud sin formato estándar."
+    monkeypatch.setattr(dashboard, "_try_nano_extract", lambda *a, **kw: {
+        "answer": nano_answer,
+        "domain": "health",
+        "entry_ids": [42],
+    })
+
+    brain_called = []
+    monkeypatch.setattr(brain, "ask", lambda p, **kw: (brain_called.append(p), "SHOULD NOT APPEAR")[1])
+
+    tc = TestClient(dashboard.app)
+    r = tc.post("/api/chat/ask", json={
+        # Text with no digits and no regex-matched keywords — bypasses all fast-paths
+        "text": "hoy me sentí algo cansado después de caminar bastante",
+        "logging_mode": True,
+    })
+    assert r.status_code == 200
+    body = r.json()
+    assert body["answer"] == nano_answer, (
+        f"Expected nano answer in logging mode, got: {body['answer']!r}"
+    )
+    assert not brain_called, "brain.ask was called — must not in logging mode when nano saves"
+
+
+# ---------------------------------------------------------------------------
+# T5 — logging_mode=True: /busca does NOT trigger web research
+# ---------------------------------------------------------------------------
+
+
+def test_logging_mode_busca_no_web_research(monkeypatch):
+    """logging_mode=True + /busca → web research is DISABLED, falls to logging path."""
+    from axi import brain, dashboard
+    import lifeos.web as web_research
+
+    monkeypatch.setattr(dashboard, "_chat_memory", None)
+    monkeypatch.setattr(dashboard, "_chat_memory_lock", None)
+    monkeypatch.setattr(dashboard, "_try_nano_extract", lambda *a, **kw: None)
+
+    search_called = []
+    web_research.configure(
+        search_fn=lambda q, **kw: (search_called.append(q), []),
+        read_fn=lambda url: __import__("lifeos.web.port", fromlist=["PageText"]).PageText(
+            url=url, text="", ok=False
+        ),
+        enabled_fn=lambda: True,
+    )
+
+    brain_called = []
+    monkeypatch.setattr(brain, "ask", lambda p, **kw: (brain_called.append(p), "brain")[1])
+
+    tc = TestClient(dashboard.app)
+    r = tc.post("/api/chat/ask", json={
+        "text": "/busca python async",
+        "logging_mode": True,
+    })
+    assert r.status_code == 200
+    assert not search_called, (
+        f"search_fn was called in logging mode — internet should be DISABLED. "
+        f"Calls: {search_called}"
+    )
+    # Brain should also NOT be called (logging mode routes to nano/format message)
+    assert not brain_called, (
+        f"brain.ask was called in logging mode — should NOT be. Calls: {brain_called[:1]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# T6 — logging_mode absent defaults to False (regression + API contract)
+# ---------------------------------------------------------------------------
+
+
+def test_logging_mode_absent_defaults_to_conversation(monkeypatch):
+    """logging_mode absent → equivalent to logging_mode=False (conversation mode).
+
+    - Brain is called
+    - Persistence words in brain answer are NOT clobbered
+    """
+    from axi import brain, dashboard
+    import lifeos.web as web_research
+
+    monkeypatch.setattr(dashboard, "_chat_memory", None)
+    monkeypatch.setattr(dashboard, "_chat_memory_lock", None)
+    monkeypatch.setattr(dashboard, "_try_nano_extract", lambda *a, **kw: None)
+    monkeypatch.setattr(web_research, "_search_fn", None)
+    monkeypatch.setattr(web_research, "_read_fn", None)
+    monkeypatch.setattr(web_research, "_enabled_fn", None)
+
+    answer_with_persistence_verb = "Anotado y registré la información en tu perfil."
+    monkeypatch.setattr(brain, "ask", lambda p, **kw: answer_with_persistence_verb)
+
+    tc = TestClient(dashboard.app)
+    # No logging_mode field at all
+    r = tc.post("/api/chat/ask", json={"text": "cómo guardar mis notas"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["answer"] == answer_with_persistence_verb, (
+        f"Absent logging_mode should default to conversation (no guardrail). "
+        f"Got: {body['answer']!r}"
+    )


### PR DESCRIPTION
Fixes the persistence-guardrail false-positive that clobbered conversations (Héctor asked for a gym routine; the brain non-deterministically said "anotado", so the guardrail nuked the reply with a nonsensical blood-pressure format hint).

## The model (Héctor's design)
A chat toggle that separates the two worlds explicitly, killing the ambiguity the guardrail was patching:

| Toggle | Handler | Internet | Saves |
|---|---|---|---|
| **💬 Charla** (default) | big model, free conversation | ✅ on | only unambiguous regex vitals (presión 120/80, glucosa 95) |
| **💾 Registro** | nano extractor, deterministic | ❌ off | structured data; honest "no pude registrar" if it can't parse |

**Invariant**: unambiguous vitals auto-save in BOTH modes — you never lose a vital by forgetting the toggle. The big model always has internet; nano/logging never does.

## What changed
- `dashboard.py`: per-request `logging_mode` (default false) splits `/api/chat/ask` routing. The old `_looks_like_persistence_claim` guardrail is **removed** — the toggle makes it unnecessary.
- `chat.html`: 💬/💾 toggle button, mode hints (charla mode clearly states only fixed-format data auto-saves), in-memory only (no zombie-mode across reloads).

## Tests / review
Strict TDD, 15 toggle tests, full axi suite **595 green**. A fresh adversarial review caught and fixed: brain.ask firing in logging mode via the purchase-consult path (HIGH), `/busca` returning a nonsense message in logging mode, a `bool("true")` coercion footgun, localStorage zombie-mode, and a hollow test on the #1 (always-saves) invariant — all RED→GREEN.