### PR TITLE
fix(events_cli): connect to dashboard's real HTTPS:8081 endpoint (was http://...:7799)

### DIFF
--- a/axi/src/axi/events_cli.py
+++ b/axi/src/axi/events_cli.py
@@ -26,9 +26,24 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+import ssl
 from typing import Any
 
-_DEFAULT_BASE_URL = "http://127.0.0.1:7799"
+_DEFAULT_BASE_URL = "https://127.0.0.1:8081"
+
+
+def _build_ssl_context() -> ssl.SSLContext:
+    """SSL context for talking to the local dashboard.
+
+    The dashboard serves HTTPS with a self-signed cert bound to loopback
+    (single-user, trusted-loopback posture). Verification is disabled because
+    there is no CA for a self-signed localhost cert; the connection never
+    leaves 127.0.0.1.
+    """
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    return ctx
 
 # ---------------------------------------------------------------------------
 # Public helpers (also tested directly)
@@ -147,8 +162,9 @@ def _fetch_events(
         params["since_ts"] = f"{since_ts:.6f}"
 
     url = f"{base_url}/api/events?" + urllib.parse.urlencode(params)
+    ctx = _build_ssl_context() if url.startswith("https") else None
     try:
-        with urllib.request.urlopen(url, timeout=10) as resp:  # noqa: S310
+        with urllib.request.urlopen(url, timeout=10, context=ctx) as resp:  # noqa: S310
             body = resp.read().decode()
             payload = json.loads(body)
             return payload.get("events", [])

--- a/axi/tests/test_events_cli.py
+++ b/axi/tests/test_events_cli.py
@@ -1,0 +1,26 @@
+"""Tests for the events_cli connection defaults.
+
+Regression guard: the CLI pointed at http://127.0.0.1:7799, but the dashboard
+serves HTTPS on 8081 (self-signed, loopback). The wrong scheme + port left the
+CLI unable to reach the dashboard at all.
+"""
+from __future__ import annotations
+
+import ssl
+
+from axi import events_cli
+
+
+def test_default_base_url_matches_dashboard_https_8081():
+    assert events_cli._DEFAULT_BASE_URL == "https://127.0.0.1:8081", (
+        "events_cli must point at the dashboard's actual scheme+port "
+        "(HTTPS on 8081), not http://...:7799"
+    )
+
+
+def test_ssl_context_does_not_verify_self_signed_loopback_cert():
+    ctx = events_cli._build_ssl_context()
+    # Loopback self-signed cert → verification must be disabled or the CLI
+    # cannot talk to the user's own dashboard.
+    assert ctx.verify_mode == ssl.CERT_NONE
+    assert ctx.check_hostname is False


### PR DESCRIPTION
## Why
`axi.events_cli` defaulted to `http://127.0.0.1:7799`, but the dashboard serves **HTTPS on 8081** (self-signed, loopback). Wrong scheme **and** wrong port — the CLI could never reach the dashboard (connection refused / reset on every invocation).

## What
- Default base URL → `https://127.0.0.1:8081`.
- New `_build_ssl_context()` — a non-verifying SSL context for the self-signed loopback cert (there's no CA for a self-signed localhost cert; the connection never leaves 127.0.0.1, matching the dashboard's documented single-user trusted-loopback posture). Passed to `urlopen` for https URLs.

## Verification
- Strict TDD: RED → GREEN. Tests assert the default URL is `https://127.0.0.1:8081` and the SSL context is non-verifying (`CERT_NONE`, `check_hostname=False`).
- End-to-end: `python -m axi.events_cli --since 1h` now reaches the live dashboard and returns recent events (exit 0).