### PR TITLE
fix(vision): pin spectacle to Wayland Qt plugin (stop xcb SIGABRT on every capture)

### DIFF
--- a/axi/src/axi/vision.py
+++ b/axi/src/axi/vision.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import base64
 import logging
+import os
 import shutil
 import subprocess
 import tempfile
@@ -38,7 +39,15 @@ def _spectacle_capture(active_only: bool) -> bytes | None:
     try:
         args = ["spectacle", "-b", "-n", "-o", str(out_path)]
         args.append("-a" if active_only else "-f")
-        proc = subprocess.run(args, capture_output=True, timeout=5, check=False)
+        # On a Wayland session DISPLAY is often still set, which tempts Qt into
+        # the xcb platform plugin — that needs libxcb-cursor0 and otherwise
+        # aborts with SIGABRT (no capture, coredump on every attempt). Pin Qt to
+        # the Wayland plugin so spectacle talks to KWin directly. Left untouched
+        # on pure-X sessions so we don't force an unavailable plugin there.
+        env = None
+        if os.environ.get("WAYLAND_DISPLAY"):
+            env = {**os.environ, "QT_QPA_PLATFORM": "wayland"}
+        proc = subprocess.run(args, capture_output=True, timeout=5, check=False, env=env)
         if proc.returncode != 0:
             err = proc.stderr.decode(errors="replace")[:200]
             log.warning("spectacle returned %d: %s", proc.returncode, err)

--- a/axi/tests/test_vision_capture.py
+++ b/axi/tests/test_vision_capture.py
@@ -1,0 +1,55 @@
+"""Tests for spectacle screen capture — platform-plugin handling.
+
+Regression guard for the Wayland crash: with DISPLAY set alongside
+WAYLAND_DISPLAY, Qt picks the xcb platform plugin (missing libxcb-cursor0)
+and spectacle aborts with SIGABRT. Forcing QT_QPA_PLATFORM=wayland when a
+Wayland session is present routes spectacle to the working plugin.
+"""
+from __future__ import annotations
+
+import subprocess
+from types import SimpleNamespace
+
+from axi import vision
+
+
+def _fake_run_factory(captured: dict):
+    def _fake_run(args, **kwargs):
+        captured["args"] = args
+        captured["env"] = kwargs.get("env")
+        # Simulate a successful capture: write nothing, return rc 0. The caller
+        # reads the out file which won't exist → returns None, which is fine;
+        # we only assert on how spectacle was invoked.
+        return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+    return _fake_run
+
+
+def test_spectacle_forces_wayland_platform_when_wayland_session(monkeypatch):
+    monkeypatch.setenv("WAYLAND_DISPLAY", "wayland-0")
+    monkeypatch.setenv("DISPLAY", ":0")  # the trap that makes Qt pick xcb
+    monkeypatch.setattr(vision.shutil, "which", lambda _: "/usr/bin/spectacle")
+    captured: dict = {}
+    monkeypatch.setattr(subprocess, "run", _fake_run_factory(captured))
+
+    vision._spectacle_capture(active_only=True)
+
+    env = captured["env"]
+    assert env is not None, "spectacle must run with an explicit env on Wayland"
+    assert env.get("QT_QPA_PLATFORM") == "wayland", (
+        "QT_QPA_PLATFORM must be forced to 'wayland' so Qt does not fall back "
+        "to the broken xcb plugin when DISPLAY is set"
+    )
+
+
+def test_spectacle_does_not_force_platform_without_wayland(monkeypatch):
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+    monkeypatch.setattr(vision.shutil, "which", lambda _: "/usr/bin/spectacle")
+    captured: dict = {}
+    monkeypatch.setattr(subprocess, "run", _fake_run_factory(captured))
+
+    vision._spectacle_capture(active_only=True)
+
+    env = captured["env"]
+    # On a non-Wayland session we must not force wayland (would break pure X).
+    if env is not None:
+        assert env.get("QT_QPA_PLATFORM") != "wayland"


### PR DESCRIPTION
## Why
Axi's screen capture (`vision._spectacle_capture`) crashed on **every** attempt: spectacle aborted with SIGABRT and dumped core, so Axi's vision/co-pilot got no screenshot. Logs showed `Could not load the Qt platform plugin "xcb"` + `xcb-cursor0 ... is needed`.

Root cause: the session is KDE **Wayland**, but the service environment also has `DISPLAY=:0` set. With DISPLAY present, Qt picks the **xcb** platform plugin, which needs `libxcb-cursor0` (absent) → abort. The `wayland` plugin is available and works.

## What
`vision._spectacle_capture` now forces `QT_QPA_PLATFORM=wayland` for the spectacle subprocess **when `WAYLAND_DISPLAY` is set**, routing Qt to the working Wayland plugin. Pure-X sessions are left untouched (no forced plugin).

## Verification
- Empirically confirmed before coding: `env QT_QPA_PLATFORM=wayland spectacle -b -n -o … -a` produced a valid 2561×1556 PNG where the default invocation crashed.
- Strict TDD: RED test (asserts env carries `QT_QPA_PLATFORM=wayland` on a Wayland session) → GREEN. Plus a guard that pure-X is not forced.
- End-to-end: `capture_active_window_b64()` through the real code path returns a valid PNG (~795 KB) in this KDE Wayland session.
- 115 vision/daemon/copilot tests pass.