### PR TITLE
fix(backfill): full-history CLI defaults (was days=90) + argparse override

### DIFF
--- a/axi/src/axi/backfill.py
+++ b/axi/src/axi/backfill.py
@@ -30,34 +30,58 @@ See also: axi/domain_bridge.py — backfill_all_domains
 """
 from __future__ import annotations
 
+import argparse
 import logging
 import sys
 
 from axi import store
 from axi.domain_bridge import backfill_all_domains
+from axi.logging_setup import setup_logging
 
 log = logging.getLogger("axi.backfill")
 
 # Bounded defaults: wide enough to catch all practical history without
 # unbounded runtime on a large DB.
-_DEFAULT_DAYS = 90
-_DEFAULT_NODE_LIMIT = 500
+# Generous defaults so a one-shot run captures ALL practical history. Round-robin
+# fairness inside backfill_all_domains keeps an unbounded run safe (no domain
+# starves), bounded only by each domain's fetch limit. Override with --days /
+# --node-limit.
+_DEFAULT_DAYS = 3650
+_DEFAULT_NODE_LIMIT: int | None = None
 
 
-def main() -> None:
-    """Run a bounded one-shot backfill and exit durably."""
-    from axi.logging_setup import setup_logging as _setup_logging
-    _setup_logging()
+def main(argv: list[str] | None = None) -> None:
+    """Run a one-shot backfill and exit durably.
+
+    Args:
+        argv: CLI args (defaults to sys.argv[1:]). Supports --days and
+            --node-limit to override the full-history defaults.
+    """
+    parser = argparse.ArgumentParser(
+        prog="python -m axi.backfill",
+        description="One-shot backfill of structured domains into the semantic graph.",
+    )
+    parser.add_argument(
+        "--days", type=int, default=_DEFAULT_DAYS,
+        help=f"Look-back window in days (default: {_DEFAULT_DAYS}).",
+    )
+    parser.add_argument(
+        "--node-limit", type=int, default=_DEFAULT_NODE_LIMIT,
+        help="Max total new nodes across all domains (default: unbounded).",
+    )
+    args = parser.parse_args(argv)
+
+    setup_logging()
 
     log.info(
-        "backfill: starting (days=%d, node_limit=%d)",
-        _DEFAULT_DAYS,
-        _DEFAULT_NODE_LIMIT,
+        "backfill: starting (days=%s, node_limit=%s)",
+        args.days,
+        args.node_limit if args.node_limit is not None else "unbounded",
     )
 
     result = backfill_all_domains(
-        days=_DEFAULT_DAYS,
-        node_limit=_DEFAULT_NODE_LIMIT,
+        days=args.days,
+        node_limit=args.node_limit,
         sleep_s=0.05,
     )
 

--- a/axi/tests/test_backfill_cli.py
+++ b/axi/tests/test_backfill_cli.py
@@ -1,0 +1,39 @@
+"""Tests for the backfill CLI argument handling and defaults.
+
+The CLI previously hardcoded days=90 / node_limit=500, so a one-shot run could
+not capture older history and could not be overridden without editing source.
+"""
+from __future__ import annotations
+
+from axi import backfill
+
+
+def test_default_days_covers_full_history():
+    # 90 days dropped everything older than a quarter; a one-shot backfill
+    # should reach all practical history by default.
+    assert backfill._DEFAULT_DAYS >= 3650
+
+
+def test_default_node_limit_is_unbounded():
+    # Round-robin fairness makes an unbounded run safe; the default should
+    # bridge everything rather than stopping at a small cap.
+    assert backfill._DEFAULT_NODE_LIMIT is None
+
+
+def test_main_passes_parsed_args_to_backfill(monkeypatch):
+    captured: dict = {}
+
+    def _fake_backfill(*, days, node_limit, sleep_s):
+        captured["days"] = days
+        captured["node_limit"] = node_limit
+        return {}
+
+    monkeypatch.setattr(backfill, "backfill_all_domains", _fake_backfill)
+    monkeypatch.setattr(backfill.store, "checkpoint", lambda: None)
+    monkeypatch.setattr(backfill.store, "close", lambda: None)
+    monkeypatch.setattr(backfill, "setup_logging", lambda: None, raising=False)
+
+    backfill.main(["--days", "5", "--node-limit", "10"])
+
+    assert captured["days"] == 5
+    assert captured["node_limit"] == 10

--- a/axi/tests/test_backfill_durable.py
+++ b/axi/tests/test_backfill_durable.py
@@ -177,7 +177,7 @@ def test_backfill_main_calls_backfill_then_checkpoint_then_close():
          patch("axi.backfill.store") as mock_store:
         mock_store.checkpoint.side_effect = fake_checkpoint
         mock_store.close.side_effect = fake_close
-        backfill_mod.main()
+        backfill_mod.main([])
 
     assert call_order == ["backfill", "checkpoint", "close"], (
         f"expected [backfill, checkpoint, close] in order, got {call_order}"


### PR DESCRIPTION
## Why
`python -m axi.backfill` hardcoded `days=90` / `node_limit=500` — a one-shot run silently dropped any structured-domain history older than ~3 months, and there was no way to tune it without editing source. For a "bring all my history into the graph" backfill, that's the wrong default.

## What
- Defaults raised: `days=3650` (~10y, all practical history) and `node_limit=None` (unbounded). Round-robin fairness inside `backfill_all_domains` keeps an unbounded run safe (no domain starves), bounded only by each domain's fetch limit.
- Added `argparse` with `--days` and `--node-limit` so an operator can override.
- `main(argv=None)` accepts args for testability; the `node_limit=None` case is handled in the log line ("unbounded").

## Quality
- Strict TDD: RED → GREEN. Tests assert the generous defaults and that `main(["--days","5","--node-limit","10"])` forwards parsed args to `backfill_all_domains`. Updated the existing durable-CLI test to call `main([])` (so it doesn't parse pytest's argv).
- `--help` verified; 20 backfill tests green.