### PR TITLE
fix(store): recovery refuses to wipe memory.db when recoverable data exists (defense-in-depth)

### DIFF
--- a/axi/src/axi/memory.py
+++ b/axi/src/axi/memory.py
@@ -23,6 +23,8 @@ from datetime import datetime
 from zoneinfo import ZoneInfo
 
 from axi import config, store
+from axi.output import notify
+from axi.store import RecoveryError
 
 log = logging.getLogger("axi.memory")
 
@@ -59,6 +61,25 @@ class ConversationMemory:
         try:
             store.init_db()
             log.info("memory backend: %s (%d turns)", store.DB_PATH, store.conversation_count())
+        except RecoveryError as exc:
+            log.critical(
+                "RECOVERY REQUIRED — recoverable data exists but restore failed; "
+                "refusing to run with empty memory. Manual recovery needed. "
+                "Files: ~/.local/state/axi/memory.db, "
+                ".corrupt-*.bak backups in that directory, ~/lifeos-backups. "
+                "Error: %s",
+                exc,
+            )
+            try:
+                notify(
+                    "Axi — Recovery Required",
+                    "Recoverable data exists but restore failed. "
+                    "Check ~/.local/state/axi/ and ~/lifeos-backups. Manual recovery needed.",
+                    icon="dialog-error",
+                )
+            except Exception:  # noqa: BLE001
+                pass
+            raise
         except Exception as exc:  # noqa: BLE001
             self.degraded = True
             log.warning("memory degraded: %s — running with empty history", exc)
@@ -80,6 +101,21 @@ class ConversationMemory:
             with store._tx() as c:  # noqa: SLF001 — internal helper, intentional
                 c.execute("UPDATE conversations SET node_id = ? WHERE id = ?", (node_id, conv_id))
             return conv_id, node_id
+        except RecoveryError as exc:
+            log.critical(
+                "RECOVERY REQUIRED — store raised RecoveryError at runtime; "
+                "turn not persisted. Manual recovery needed. Error: %s",
+                exc,
+            )
+            try:
+                notify(
+                    "Axi — Recovery Required",
+                    "Store error: recoverable data at risk. Check ~/.local/state/axi/.",
+                    icon="dialog-error",
+                )
+            except Exception:  # noqa: BLE001
+                pass
+            return 0, 0
         except Exception as exc:  # noqa: BLE001
             log.warning("memory degraded: %s — turn not persisted", exc)
             return 0, 0
@@ -96,6 +132,21 @@ class ConversationMemory:
                 out.append({"role": "user", "content": r["user_text"]})
                 out.append({"role": "assistant", "content": r["axi_text"]})
             return out
+        except RecoveryError as exc:
+            log.critical(
+                "RECOVERY REQUIRED — store raised RecoveryError fetching history; "
+                "returning empty. Error: %s",
+                exc,
+            )
+            try:
+                notify(
+                    "Axi — Recovery Required",
+                    "Store error: recoverable data at risk. Check ~/.local/state/axi/.",
+                    icon="dialog-error",
+                )
+            except Exception:  # noqa: BLE001
+                pass
+            return []
         except Exception as exc:  # noqa: BLE001
             log.warning("memory degraded: %s — returning empty history", exc)
             return []
@@ -112,6 +163,21 @@ class ConversationMemory:
         """
         try:
             return store.conversation_count()
+        except RecoveryError as exc:
+            log.critical(
+                "RECOVERY REQUIRED — store raised RecoveryError fetching turn count; "
+                "returning 0. Error: %s",
+                exc,
+            )
+            try:
+                notify(
+                    "Axi — Recovery Required",
+                    "Store error: recoverable data at risk. Check ~/.local/state/axi/.",
+                    icon="dialog-error",
+                )
+            except Exception:  # noqa: BLE001
+                pass
+            return 0
         except Exception as exc:  # noqa: BLE001
             log.warning("memory degraded: %s — turn count unavailable", exc)
             return 0

--- a/axi/src/axi/store.py
+++ b/axi/src/axi/store.py
@@ -33,6 +33,16 @@ log = logging.getLogger("axi.store")
 
 import sqlcipher3
 
+
+class RecoveryError(RuntimeError):
+    """Raised when healthy backups exist but every restore attempt failed.
+
+    This signals that recoverable data is present but cannot be written to
+    disk (e.g. due to I/O errors). Axi refuses to wipe the database and
+    start with an empty schema when data is demonstrably recoverable — a
+    loud failure forces human intervention rather than silent data loss.
+    """
+
 from axi import events as _events
 
 STATE_DIR = Path(
@@ -447,6 +457,12 @@ def _repair_corrupt_db(db_path: Path, key: str) -> sqlcipher3.Connection:
         key=lambda p: p.stat().st_mtime,
         reverse=True,
     )
+    # Track whether any candidate passed the integrity check, regardless of
+    # whether its subsequent restore succeeded.  This distinguishes "no
+    # recoverable data anywhere" (healthy_backup_seen=False → step 4 safe to
+    # rebuild empty) from "data exists but disk refuses writes" (True → MUST
+    # raise rather than wipe).
+    healthy_backup_seen = False
     for candidate in candidates:
         if not _backup_passes_integrity(candidate, key):
             log.warning("recovery: backup %s failed integrity_check — skipping", candidate.name)
@@ -456,6 +472,8 @@ def _repair_corrupt_db(db_path: Path, key: str) -> sqlcipher3.Connection:
                 {"backup_file": candidate.name},
             )
             continue
+        # At least one healthy (integrity-passing) backup exists.
+        healthy_backup_seen = True
         try:
             shutil.copy2(str(candidate), str(db_path))
             _remove_wal_sidecars(db_path)
@@ -476,7 +494,28 @@ def _repair_corrupt_db(db_path: Path, key: str) -> sqlcipher3.Connection:
                 {"backup_file": candidate.name, "error": str(cand_err)},
             )
 
-    # Step 4 — last resort: rebuild an empty schema.
+    # Step 4 — last resort: rebuild an empty schema — BUT only when there is
+    # genuinely nothing to recover.  If at least one backup passed the integrity
+    # check (healthy_backup_seen=True) but every restore failed (e.g. a btrfs
+    # I/O error), wiping db_path would destroy recoverable data.  Raise instead
+    # so Axi fails loudly and a human can intervene.
+    if healthy_backup_seen:
+        msg = (
+            "recovery aborted: healthy backups exist but every restore attempt "
+            "failed — refusing to wipe memory.db to prevent data loss; "
+            "manual recovery required"
+        )
+        log.error("recovery: %s", msg)
+        try:
+            _emit_recovery_event(
+                "critical",
+                f"recovery step 4 ABORTED: {msg}",
+                {"strategy": "refuse_wipe", "db_path": str(db_path)},
+            )
+        except Exception:  # noqa: BLE001 — event emission must never mask the primary error
+            pass
+        raise RecoveryError(msg)
+
     log.warning("recovery: no clean backup found — rebuilding empty memory DB")
     # Emit the critical event BEFORE attempting the unlink+connect so it is
     # always recorded even if the step itself fails (e.g. disk full / permissions).

--- a/axi/tests/test_memory_resilience.py
+++ b/axi/tests/test_memory_resilience.py
@@ -401,6 +401,157 @@ class TestStartupRecovery:
         ]
         assert len(recovery_msgs) >= 1, "No recovery log message found"
 
+    # ── Safety-gate tests (new, 2026-06-24) ──────────────────────────────────
+
+    def test_healthy_backup_restore_fails_raises_recovery_error(
+        self, tmp_path, monkeypatch
+    ):
+        """SAFETY: healthy backup exists but restore raises OSError → MUST raise
+        RecoveryError, MUST NOT wipe db_path to empty.
+
+        Discriminates old vs new:
+        - OLD behavior: exits step-3 loop with no success, falls to step 4,
+          calls db_path.unlink() and returns an empty-schema connection.
+        - NEW behavior: detects healthy_backup_seen=True, refuses to wipe,
+          raises RecoveryError so the caller learns recoverable data exists.
+        """
+        db = tmp_path / "memory.db"
+        key = "a" * 64
+
+        # Main file is garbage (forces step 2 to fail).
+        db.write_bytes(b"\xff" * 4096)
+
+        # Create a healthy backup that passes integrity_check.
+        healthy_bak = tmp_path / "memory.db.good.bak"
+        c = sqlcipher3.connect(str(healthy_bak), check_same_thread=False, isolation_level=None)
+        c.execute(f"PRAGMA key = \"x'{key}'\"")
+        c.execute("CREATE TABLE nodes (id INTEGER PRIMARY KEY, label TEXT)")
+        c.execute("INSERT INTO nodes (label) VALUES ('precious')")
+        c.close()
+
+        # Capture the original bytes of db_path before recovery.
+        original_bytes = db.read_bytes()
+
+        # Monkeypatch shutil.copy2 so the restore step always raises OSError.
+        real_copy2 = shutil.copy2
+        call_count = {"n": 0}
+
+        def _failing_copy2(src, dst, **kwargs):
+            call_count["n"] += 1
+            # Only fail copies that target db_path (restores); allow backups.
+            if str(dst) == str(db):
+                raise OSError("disk I/O error — btrfs failure")
+            return real_copy2(src, dst, **kwargs)
+
+        monkeypatch.setattr(store, "DB_PATH", db)
+        monkeypatch.setattr(store, "STATE_DIR", tmp_path)
+        monkeypatch.setattr("axi.store.shutil.copy2", _failing_copy2)
+
+        # Must raise RecoveryError (not return an empty connection).
+        with pytest.raises(store.RecoveryError):
+            store._repair_corrupt_db(db, key)
+
+        # db_path must NOT have been wiped — original bytes preserved.
+        assert db.exists(), "db_path must not be unlinked"
+        assert db.read_bytes() == original_bytes, (
+            "db_path bytes changed — it was wiped or overwritten during failed recovery"
+        )
+
+    def test_healthy_backup_restore_fails_does_not_return_empty_connection(
+        self, tmp_path, monkeypatch
+    ):
+        """Companion to above: _repair_corrupt_db must not return a fresh empty
+        connection when healthy backups exist but restores fail.
+
+        OLD: returned a live sqlcipher3.Connection to an empty schema → silent loss.
+        NEW: raises, never returns, so no caller can mistake 'empty connection' for success.
+        """
+        db = tmp_path / "memory.db"
+        key = "a" * 64
+
+        db.write_bytes(b"\xff" * 4096)
+
+        healthy_bak = tmp_path / "memory.db.healthy.bak"
+        c = sqlcipher3.connect(str(healthy_bak), check_same_thread=False, isolation_level=None)
+        c.execute(f"PRAGMA key = \"x'{key}'\"")
+        c.execute("CREATE TABLE t (v TEXT)")
+        c.execute("INSERT INTO t VALUES ('must-not-lose')")
+        c.close()
+
+        real_copy2 = shutil.copy2
+
+        def _failing_copy2(src, dst, **kwargs):
+            if str(dst) == str(db):
+                raise OSError("disk I/O error")
+            return real_copy2(src, dst, **kwargs)
+
+        monkeypatch.setattr(store, "DB_PATH", db)
+        monkeypatch.setattr(store, "STATE_DIR", tmp_path)
+        monkeypatch.setattr("axi.store.shutil.copy2", _failing_copy2)
+
+        result = None
+        raised = False
+        try:
+            result = store._repair_corrupt_db(db, key)
+        except (store.RecoveryError, RuntimeError):
+            raised = True
+
+        assert raised, "_repair_corrupt_db must raise, not return, when healthy backup exists"
+        assert result is None, "result must be None — no empty connection was returned"
+
+    def test_no_healthy_backup_still_rebuilds_empty_schema(self, tmp_path, monkeypatch):
+        """Regression guard: when genuinely NO healthy backup exists,
+        the existing behavior (rebuild empty schema) must be preserved.
+
+        This covers the 'nothing to lose' path — healthy_backup_seen stays False
+        and step 4 runs as before.
+
+        Note: we verify conn is not None (step 4 returns a connection, not raises).
+        We do not attempt DDL here because a just-unlinked+recreated SQLCipher file
+        may exhibit transient disk-I/O in certain fs setups (matches the known flake
+        in test_fresh_schema_created_when_no_recovery_possible when run in suite).
+        """
+        db = tmp_path / "memory.db"
+        key = "a" * 64
+
+        # Main file + WAL are garbage. NO .bak files exist.
+        db.write_bytes(b"\xff" * 4096)
+        Path(str(db) + "-wal").write_bytes(b"\xff" * 512)
+
+        monkeypatch.setattr(store, "DB_PATH", db)
+        monkeypatch.setattr(store, "STATE_DIR", tmp_path)
+
+        # Must NOT raise RecoveryError — no data to lose, rebuild empty.
+        conn = store._repair_corrupt_db(db, key)
+        assert conn is not None, "step 4 must return a fresh connection, not raise"
+
+    def test_healthy_backup_that_restores_ok_returns_connection(self, tmp_path, monkeypatch):
+        """Happy path: healthy backup + restore succeeds → returns working connection.
+        This must remain GREEN (no regression from the safety flag).
+        """
+        db = tmp_path / "memory.db"
+        key = "a" * 64
+
+        # Main file is garbage.
+        db.write_bytes(b"\xff" * 4096)
+
+        # Healthy backup.
+        healthy_bak = tmp_path / "memory.db.restore-ok.bak"
+        c = sqlcipher3.connect(str(healthy_bak), check_same_thread=False, isolation_level=None)
+        c.execute(f"PRAGMA key = \"x'{key}'\"")
+        c.execute("CREATE TABLE memories (id INTEGER PRIMARY KEY, content TEXT)")
+        c.execute("INSERT INTO memories (content) VALUES ('survive-recovery')")
+        c.close()
+
+        monkeypatch.setattr(store, "DB_PATH", db)
+        monkeypatch.setattr(store, "STATE_DIR", tmp_path)
+
+        conn = store._repair_corrupt_db(db, key)
+        assert conn is not None
+
+        rows = conn.execute("SELECT content FROM memories").fetchall()
+        assert [r[0] for r in rows] == ["survive-recovery"]
+
     def test_connect_triggers_repair_when_open_raises(self, tmp_path, monkeypatch):
         """_connect() must call _repair_corrupt_db when _try_open raises DatabaseError."""
         import sqlcipher3

--- a/axi/tests/test_memory_resilience.py
+++ b/axi/tests/test_memory_resilience.py
@@ -588,3 +588,125 @@ class TestStartupRecovery:
         conn = store._connect()
         assert conn is not None
         assert len(repair_calls) == 1, "_repair_corrupt_db must be called when _try_open raises"
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# LAYER 4 — RecoveryError propagation (daemon loudness)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestRecoveryErrorLoudness:
+    """ConversationMemory must NOT swallow RecoveryError silently.
+
+    When init_db raises RecoveryError it means recoverable data exists but
+    restore failed — the daemon must fail loudly rather than run amnesiac.
+    """
+
+    def test_init_reraises_recovery_error_not_silent_degrade(self, monkeypatch):
+        """__init__ must propagate RecoveryError, NOT return degraded=True.
+
+        RED discriminator:
+        - OLD: except Exception catches RecoveryError → sets degraded=True, returns object.
+        - NEW: except RecoveryError clause re-raises → ConversationMemory() raises.
+        """
+        from axi.store import RecoveryError
+
+        def _raise_recovery():
+            raise RecoveryError("healthy backup exists but every restore failed")
+
+        monkeypatch.setattr("axi.memory.store.init_db", _raise_recovery)
+
+        with pytest.raises(RecoveryError):
+            ConversationMemory()
+
+    def test_init_fires_critical_log_on_recovery_error(self, monkeypatch, caplog):
+        """__init__ must emit a CRITICAL log (not WARNING) when RecoveryError is raised.
+
+        RED discriminator:
+        - OLD: logs at WARNING level via the broad except Exception clause.
+        - NEW: logs at CRITICAL level in the specific except RecoveryError clause
+               before re-raising.
+        """
+        import logging
+        from axi.store import RecoveryError
+
+        def _raise_recovery():
+            raise RecoveryError("healthy backup exists but every restore failed")
+
+        monkeypatch.setattr("axi.memory.store.init_db", _raise_recovery)
+
+        with caplog.at_level(logging.CRITICAL, logger="axi.memory"):
+            with pytest.raises(RecoveryError):
+                ConversationMemory()
+
+        critical_records = [r for r in caplog.records if r.levelno == logging.CRITICAL]
+        assert critical_records, "Expected at least one CRITICAL log record from axi.memory"
+
+    def test_init_fires_notification_on_recovery_error(self, monkeypatch):
+        """__init__ must call notify() (best-effort desktop alert) on RecoveryError.
+
+        RED discriminator:
+        - OLD: notify() is never called because the error is silently swallowed.
+        - NEW: notify() is called in the except RecoveryError clause before re-raising.
+        """
+        from axi.store import RecoveryError
+
+        notify_calls = []
+
+        def _raise_recovery():
+            raise RecoveryError("healthy backup exists but every restore failed")
+
+        monkeypatch.setattr("axi.memory.store.init_db", _raise_recovery)
+        monkeypatch.setattr("axi.memory.notify", lambda *a, **kw: notify_calls.append((a, kw)))
+
+        with pytest.raises(RecoveryError):
+            ConversationMemory()
+
+        assert notify_calls, "notify() must be called when RecoveryError is raised in __init__"
+
+    def test_generic_exception_still_degrades_gracefully(self, monkeypatch):
+        """Non-RecoveryError exceptions must still set degraded=True without raising.
+
+        Ensures the existing contract for transient/unknown DB errors is preserved.
+
+        RED discriminator: this test must pass both before and after the fix —
+        it guards against over-catching that breaks the graceful-degradation path.
+        """
+        import sqlcipher3
+
+        def _raise_db_error():
+            raise sqlcipher3.dbapi2.DatabaseError("database disk image is malformed")
+
+        monkeypatch.setattr("axi.memory.store.init_db", _raise_db_error)
+
+        mem = ConversationMemory()  # must NOT raise
+        assert mem.degraded is True
+
+    def test_add_logs_critical_and_notifies_on_recovery_error(self, monkeypatch, caplog):
+        """add() must log CRITICAL + call notify() when store raises RecoveryError.
+
+        Returns (0, 0) safe default — must NOT crash mid-conversation.
+
+        RED discriminator:
+        - OLD: except Exception logs WARNING only, no notification.
+        - NEW: except RecoveryError logs CRITICAL + calls notify() before returning (0, 0).
+        """
+        import logging
+        from axi.store import RecoveryError
+
+        notify_calls = []
+
+        raising_store = _RaisingStore(exc=RecoveryError("runtime recovery error"))
+        monkeypatch.setattr("axi.memory.store", raising_store)
+        monkeypatch.setattr("axi.memory.notify", lambda *a, **kw: notify_calls.append((a, kw)))
+
+        mem = ConversationMemory.__new__(ConversationMemory)
+        mem.max_context_turns = 20
+
+        with caplog.at_level(logging.CRITICAL, logger="axi.memory"):
+            result = mem.add("hola", "respuesta")
+
+        assert result == (0, 0), "add() must return (0, 0) safe default"
+        critical_records = [r for r in caplog.records if r.levelno == logging.CRITICAL]
+        assert critical_records, "add() must emit CRITICAL log on RecoveryError"
+        assert notify_calls, "add() must call notify() on RecoveryError"


### PR DESCRIPTION
## Why

memory.db was silently wiped to an empty schema **twice** (2026-06-20, 2026-06-23). Root cause was btrfs CoW corrupting the SQLite file (fixed separately via NoCoW), but the recovery ladder had a dangerous failure mode that **destroyed recoverable data**: in `_repair_corrupt_db`, when every healthy backup's *restore* failed (e.g. a btrfs "disk I/O error"), the code treated it identically to "no backup exists" and fell through to `unlink()` + rebuild-empty — wiping data that was demonstrably recoverable.

This is defense-in-depth on top of the NoCoW root fix: recovery must **never** silently destroy data.

## What

**`store.py` — refuse to wipe when recoverable data exists** (`b606824`)
- New `RecoveryError(RuntimeError)`.
- `_repair_corrupt_db` tracks `healthy_backup_seen` (set whenever a candidate passes `integrity_check`, regardless of whether its restore then succeeds).
- Step 4: if a healthy backup existed but every restore failed → emit a CRITICAL event, log loudly, and **raise `RecoveryError`** instead of unlinking + rebuilding empty. The corrupt original and all `.corrupt-*.bak` backups are left intact for manual recovery.
- Genuine total loss (no healthy backup anywhere — e.g. fresh install) still rebuilds an empty schema, exactly as before. No regression.

**`memory.py` — make the daemon path loud** (`0010e5f`)
- `ConversationMemory` previously swallowed `RecoveryError` in a broad `except Exception` → daemon ran silently amnesiac. Now `RecoveryError` is special-cased in `__init__` (CRITICAL log + desktop `notify()` + re-raise → loud startup failure) and in `add()`/`messages()`/`turn_count()` (CRITICAL log + notify). Generic/transient errors still degrade gracefully — no regression.

## Quality

- Strict TDD. **1538 passed, 6 skipped.**
- Dual blind adversarial review (2 independent judges, sonnet + opus): both confirmed the wipe is genuinely prevented (db_path never unlinked on the raise path; original always preserved in the step-1 backup), tests genuinely discriminate (the key test asserts the file's **bytes are unchanged**, not just that an exception was raised), and no regression to the legit empty-rebuild path. Both flagged the daemon swallowing `RecoveryError` → fixed in `0010e5f`.

## Notes / follow-ups (not blocking)
- On the raise path the daemon crashes loudly; systemd's default StartLimitBurst caps the restart loop and holds the unit `failed` (visible signal) — a few notifications, not an infinite storm.
- Dashboard already fails loudly (unguarded `init_db`).