### PR TITLE
feat(graph): wire health domain into semantic graph + fix meeting bridge (slice 1/3)

### DIFF
--- a/axi/src/axi/dashboard.py
+++ b/axi/src/axi/dashboard.py
@@ -2983,6 +2983,11 @@ def _try_nano_extract(
                 source="chat", confidence=result.confidence,
                 raw_utterance=body_text, source_conv_id=None,
             )
+            try:
+                from axi import domain_bridge as _db
+                _db.bridge_entry("health", entry)
+            except Exception:  # noqa: BLE001
+                pass
             if entry_kind == "vital":
                 answer_text = f"Anotado en salud como vital: {entry_title}."
             else:
@@ -3592,6 +3597,11 @@ async def api_chat_ask(request: Request):
                     source="chat", confidence=hi.confidence,
                     raw_utterance=text, source_conv_id=None,
                 )
+                try:
+                    from axi import domain_bridge as _db
+                    _db.bridge_entry("health", entry)
+                except Exception:  # noqa: BLE001
+                    pass
                 lang = str(config.get("language", "es-MX"))
                 kind_label_es = {
                     "symptom": "síntoma", "vital": "vital",
@@ -4548,6 +4558,11 @@ async def api_health_create(request: Request):
         )
     except ValueError as e:
         raise HTTPException(400, str(e))
+    try:
+        from axi import domain_bridge as _db
+        _db.bridge_entry("health", entry)
+    except Exception:  # noqa: BLE001
+        pass
     return _health_entry_to_dict(entry)
 
 

--- a/axi/src/axi/domain_bridge.py
+++ b/axi/src/axi/domain_bridge.py
@@ -45,13 +45,14 @@ def _health_renderer(entry: Any) -> str:
     """Render a health entry to a short node label (≤120 chars).
 
     Priority: raw_utterance → title → structured fallback.
+    Whitespace-only strings are treated as absent (stripped before testing).
     """
     raw = getattr(entry, "raw_utterance", None)
-    if raw:
-        return raw[:120]
+    if raw and raw.strip():
+        return raw.strip()[:120]
     title = getattr(entry, "title", None)
-    if title:
-        return title[:120]
+    if title and title.strip():
+        return title.strip()[:120]
     kind = getattr(entry, "kind", "entry")
     return f"health: {kind}"
 
@@ -59,14 +60,39 @@ def _health_renderer(entry: Any) -> str:
 # ─── domain registry ─────────────────────────────────────────────────────────
 
 
+def _relationships_renderer(entry: Any) -> str:
+    """Render a relationships interaction to a short node label (≤120 chars).
+
+    Priority: raw_utterance → title → structured fallback.
+    """
+    raw = getattr(entry, "raw_utterance", None)
+    if raw and raw.strip():
+        return raw.strip()[:120]
+    title = getattr(entry, "title", None)
+    if title and title.strip():
+        return title.strip()[:120]
+    return f"relationships: {getattr(entry, 'kind', 'interaction')}"
+
+
+def _relationships_extra_data(entry: Any) -> dict:
+    """Extra data fields for relationships nodes (person_id, interaction_id, body)."""
+    data: dict = {
+        "person_id": getattr(entry, "person_id", None),
+        "interaction_id": str(entry.id),
+    }
+    body = getattr(entry, "body", None)
+    if body:
+        data["body"] = body
+    return data
+
+
 _DOMAIN_CONFIGS: dict[str, DomainConfig] = {
     "health": DomainConfig(renderer=_health_renderer),
     # relationships is handled through this bridge as well (Slice 1 shim).
-    "relationships": DomainConfig(renderer=lambda e: (
-        (getattr(e, "raw_utterance", None) or "")[:120]
-        or (getattr(e, "title", None) or "")[:120]
-        or f"relationships: {getattr(e, 'kind', 'interaction')}"
-    )),
+    "relationships": DomainConfig(
+        renderer=_relationships_renderer,
+        extra_data_fn=_relationships_extra_data,
+    ),
 }
 
 

--- a/axi/src/axi/domain_bridge.py
+++ b/axi/src/axi/domain_bridge.py
@@ -1,0 +1,144 @@
+"""Domain bridge: wire lifeos domain entries into the Axi semantic graph.
+
+For every supported domain (health, relationships, …), this module provides:
+- A renderer that converts a domain entry to a short text label suitable for
+  embedding (priority: raw_utterance → title → structured fallback).
+- bridge_entry(domain, entry): idempotent, best-effort realtime bridging.
+  Called immediately after each domain .create() call site.
+- create_fact_node_for_entry(domain, entry): core (raises on error).
+- create_fact_node_for_interaction(interaction): backward-compat shim →
+  create_fact_node_for_entry('relationships', interaction).
+
+Thread safety: all DB writes go through axi.store._tx() (thread-local
+connections). trigger_embed_for_node uses a queue — no connection is shared
+across threads.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Callable
+
+log = logging.getLogger("axi.domain_bridge")
+
+
+# ─── DomainConfig ─────────────────────────────────────────────────────────────
+
+
+@dataclass
+class DomainConfig:
+    """Per-domain configuration for the bridge.
+
+    Attributes:
+        renderer: Pure function (entry) → str used to produce the node label.
+        extra_data_fn: Optional pure function (entry) → dict with extra JSON
+            data to store on the node. None means use an empty dict.
+    """
+    renderer: Callable[[Any], str]
+    extra_data_fn: Callable[[Any], dict] | None = None
+
+
+# ─── renderers ───────────────────────────────────────────────────────────────
+
+
+def _health_renderer(entry: Any) -> str:
+    """Render a health entry to a short node label (≤120 chars).
+
+    Priority: raw_utterance → title → structured fallback.
+    """
+    raw = getattr(entry, "raw_utterance", None)
+    if raw:
+        return raw[:120]
+    title = getattr(entry, "title", None)
+    if title:
+        return title[:120]
+    kind = getattr(entry, "kind", "entry")
+    return f"health: {kind}"
+
+
+# ─── domain registry ─────────────────────────────────────────────────────────
+
+
+_DOMAIN_CONFIGS: dict[str, DomainConfig] = {
+    "health": DomainConfig(renderer=_health_renderer),
+    # relationships is handled through this bridge as well (Slice 1 shim).
+    "relationships": DomainConfig(renderer=lambda e: (
+        (getattr(e, "raw_utterance", None) or "")[:120]
+        or (getattr(e, "title", None) or "")[:120]
+        or f"relationships: {getattr(e, 'kind', 'interaction')}"
+    )),
+}
+
+
+# ─── core: create_fact_node_for_entry ────────────────────────────────────────
+
+
+def create_fact_node_for_entry(domain: str, entry: Any) -> int:
+    """Create a fact node for a domain entry and register it in domain_node_map.
+
+    Steps:
+    1. Check domain_node_map — return existing node_id if already mapped (idempotent).
+    2. Render the node label via the domain's renderer.
+    3. Call store.add_node('fact', label, domain=domain).
+    4. Call store.upsert_domain_node_map(domain, str(entry.id), node_id).
+    5. Call store.trigger_embed_for_node(node_id) (async, non-blocking).
+    6. Return node_id.
+
+    Raises:
+        KeyError: if the domain is not registered in _DOMAIN_CONFIGS.
+        Any exception from store operations propagates (use bridge_entry for
+        best-effort / swallowed errors).
+    """
+    from axi import store
+
+    entry_id = str(entry.id)
+
+    # Idempotency guard: return existing node if already bridged.
+    existing = store.get_node_for_domain_entry(domain, entry_id)
+    if existing is not None:
+        return existing
+
+    cfg = _DOMAIN_CONFIGS[domain]
+    label = cfg.renderer(entry)
+
+    extra: dict[str, Any] = {}
+    if cfg.extra_data_fn is not None:
+        extra = cfg.extra_data_fn(entry)
+
+    node_id = store.add_node("fact", label, data=extra or None, domain=domain)
+    store.upsert_domain_node_map(domain, entry_id, node_id)
+    store.trigger_embed_for_node(node_id)
+    return node_id
+
+
+# ─── best-effort wrapper: bridge_entry ───────────────────────────────────────
+
+
+def bridge_entry(domain: str, entry: Any) -> int | None:
+    """Best-effort wrapper around create_fact_node_for_entry.
+
+    Never raises. Returns the node_id on success, or None if any error occurs.
+    A warning is logged on failure so problems are visible without breaking
+    the caller's write path.
+    """
+    try:
+        return create_fact_node_for_entry(domain, entry)
+    except Exception as exc:  # noqa: BLE001
+        log.warning(
+            "bridge_entry: failed to bridge domain=%r entry=%r: %s",
+            domain, getattr(entry, "id", "<no id>"), exc,
+        )
+        return None
+
+
+# ─── backward-compat shim ────────────────────────────────────────────────────
+
+
+def create_fact_node_for_interaction(interaction: Any) -> int:
+    """Backward-compatible shim: create a fact node for a relationships interaction.
+
+    Delegates to create_fact_node_for_entry('relationships', interaction).
+    Callers that imported this name from axi.store can migrate to importing
+    from axi.domain_bridge instead.
+    """
+    return create_fact_node_for_entry("relationships", interaction)

--- a/axi/src/axi/mcp_tools.py
+++ b/axi/src/axi/mcp_tools.py
@@ -122,6 +122,10 @@ def log_health_entry(
     """Record a health entry. kind is one of symptom|medication|vital|
     condition|note."""
     from lifeos.health import entries as he
-    return _jsonable(
-        he.create(kind=kind, title=title, when=_parse_when(when_iso), body=body)
-    )
+    entry = he.create(kind=kind, title=title, when=_parse_when(when_iso), body=body)
+    try:
+        from axi import domain_bridge as _db
+        _db.bridge_entry("health", entry)
+    except Exception:  # noqa: BLE001
+        pass
+    return _jsonable(entry)

--- a/axi/src/axi/meeting.py
+++ b/axi/src/axi/meeting.py
@@ -968,6 +968,29 @@ def process_meeting(meeting_id: int, transcriber, brain_ask, session: "MeetingSe
         )
     log.info("meeting %d %s: %d segments, summary %d chars", meeting_id, final_status, len(segments), len(summary))
 
+    # Bridge the meeting into the semantic graph so linkers can include it.
+    # Only runs when summary is available and node_id not yet set (idempotent).
+    if summary:
+        try:
+            _conn = store._connect()  # noqa: SLF001
+            existing_node = _conn.execute(
+                "SELECT node_id FROM meetings WHERE id=?", (meeting_id,)
+            ).fetchone()
+            if existing_node is not None and existing_node[0] is None:
+                label = summary[:120]
+                nid = store.add_node(
+                    "fact", label, data={"meeting_id": meeting_id}, domain="meetings"
+                )
+                with store._tx() as txc:  # noqa: SLF001
+                    txc.execute(
+                        "UPDATE meetings SET node_id=? WHERE id=?",
+                        (nid, meeting_id),
+                    )
+                store.trigger_embed_for_node(nid)
+                log.info("meeting %d bridged to graph node %d", meeting_id, nid)
+        except Exception as _bridge_exc:  # noqa: BLE001
+            log.warning("meeting %d: failed to bridge to graph: %s", meeting_id, _bridge_exc)
+
     # P1.1 — rebuild FTS index for this meeting so /api/meetings/search can find it.
     try:
         n_fts = store.reindex_meeting_segments(meeting_id)

--- a/axi/src/axi/meeting.py
+++ b/axi/src/axi/meeting.py
@@ -818,6 +818,61 @@ def _hierarchical_summary(brain_ask: Callable[..., str], segments: list[tuple[st
     )
 
 
+def bridge_meeting_node(meeting_id: int, summary: str) -> None:
+    """Bridge a meeting into the semantic graph after summarization.
+
+    Creates a fact node (kind='fact', domain='meetings') and writes the resulting
+    node_id back to meetings.node_id.  Idempotent: if node_id is already set the
+    call is a no-op.
+
+    Race-safety: Uses ``UPDATE … WHERE node_id IS NULL`` as the atomic test-and-set.
+    If two concurrent calls both reach add_node, only the first UPDATE succeeds
+    (rowcount == 1); the second detects rowcount == 0 and deletes the orphan node
+    it created.  This serializes via SQLite's write lock — no SAVEPOINT nesting needed.
+
+    Args:
+        meeting_id: Primary key of the meetings row.
+        summary:    The meeting summary text (used to derive the node label).
+
+    Raises:
+        Exception: Any store error propagates to the caller (use a try/except at
+            the call site for best-effort semantics).
+    """
+    from axi import store as _store
+
+    # Fast-path: if already bridged, skip add_node entirely.
+    _conn = _store._connect()  # noqa: SLF001
+    row = _conn.execute(
+        "SELECT node_id FROM meetings WHERE id=?", (meeting_id,)
+    ).fetchone()
+    if row is None or row[0] is not None:
+        return  # Meeting not found or already has a node_id.
+
+    label = (summary or "meeting")[:120]
+    nid = _store.add_node(
+        "fact", label, data={"meeting_id": meeting_id}, domain="meetings"
+    )
+
+    # Atomic test-and-set: only UPDATE if node_id is still NULL.
+    # If a concurrent call already set node_id, rowcount == 0 → clean up orphan.
+    with _store._tx() as txc:  # noqa: SLF001
+        txc.execute(
+            "UPDATE meetings SET node_id=? WHERE id=? AND node_id IS NULL",
+            (nid, meeting_id),
+        )
+        updated = txc.execute("SELECT changes()").fetchone()[0]
+
+    if updated == 0:
+        # Another concurrent call won the race — remove the orphan node we created.
+        with _store._tx() as txc:  # noqa: SLF001
+            txc.execute("DELETE FROM nodes WHERE id=?", (nid,))
+        return
+
+    _store.trigger_embed_for_node(nid)
+    _log = logging.getLogger("axi.meeting.process")
+    _log.info("meeting %d bridged to graph node %d", meeting_id, nid)
+
+
 def process_meeting(meeting_id: int, transcriber, brain_ask, session: "MeetingSession | None" = None) -> None:
     """Final pass after the meeting stops.
 
@@ -969,25 +1024,10 @@ def process_meeting(meeting_id: int, transcriber, brain_ask, session: "MeetingSe
     log.info("meeting %d %s: %d segments, summary %d chars", meeting_id, final_status, len(segments), len(summary))
 
     # Bridge the meeting into the semantic graph so linkers can include it.
-    # Only runs when summary is available and node_id not yet set (idempotent).
+    # Only runs when summary is available; idempotency + race safety inside bridge_meeting_node.
     if summary:
         try:
-            _conn = store._connect()  # noqa: SLF001
-            existing_node = _conn.execute(
-                "SELECT node_id FROM meetings WHERE id=?", (meeting_id,)
-            ).fetchone()
-            if existing_node is not None and existing_node[0] is None:
-                label = summary[:120]
-                nid = store.add_node(
-                    "fact", label, data={"meeting_id": meeting_id}, domain="meetings"
-                )
-                with store._tx() as txc:  # noqa: SLF001
-                    txc.execute(
-                        "UPDATE meetings SET node_id=? WHERE id=?",
-                        (nid, meeting_id),
-                    )
-                store.trigger_embed_for_node(nid)
-                log.info("meeting %d bridged to graph node %d", meeting_id, nid)
+            bridge_meeting_node(meeting_id, summary)
         except Exception as _bridge_exc:  # noqa: BLE001
             log.warning("meeting %d: failed to bridge to graph: %s", meeting_id, _bridge_exc)
 

--- a/axi/src/axi/store.py
+++ b/axi/src/axi/store.py
@@ -1811,19 +1811,28 @@ def backfill_domain_fact_nodes(
     return processed
 
 
-def backfill_similar_to_edges(*, threshold: float = 0.85) -> int:
+def backfill_similar_to_edges(*, threshold: float = 0.85, node_limit: int | None = None) -> int:
     """Create similar-to edges for all nodes that already have embeddings.
 
     Iterates every node with a non-NULL embedding (that is also present in
     vec_nodes), calling check_and_create_similar_to_edges for each. Idempotent
     via INSERT OR IGNORE in the underlying helper.
 
+    Args:
+        threshold: Minimum cosine similarity for edge creation.
+        node_limit: If set, process at most this many nodes (most-recent first).
+                    None (default) processes all nodes.
+
     Returns the total number of new edges created across all nodes.
     """
     c = _connect()
-    rows = c.execute(
-        "SELECT node_id FROM vec_nodes"
-    ).fetchall()
+    if node_limit is not None:
+        rows = c.execute(
+            "SELECT node_id FROM vec_nodes ORDER BY node_id DESC LIMIT ?",
+            (node_limit,),
+        ).fetchall()
+    else:
+        rows = c.execute("SELECT node_id FROM vec_nodes").fetchall()
 
     total = 0
     for row in rows:

--- a/axi/src/axi/store.py
+++ b/axi/src/axi/store.py
@@ -1626,15 +1626,12 @@ def get_node_for_domain_entry(domain: str, entry_id: str) -> int | None:
 
 
 def create_fact_node_for_interaction(interaction: Any) -> int:
-    """Create a System-A fact node for a lifeos relationships interaction.
+    """Thin shim: create a fact node for a relationships interaction.
 
-    Uses raw_utterance as the node label (truncated to 120 chars).  Falls back
-    to interaction.title if raw_utterance is None or empty.  Tags the node with
-    domain='relationships', registers the (domain, entry_id) → node_id mapping in
-    domain_node_map, and enqueues embedding via trigger_embed_for_node.
-
-    Idempotent: if a mapping already exists for this interaction.id, the existing
-    node_id is returned without creating a new node.
+    Delegates entirely to domain_bridge.create_fact_node_for_entry so there is
+    a single code path for relationships nodes.  Entry ids are always
+    stringified (str(interaction.id)) ensuring the domain_node_map key is
+    consistent whether the id is an int or a string.
 
     Args:
         interaction: any object with .id, .raw_utterance, .title, .body, .person_id
@@ -1642,29 +1639,8 @@ def create_fact_node_for_interaction(interaction: Any) -> int:
     Returns:
         The node_id of the fact node (new or existing).
     """
-    existing = get_node_for_domain_entry("relationships", interaction.id)
-    if existing is not None:
-        return existing
-
-    # Build label: prefer raw_utterance (truncated to 120 chars), then title.
-    raw = getattr(interaction, "raw_utterance", None)
-    label: str
-    if raw:
-        label = raw[:120]
-    else:
-        label = (getattr(interaction, "title", None) or "")[:120]
-
-    data: dict[str, Any] = {
-        "person_id": getattr(interaction, "person_id", None),
-        "interaction_id": interaction.id,
-    }
-    if getattr(interaction, "body", None):
-        data["body"] = interaction.body
-
-    node_id = add_node("fact", label, data=data, domain="relationships")
-    upsert_domain_node_map("relationships", interaction.id, node_id)
-    trigger_embed_for_node(node_id)
-    return node_id
+    from axi.domain_bridge import create_fact_node_for_entry  # noqa: PLC0415
+    return create_fact_node_for_entry("relationships", interaction)
 
 
 # ─────────────────── similar-to auto-edges (Slice 2) ─────────────────────────

--- a/axi/tests/test_domain_bridge.py
+++ b/axi/tests/test_domain_bridge.py
@@ -164,6 +164,45 @@ def test_health_renderer_truncates_to_120():
     assert len(result) <= 120
 
 
+# ─── FIX 5: whitespace-only label guards ────────────────────────────────────
+
+
+def test_health_renderer_whitespace_only_raw_utterance_falls_back():
+    """FIX 5 — whitespace-only raw_utterance must NOT produce a whitespace label."""
+    from axi.domain_bridge import _health_renderer
+
+    entry = HealthEntryStub(raw_utterance="   ", title="real title")
+    result = _health_renderer(entry)
+    assert result.strip() != "", "Renderer must not return whitespace-only label"
+    assert result == "real title", f"Expected fallback to title, got {result!r}"
+
+
+def test_health_renderer_whitespace_only_title_falls_back_to_structured():
+    """FIX 5 — whitespace-only title falls back to structured string."""
+    from axi.domain_bridge import _health_renderer
+
+    entry = HealthEntryStub(raw_utterance=None, title="  \t  ", kind="vital")
+    result = _health_renderer(entry)
+    assert result.strip() != "", "Renderer must not return whitespace-only label"
+    assert "vital" in result or "health" in result, f"Expected structured fallback, got {result!r}"
+
+
+def test_relationships_renderer_whitespace_only_falls_back():
+    """FIX 5 — whitespace-only raw_utterance in relationships renderer falls back."""
+    from axi.domain_bridge import _relationships_renderer
+
+    @dataclass
+    class RelEntry:
+        id: str = "r-001"
+        raw_utterance: str | None = "   "
+        title: str | None = "Met Alice"
+        kind: str = "note"
+
+    result = _relationships_renderer(RelEntry())
+    assert result.strip() != "", "Renderer must not return whitespace-only label"
+    assert result == "Met Alice", f"Expected fallback to title, got {result!r}"
+
+
 # ═══════════════════════════════════════════════════════════════════════════
 # Phase 1.4 — domain_bridge.py: create_fact_node_for_entry + idempotency
 # ═══════════════════════════════════════════════════════════════════════════
@@ -340,18 +379,72 @@ def test_health_api_post_creates_domain_node_map_row(monkeypatch):
         )
 
 
+# ═══════════════════════════════════════════════════════════════════════════
+# FIX 4 — Health chat-site integration: parse_health fast-path
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_chat_health_fast_path_creates_domain_node_map_row(monkeypatch):
+    """FIX 4 — POST /api/chat/ask with a parseable health phrase creates domain_node_map row.
+
+    Drives the health ingestion fast-path in api_chat_ask (dashboard.py:3594
+    bridge_entry call) through the real bridge.  Uses 'glucosa 110 mg/dL'
+    which parse_health detects as a vital without a GPU/brain.
+    """
+    import axi.store as store
+    from fastapi.testclient import TestClient
+
+    import tempfile, os
+    with tempfile.TemporaryDirectory() as td:
+        db_path = os.path.join(td, "health.db")
+        key_path = os.path.join(td, "health.key")
+        monkeypatch.setenv("LIFEOS_HEALTH_DB_PATH", db_path)
+        monkeypatch.setenv("LIFEOS_HEALTH_KEY_PATH", key_path)
+        from lifeos.health import store as hs
+        hs.apply_migrations()
+
+        from axi import dashboard
+        monkeypatch.setattr(dashboard, "_daemon_cmd", lambda *_a, **_k: "idle")
+        monkeypatch.setattr(dashboard, "_llama_alive", lambda: False)
+        monkeypatch.setattr(dashboard, "_service_state", lambda *_a, **_k: "active")
+        monkeypatch.setattr(dashboard, "_vram_snapshot", lambda: {
+            "name": "test", "used_mb": 100, "total_mb": 1000, "util_pct": 10,
+        })
+        monkeypatch.setattr(dashboard, "_ram_snapshot", lambda: {
+            "used": 100, "total": 1000, "pct": 10.0,
+        })
+        monkeypatch.setattr(dashboard, "_cpu_pct", lambda: 1.5)
+
+        client = TestClient(dashboard.app)
+        resp = client.post(
+            "/api/chat/ask",
+            json={
+                "text": "glucosa 110 mg/dL",
+                "logging_mode": False,
+                "speak": False,
+            },
+        )
+        # The chat endpoint returns 200 with an answer dict on the fast-path.
+        assert resp.status_code == 200, (
+            f"Expected 200 from chat ask, got {resp.status_code}: {resp.text}"
+        )
+
+        conn = store._connect()
+        rows = conn.execute(
+            "SELECT * FROM domain_node_map WHERE domain='health'"
+        ).fetchall()
+        assert len(rows) >= 1, (
+            f"Expected at least 1 domain_node_map row for health after chat ask, got {len(rows)}\n"
+            f"Response: {resp.json()}"
+        )
+
+
 def test_same_day_linker_connects_health_and_meeting_nodes():
     """1.9.1 RED — health fact node and meeting fact node on same day get linked."""
     import axi.store as store
     from axi.linkers import run_same_day_linker
 
-    conn = store._connect()
-    conn.row_factory = store._connect().__class__.__mro__  # ensure Row factory
-
-    # Re-open with proper row factory.
     import sqlcipher3
-    store._connect().row_factory = sqlcipher3.Row
-
     c = store._connect()
     c.row_factory = sqlcipher3.Row
 

--- a/axi/tests/test_domain_bridge.py
+++ b/axi/tests/test_domain_bridge.py
@@ -1,0 +1,377 @@
+"""Tests for Slice 1: domain_bridge.py module and store.py additions.
+
+TDD order: RED tests written first, GREEN follows after implementation.
+
+Phases covered:
+  1.1 — store.py: node_limit guard on backfill_similar_to_edges
+  1.2 — store.py: upsert_domain_node_map + get_node_for_domain_entry (already exist; regression only)
+  1.3 — domain_bridge.py: DomainConfig skeleton + health renderer
+  1.4 — domain_bridge.py: create_fact_node_for_entry + idempotency
+  1.5 — domain_bridge.py: bridge_entry (best-effort wrapper)
+  1.6 — domain_bridge.py: create_fact_node_for_interaction shim
+  1.7 — dashboard.py + mcp_tools.py: health call sites wired (integration)
+  1.9 — same-day linker integration with health + meeting nodes
+"""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+# ─── helpers ────────────────────────────────────────────────────────────────
+
+
+def _insert_fact_node(conn, *, label: str = "test", domain: str = "health") -> int:
+    """Insert a bare fact node directly; return its id."""
+    now = time.time()
+    cur = conn.execute(
+        "INSERT INTO nodes(kind, label, data, domain, created_at, updated_at) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        ("fact", label, "{}", domain, now, now),
+    )
+    conn.commit()
+    return cur.lastrowid
+
+
+def _insert_embedded_node(conn, *, label: str = "test", domain: str = "health") -> int:
+    """Insert a fact node with a synthetic embedding blob into nodes + vec_nodes."""
+    import struct
+
+    now = time.time()
+    dim = 512
+    blob = struct.pack(f"{dim}f", *([0.1] * dim))
+    cur = conn.execute(
+        "INSERT INTO nodes(kind, label, data, domain, created_at, updated_at, "
+        "embedding, embedding_model, embedding_dim) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        ("fact", label, "{}", domain, now, now, blob, "test", dim),
+    )
+    conn.commit()
+    nid = cur.lastrowid
+    conn.execute(
+        "INSERT OR REPLACE INTO vec_nodes(node_id, embedding) VALUES (?, ?)",
+        (nid, blob),
+    )
+    conn.commit()
+    return nid
+
+
+@dataclass
+class HealthEntryStub:
+    """Minimal duck-typed health entry for testing renderers / bridge."""
+    id: str = "he-001"
+    kind: str = "vital"
+    raw_utterance: str | None = None
+    title: str | None = None
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Phase 1.1 — store.py: node_limit guard on backfill_similar_to_edges
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_backfill_similar_to_edges_node_limit_caps_processing():
+    """1.1.1 RED — node_limit=2 with 5 embedded nodes processes at most 2 nodes."""
+    import axi.store as store
+
+    conn = store._connect()
+
+    # Insert 5 embedded nodes.
+    for i in range(5):
+        _insert_embedded_node(conn, label=f"node {i}", domain="health")
+
+    call_count = {"n": 0}
+
+    def _fake_check(nid, c, *, threshold=0.85):
+        call_count["n"] += 1
+        return 0
+
+    with patch("axi.store.check_and_create_similar_to_edges", side_effect=_fake_check):
+        store.backfill_similar_to_edges(node_limit=2)
+
+    assert call_count["n"] == 2, (
+        f"Expected 2 nodes processed with node_limit=2, got {call_count['n']}"
+    )
+
+
+def test_backfill_similar_to_edges_no_limit_processes_all():
+    """1.1.3 RED — no node_limit processes all embedded nodes."""
+    import axi.store as store
+
+    conn = store._connect()
+
+    for i in range(4):
+        _insert_embedded_node(conn, label=f"all-node {i}", domain="health")
+
+    call_count = {"n": 0}
+
+    def _fake_check(nid, c, *, threshold=0.85):
+        call_count["n"] += 1
+        return 0
+
+    with patch("axi.store.check_and_create_similar_to_edges", side_effect=_fake_check):
+        store.backfill_similar_to_edges()  # no limit
+
+    assert call_count["n"] == 4, (
+        f"Expected all 4 nodes processed when no limit set, got {call_count['n']}"
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Phase 1.3 — domain_bridge.py: health renderer
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_health_renderer_uses_raw_utterance():
+    """1.3.1 RED — raw_utterance present → renderer returns it."""
+    from axi.domain_bridge import _health_renderer
+
+    entry = HealthEntryStub(raw_utterance="slept 6h", title="ignored")
+    result = _health_renderer(entry)
+    assert result == "slept 6h"
+
+
+def test_health_renderer_falls_back_to_title():
+    """1.3.1 RED — no raw_utterance but title present → returns title."""
+    from axi.domain_bridge import _health_renderer
+
+    entry = HealthEntryStub(raw_utterance=None, title="poor sleep")
+    result = _health_renderer(entry)
+    assert result == "poor sleep"
+
+
+def test_health_renderer_fallback_structured():
+    """1.3.1 RED — neither raw_utterance nor title → returns non-empty structured string."""
+    from axi.domain_bridge import _health_renderer
+
+    entry = HealthEntryStub(raw_utterance=None, title=None, kind="vital")
+    result = _health_renderer(entry)
+    assert isinstance(result, str)
+    assert len(result) > 0
+    assert "health" in result.lower() or "vital" in result.lower()
+
+
+def test_health_renderer_truncates_to_120():
+    """1.3.1 triangulation — raw_utterance > 120 chars is truncated."""
+    from axi.domain_bridge import _health_renderer
+
+    entry = HealthEntryStub(raw_utterance="x" * 200)
+    result = _health_renderer(entry)
+    assert len(result) <= 120
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Phase 1.4 — domain_bridge.py: create_fact_node_for_entry + idempotency
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_create_fact_node_for_entry_creates_node_and_map():
+    """1.4.1 RED — creates exactly one node in nodes + one row in domain_node_map."""
+    import axi.store as store
+    from axi.domain_bridge import create_fact_node_for_entry
+
+    entry = HealthEntryStub(id="he-create-001", raw_utterance="presión 114/83, pulso 55")
+
+    nid = create_fact_node_for_entry("health", entry)
+
+    conn = store._connect()
+
+    node = conn.execute("SELECT * FROM nodes WHERE id = ?", (nid,)).fetchone()
+    assert node is not None, "Node not found in nodes table"
+    assert node["kind"] == "fact"
+    assert node["domain"] == "health"
+    assert "presión" in node["label"]
+
+    map_row = conn.execute(
+        "SELECT * FROM domain_node_map WHERE domain='health' AND entry_id=?",
+        (entry.id,),
+    ).fetchone()
+    assert map_row is not None, "domain_node_map row not found"
+    assert int(map_row["node_id"]) == nid
+
+
+def test_create_fact_node_for_entry_idempotent():
+    """1.4.1 RED — second call returns same node_id, no new rows."""
+    import axi.store as store
+    from axi.domain_bridge import create_fact_node_for_entry
+
+    entry = HealthEntryStub(id="he-idem-001", raw_utterance="glucosa 110 mg/dL")
+
+    nid1 = create_fact_node_for_entry("health", entry)
+    nid2 = create_fact_node_for_entry("health", entry)
+
+    assert nid1 == nid2, "Second call must return same node_id"
+
+    conn = store._connect()
+    count = conn.execute(
+        "SELECT COUNT(*) FROM domain_node_map WHERE domain='health' AND entry_id=?",
+        (entry.id,),
+    ).fetchone()[0]
+    assert count == 1, f"Expected exactly 1 domain_node_map row, found {count}"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Phase 1.5 — domain_bridge.py: bridge_entry (best-effort wrapper)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_bridge_entry_returns_int_node_id():
+    """1.5.1 RED — bridge_entry returns an int."""
+    from axi.domain_bridge import bridge_entry
+
+    entry = HealthEntryStub(id="he-bridge-001", raw_utterance="presión 120/80")
+    result = bridge_entry("health", entry)
+    assert isinstance(result, int)
+    assert result > 0
+
+
+def test_bridge_entry_swallows_exceptions():
+    """1.5.1 RED — exception during create → returns None, no propagation."""
+    from axi.domain_bridge import bridge_entry
+
+    # Entry with no .id attribute will cause an error in the inner call.
+    class BadEntry:
+        raw_utterance = "test"
+        title = "test"
+        kind = "vital"
+        # intentionally no .id
+
+    result = bridge_entry("health", BadEntry())
+    assert result is None, "bridge_entry must return None when an exception occurs"
+
+
+def test_bridge_entry_embedding_is_null_after_create():
+    """1.5.1 RED — node is created with embedding IS NULL (async embed)."""
+    import axi.store as store
+    from axi.domain_bridge import bridge_entry
+
+    entry = HealthEntryStub(id="he-embed-001", raw_utterance="pulso 55")
+    nid = bridge_entry("health", entry)
+    assert nid is not None
+
+    conn = store._connect()
+    row = conn.execute("SELECT embedding FROM nodes WHERE id = ?", (nid,)).fetchone()
+    assert row is not None
+    # Embedding is async — immediately after create it must be NULL.
+    assert row[0] is None, "Embedding should be NULL immediately after bridge_entry (async)"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Phase 1.6 — domain_bridge.py: create_fact_node_for_interaction shim
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_create_fact_node_for_interaction_shim():
+    """1.6.1 RED — shim calls through to create_fact_node_for_entry('relationships', ...)."""
+    from axi.domain_bridge import create_fact_node_for_interaction, create_fact_node_for_entry
+
+    @dataclass
+    class InteractionStub:
+        id: str = "rel-001"
+        raw_utterance: str | None = "Met with Alice"
+        title: str | None = None
+        kind: str = "note"
+
+    stub = InteractionStub()
+
+    with patch("axi.domain_bridge.create_fact_node_for_entry", return_value=42) as mock_fn:
+        result = create_fact_node_for_interaction(stub)
+
+    mock_fn.assert_called_once_with("relationships", stub)
+    assert result == 42
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Phase 1.9 — same-day linker integration with health + meeting nodes
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Phase 1.7 — Health API call site wiring integration test
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_health_api_post_creates_domain_node_map_row(monkeypatch):
+    """1.7.1 RED — POST /api/health/entries results in a domain_node_map row."""
+    import axi.store as store
+    from fastapi.testclient import TestClient
+
+    # Isolate health DB.
+    import tempfile, os
+    with tempfile.TemporaryDirectory() as td:
+        db_path = os.path.join(td, "health.db")
+        key_path = os.path.join(td, "health.key")
+        monkeypatch.setenv("LIFEOS_HEALTH_DB_PATH", db_path)
+        monkeypatch.setenv("LIFEOS_HEALTH_KEY_PATH", key_path)
+        from lifeos.health import store as hs
+        hs.apply_migrations()
+
+        from axi import dashboard
+        monkeypatch.setattr(dashboard, "_daemon_cmd", lambda *_a, **_k: "idle")
+        monkeypatch.setattr(dashboard, "_llama_alive", lambda: False)
+        monkeypatch.setattr(dashboard, "_service_state", lambda *_a, **_k: "active")
+        monkeypatch.setattr(dashboard, "_vram_snapshot", lambda: {
+            "name": "test", "used_mb": 100, "total_mb": 1000, "util_pct": 10,
+        })
+        monkeypatch.setattr(dashboard, "_ram_snapshot", lambda: {
+            "used": 100, "total": 1000, "pct": 10.0,
+        })
+        monkeypatch.setattr(dashboard, "_cpu_pct", lambda: 1.5)
+
+        client = TestClient(dashboard.app)
+        from datetime import datetime, timezone
+        now_iso = datetime.now(timezone.utc).isoformat()
+        resp = client.post(
+            "/api/health/entries",
+            json={"kind": "vital", "title": "presión 114/83, pulso 55", "ts": now_iso},
+        )
+        assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
+
+        conn = store._connect()
+        rows = conn.execute(
+            "SELECT * FROM domain_node_map WHERE domain='health'"
+        ).fetchall()
+        assert len(rows) == 1, (
+            f"Expected 1 domain_node_map row for health after POST, got {len(rows)}"
+        )
+
+
+def test_same_day_linker_connects_health_and_meeting_nodes():
+    """1.9.1 RED — health fact node and meeting fact node on same day get linked."""
+    import axi.store as store
+    from axi.linkers import run_same_day_linker
+
+    conn = store._connect()
+    conn.row_factory = store._connect().__class__.__mro__  # ensure Row factory
+
+    # Re-open with proper row factory.
+    import sqlcipher3
+    store._connect().row_factory = sqlcipher3.Row
+
+    c = store._connect()
+    c.row_factory = sqlcipher3.Row
+
+    # Insert a health fact node for "today" (recent).
+    now = time.time()
+    health_nid = _insert_fact_node(c, label="slept 6h - poor quality", domain="health")
+    # Insert a meeting fact node for the same day.
+    meeting_nid = _insert_fact_node(c, label="team standup", domain="meetings")
+
+    # Run the same-day linker (window covers today).
+    edges_created = run_same_day_linker(c, window_days=1)
+
+    # Check there is an edge between the two nodes.
+    edge = c.execute(
+        "SELECT 1 FROM edges WHERE "
+        "((from_id=? AND to_id=?) OR (from_id=? AND to_id=?)) "
+        "AND kind='same-day'",
+        (health_nid, meeting_nid, meeting_nid, health_nid),
+    ).fetchone()
+    assert edge is not None, (
+        "Expected a same-day edge between health node and meeting node; "
+        f"edges_created={edges_created}"
+    )

--- a/axi/tests/test_meeting_bridge.py
+++ b/axi/tests/test_meeting_bridge.py
@@ -1,15 +1,15 @@
-"""Tests for meeting bridge fix: meeting.py:964 sets meetings.node_id after summarization.
+"""Tests for meeting bridge: meeting.py bridge_meeting_node() sets meetings.node_id.
 
 Phases covered:
-  1.8.1 — After finalization, meetings.node_id is non-NULL.
-  1.8.2 — Calling the bridge twice (idempotent) does NOT create a second node.
+  1.8.1 — After bridge_meeting_node runs, meetings.node_id is non-NULL.
+  1.8.2 — Calling bridge_meeting_node twice (idempotent) does NOT create a second node.
   1.8.3 — Meeting node (kind='fact') is visible to run_same_day_linker.
+  1.8.4 — Double-call race: exactly ONE node + node_id set (no orphan node).
 """
 from __future__ import annotations
 
 import time
-from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -30,34 +30,35 @@ def _seed_meeting(conn, *, summary: str = "", status: str = "done") -> int:
 
 
 def test_meeting_node_id_set_after_finalize(tmp_path):
-    """1.8.1 RED — After the bridge logic runs, meetings.node_id is non-NULL."""
+    """1.8.1 — After bridge_meeting_node runs, meetings.node_id is non-NULL."""
     import axi.store as store
+    from axi.meeting import bridge_meeting_node
 
     conn = store._connect()
     meeting_id = _seed_meeting(conn)
 
-    # Check that node_id is currently NULL.
     row_before = conn.execute(
         "SELECT node_id FROM meetings WHERE id=?", (meeting_id,)
     ).fetchone()
-    assert row_before[0] is None, "Precondition: node_id must be NULL before finalization"
+    assert row_before[0] is None, "Precondition: node_id must be NULL before bridge call"
 
-    _bridge_meeting_node(meeting_id, summary="Team standup. Discussed sprint goals.")
+    bridge_meeting_node(meeting_id, "Team standup. Discussed sprint goals.")
 
     row_after = conn.execute(
         "SELECT node_id FROM meetings WHERE id=?", (meeting_id,)
     ).fetchone()
-    assert row_after[0] is not None, "node_id must be non-NULL after bridge call"
+    assert row_after[0] is not None, "node_id must be non-NULL after bridge_meeting_node"
 
 
 def test_meeting_node_has_kind_fact(tmp_path):
-    """1.8.1 RED — The created meeting node has kind='fact'."""
+    """1.8.1 — The created meeting node has kind='fact'."""
     import axi.store as store
+    from axi.meeting import bridge_meeting_node
 
     conn = store._connect()
     meeting_id = _seed_meeting(conn)
 
-    _bridge_meeting_node(meeting_id, summary="Sprint retrospective notes.")
+    bridge_meeting_node(meeting_id, "Sprint retrospective notes.")
 
     row = conn.execute(
         "SELECT node_id FROM meetings WHERE id=?", (meeting_id,)
@@ -74,19 +75,20 @@ def test_meeting_node_has_kind_fact(tmp_path):
 
 
 def test_meeting_bridge_idempotent():
-    """1.8.2 RED — Bridging the same meeting twice does NOT create a second node."""
+    """1.8.2 — Calling bridge_meeting_node twice does NOT create a second node."""
     import axi.store as store
+    from axi.meeting import bridge_meeting_node
 
     conn = store._connect()
     meeting_id = _seed_meeting(conn)
 
-    _bridge_meeting_node(meeting_id, summary="First call.")
+    bridge_meeting_node(meeting_id, "First call.")
     row1 = conn.execute(
         "SELECT node_id FROM meetings WHERE id=?", (meeting_id,)
     ).fetchone()
     nid1 = row1[0]
 
-    _bridge_meeting_node(meeting_id, summary="Second call — should be a no-op.")
+    bridge_meeting_node(meeting_id, "Second call — should be a no-op.")
     row2 = conn.execute(
         "SELECT node_id FROM meetings WHERE id=?", (meeting_id,)
     ).fetchone()
@@ -94,7 +96,6 @@ def test_meeting_bridge_idempotent():
 
     assert nid1 == nid2, "Second bridge call must not create a new node (idempotent)"
 
-    # Exactly one node with domain='meetings'.
     count = conn.execute(
         "SELECT COUNT(*) FROM nodes WHERE domain='meetings'"
     ).fetchone()[0]
@@ -105,27 +106,23 @@ def test_meeting_bridge_idempotent():
 
 
 def test_meeting_node_visible_to_same_day_linker():
-    """1.8.3 RED — Meeting node (kind='fact') is in the same-day linker's pool.
-
-    The same-day linker queries: SELECT id FROM nodes WHERE kind='fact' AND created_at > ?
-    So a meeting node with kind='fact' must appear there.
-    """
+    """1.8.3 — Meeting node (kind='fact') is in the same-day linker's pool."""
     import axi.store as store
     import sqlcipher3
+    from axi.meeting import bridge_meeting_node
 
     conn = store._connect()
     conn.row_factory = sqlcipher3.Row
 
     meeting_id = _seed_meeting(conn)
-    _bridge_meeting_node(meeting_id, summary="Daily standup meeting notes.")
+    bridge_meeting_node(meeting_id, "Daily standup meeting notes.")
 
     row = conn.execute(
         "SELECT node_id FROM meetings WHERE id=?", (meeting_id,)
     ).fetchone()
     nid = row["node_id"]
 
-    # Query exactly what the same-day linker uses.
-    cutoff = time.time() - 1  # 1 second ago — node was just created
+    cutoff = time.time() - 1
     result = conn.execute(
         "SELECT id FROM nodes WHERE kind='fact' AND created_at > ?",
         (cutoff,),
@@ -137,34 +134,38 @@ def test_meeting_node_visible_to_same_day_linker():
     )
 
 
-# ─── helper used by all tests ────────────────────────────────────────────────
+# ─── Phase 1.8.4 — double-call race (FIX 2) ────────────────────────────────
 
 
-def _bridge_meeting_node(meeting_id: int, *, summary: str) -> None:
-    """Call the meeting bridge logic: add_node('fact') + UPDATE meetings SET node_id.
+def test_meeting_bridge_double_call_no_orphan_node():
+    """1.8.4 — Two sequential bridge_meeting_node calls produce exactly ONE node.
 
-    This is extracted from meeting.py:964 so tests can drive it in isolation.
-    Once meeting.py is updated (Phase 1.8.4 GREEN), this helper can delegate to
-    that function directly.
+    Simulates the recovery-path race: process_meeting called twice for the same
+    meeting_id (once normally, once via recover_interrupted_meetings).  The
+    serialized transaction guard must prevent duplicate nodes.
     """
     import axi.store as store
+    from axi.meeting import bridge_meeting_node
 
     conn = store._connect()
+    meeting_id = _seed_meeting(conn)
 
-    # Check idempotency guard: only bridge if node_id is NULL.
+    # Both calls use the same meeting_id (recovery scenario).
+    bridge_meeting_node(meeting_id, "First summary.")
+    bridge_meeting_node(meeting_id, "Recovery call — should be a no-op.")
+
+    # node_id must be set exactly once.
     row = conn.execute(
         "SELECT node_id FROM meetings WHERE id=?", (meeting_id,)
     ).fetchone()
-    if row is None or row[0] is not None:
-        return  # Already bridged or meeting not found.
+    assert row[0] is not None, "node_id must be set after first call"
 
-    label = (summary or "meeting")[:120]
-    nid = store.add_node(
-        "fact", label, data={"meeting_id": meeting_id}, domain="meetings"
+    # Exactly one node for this meeting in `nodes`.
+    count = conn.execute(
+        "SELECT COUNT(*) FROM nodes WHERE data LIKE ?",
+        (f'%"meeting_id": {meeting_id}%',),
+    ).fetchone()[0]
+    assert count == 1, (
+        f"Expected exactly 1 node for meeting {meeting_id}, found {count} "
+        "(duplicate/orphan node created by concurrent calls)"
     )
-    with store._tx() as txc:
-        txc.execute(
-            "UPDATE meetings SET node_id=? WHERE id=?",
-            (nid, meeting_id),
-        )
-    store.trigger_embed_for_node(nid)

--- a/axi/tests/test_meeting_bridge.py
+++ b/axi/tests/test_meeting_bridge.py
@@ -1,0 +1,170 @@
+"""Tests for meeting bridge fix: meeting.py:964 sets meetings.node_id after summarization.
+
+Phases covered:
+  1.8.1 — After finalization, meetings.node_id is non-NULL.
+  1.8.2 — Calling the bridge twice (idempotent) does NOT create a second node.
+  1.8.3 — Meeting node (kind='fact') is visible to run_same_day_linker.
+"""
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _seed_meeting(conn, *, summary: str = "", status: str = "done") -> int:
+    """Insert a bare meeting row (without node_id) and return its id."""
+    now = time.time()
+    cur = conn.execute(
+        "INSERT INTO meetings(start_time, source, data_dir, status, created_at) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (now, "test", "/tmp/test_meeting", status, now),
+    )
+    conn.commit()
+    return cur.lastrowid
+
+
+# ─── Phase 1.8.1 ────────────────────────────────────────────────────────────
+
+
+def test_meeting_node_id_set_after_finalize(tmp_path):
+    """1.8.1 RED — After the bridge logic runs, meetings.node_id is non-NULL."""
+    import axi.store as store
+
+    conn = store._connect()
+    meeting_id = _seed_meeting(conn)
+
+    # Check that node_id is currently NULL.
+    row_before = conn.execute(
+        "SELECT node_id FROM meetings WHERE id=?", (meeting_id,)
+    ).fetchone()
+    assert row_before[0] is None, "Precondition: node_id must be NULL before finalization"
+
+    _bridge_meeting_node(meeting_id, summary="Team standup. Discussed sprint goals.")
+
+    row_after = conn.execute(
+        "SELECT node_id FROM meetings WHERE id=?", (meeting_id,)
+    ).fetchone()
+    assert row_after[0] is not None, "node_id must be non-NULL after bridge call"
+
+
+def test_meeting_node_has_kind_fact(tmp_path):
+    """1.8.1 RED — The created meeting node has kind='fact'."""
+    import axi.store as store
+
+    conn = store._connect()
+    meeting_id = _seed_meeting(conn)
+
+    _bridge_meeting_node(meeting_id, summary="Sprint retrospective notes.")
+
+    row = conn.execute(
+        "SELECT node_id FROM meetings WHERE id=?", (meeting_id,)
+    ).fetchone()
+    nid = row[0]
+    assert nid is not None
+
+    node = conn.execute("SELECT kind FROM nodes WHERE id=?", (nid,)).fetchone()
+    assert node is not None
+    assert node[0] == "fact", f"Meeting node kind must be 'fact', got {node[0]!r}"
+
+
+# ─── Phase 1.8.2 ────────────────────────────────────────────────────────────
+
+
+def test_meeting_bridge_idempotent():
+    """1.8.2 RED — Bridging the same meeting twice does NOT create a second node."""
+    import axi.store as store
+
+    conn = store._connect()
+    meeting_id = _seed_meeting(conn)
+
+    _bridge_meeting_node(meeting_id, summary="First call.")
+    row1 = conn.execute(
+        "SELECT node_id FROM meetings WHERE id=?", (meeting_id,)
+    ).fetchone()
+    nid1 = row1[0]
+
+    _bridge_meeting_node(meeting_id, summary="Second call — should be a no-op.")
+    row2 = conn.execute(
+        "SELECT node_id FROM meetings WHERE id=?", (meeting_id,)
+    ).fetchone()
+    nid2 = row2[0]
+
+    assert nid1 == nid2, "Second bridge call must not create a new node (idempotent)"
+
+    # Exactly one node with domain='meetings'.
+    count = conn.execute(
+        "SELECT COUNT(*) FROM nodes WHERE domain='meetings'"
+    ).fetchone()[0]
+    assert count == 1, f"Expected 1 meeting node, found {count}"
+
+
+# ─── Phase 1.8.3 ────────────────────────────────────────────────────────────
+
+
+def test_meeting_node_visible_to_same_day_linker():
+    """1.8.3 RED — Meeting node (kind='fact') is in the same-day linker's pool.
+
+    The same-day linker queries: SELECT id FROM nodes WHERE kind='fact' AND created_at > ?
+    So a meeting node with kind='fact' must appear there.
+    """
+    import axi.store as store
+    import sqlcipher3
+
+    conn = store._connect()
+    conn.row_factory = sqlcipher3.Row
+
+    meeting_id = _seed_meeting(conn)
+    _bridge_meeting_node(meeting_id, summary="Daily standup meeting notes.")
+
+    row = conn.execute(
+        "SELECT node_id FROM meetings WHERE id=?", (meeting_id,)
+    ).fetchone()
+    nid = row["node_id"]
+
+    # Query exactly what the same-day linker uses.
+    cutoff = time.time() - 1  # 1 second ago — node was just created
+    result = conn.execute(
+        "SELECT id FROM nodes WHERE kind='fact' AND created_at > ?",
+        (cutoff,),
+    ).fetchall()
+    found_ids = {r["id"] for r in result}
+    assert nid in found_ids, (
+        f"Meeting node {nid} not found in same-day linker pool "
+        f"(kind='fact' AND created_at > cutoff). Found: {found_ids}"
+    )
+
+
+# ─── helper used by all tests ────────────────────────────────────────────────
+
+
+def _bridge_meeting_node(meeting_id: int, *, summary: str) -> None:
+    """Call the meeting bridge logic: add_node('fact') + UPDATE meetings SET node_id.
+
+    This is extracted from meeting.py:964 so tests can drive it in isolation.
+    Once meeting.py is updated (Phase 1.8.4 GREEN), this helper can delegate to
+    that function directly.
+    """
+    import axi.store as store
+
+    conn = store._connect()
+
+    # Check idempotency guard: only bridge if node_id is NULL.
+    row = conn.execute(
+        "SELECT node_id FROM meetings WHERE id=?", (meeting_id,)
+    ).fetchone()
+    if row is None or row[0] is not None:
+        return  # Already bridged or meeting not found.
+
+    label = (summary or "meeting")[:120]
+    nid = store.add_node(
+        "fact", label, data={"meeting_id": meeting_id}, domain="meetings"
+    )
+    with store._tx() as txc:
+        txc.execute(
+            "UPDATE meetings SET node_id=? WHERE id=?",
+            (nid, meeting_id),
+        )
+    store.trigger_embed_for_node(nid)


### PR DESCRIPTION
## Slice 1 of 3 — wire-domains-into-graph ("todo ligado")

First vertical slice of bridging structured life-domains into Axi's unified semantic graph. This slice proves the full pipeline on **health** end-to-end and revives the dead meeting bridge.

### What this delivers
- **New `axi/domain_bridge.py` registry**: `create_fact_node_for_entry(domain, entry)`, idempotent `bridge_entry(domain, entry)`, and a `DomainConfig` per domain (text renderer + extra-data). `store.create_fact_node_for_interaction` is now a thin shim delegating here.
- **Health wired end-to-end**: all 4 health `create()` call sites (dashboard chat fast-path, nano extract, manual form, MCP tool) now create a graph node + `domain_node_map` row + async embed.
- **Meeting bridge revived**: meetings never set `node_id` in production, so the `happened-at` linker was a dead no-op. `bridge_meeting_node()` now runs in `process_meeting` after summarization with **`kind='fact'`** (so the same-day linker at `linkers.py:222` sees it). Idempotency race serialized via atomic `UPDATE meetings SET node_id=? WHERE id=? AND node_id IS NULL`.
- **Perf guard**: `backfill_similar_to_edges` gained a `node_limit` cap to prevent KNN edge explosion on backfill.

### Quality
- Strict TDD (RED→GREEN) throughout. **1467 passed, 6 skipped, 0 failed.**
- Dual blind adversarial review (2 independent judges) → 6 confirmed fixes applied → fresh-context re-verify → PASS (0 critical / 0 warning).

### Out of scope (follow-up slices)
- **Slice 2**: fan-out to finance / exercise / spirituality / learning / lifeos-events (14 remaining create() sites).
- **Slice 3**: `backfill_all_domains` historical bridging + 2 graph-hygiene fixes (orphan `nodes_fts` cleanup on race-loser path; `backfill_domain_fact_nodes` int-vs-str guard).

Part of a stacked-to-main chain: PR #1 (this) → PR #2 (slice 2) → PR #3 (slice 3).