### PR TITLE
fix(dashboard): brain3d 3D graph squashed into a thin strip (iframe height + canvas resize)

### DIFF
--- a/axi/src/axi/templates/brain3d.html
+++ b/axi/src/axi/templates/brain3d.html
@@ -219,6 +219,23 @@ function brain3dPage() {
         .onNodeClick(node => {
           self._selectNode(node, data.edges, nodeById);
         });
+
+      // 3d-force-graph locks the canvas to the container size at creation. Inside
+      // the dashboard's modal iframe the container often isn't at its final size
+      // yet (and the window can be resized), so keep the canvas synced to the
+      // container — otherwise the graph stays frozen in a tiny strip.
+      const syncSize = () => {
+        if (!self._graph) return;
+        self._graph.width(container.clientWidth).height(container.clientHeight);
+      };
+      syncSize();
+      if (window.ResizeObserver) {
+        if (self._resizeObs) self._resizeObs.disconnect();
+        self._resizeObs = new ResizeObserver(syncSize);
+        self._resizeObs.observe(container);
+      } else {
+        window.addEventListener('resize', syncSize);
+      }
     },
 
     _selectNode(node, edges, nodeById) {

--- a/axi/src/axi/templates/dashboard.html
+++ b/axi/src/axi/templates/dashboard.html
@@ -259,7 +259,10 @@
          x-transition:enter-start="opacity-0" x-transition:enter-end="opacity-100"
          @keydown.escape.window="$store.brain3d.open = false"
          style="display:none; position:fixed; inset:0; z-index:200; background:rgba(11,14,19,0.96); display:none; flex-direction:column;">
-      <div x-show="$store.brain3d.open" style="position:fixed; inset:0; z-index:200; background:rgba(11,14,19,0.96); display:flex; flex-direction:column;">
+      <!-- No x-show here: it is gated by the outer #brain3d-modal. Putting x-show
+           on this flex container made Alpine overwrite display:flex with block
+           when toggling, collapsing the iframe to its 150px intrinsic height. -->
+      <div style="position:fixed; inset:0; z-index:200; background:rgba(11,14,19,0.96); display:flex; flex-direction:column;">
         <!-- Modal header -->
         <div style="display:flex; align-items:center; justify-content:space-between; padding:0.75rem 1.25rem; border-bottom:1px solid var(--panel2); flex-shrink:0;">
           <div style="display:flex; align-items:center; gap:0.75rem;">
@@ -273,11 +276,16 @@
           </div>
           <button @click="$store.brain3d.open = false" class="btn" style="padding:3px 12px; font-size:0.8rem">✕ Cerrar</button>
         </div>
-        <!-- Modal body: lazy-load brain3d in iframe -->
-        <iframe x-show="$store.brain3d.open" :src="$store.brain3d.open ? '/brain3d' : ''"
-                style="flex:1; border:none; width:100%;"
-                title="Visualización 3D del grafo de memoria">
-        </iframe>
+        <!-- Modal body: lazy-load brain3d in iframe. The iframe is wrapped in a
+             flex:1 / min-height:0 box and set to height:100% so it actually
+             fills the modal — a bare flex:1 iframe collapses to its intrinsic
+             150px default, squashing the 3D graph into a thin strip. -->
+        <div style="flex:1; min-height:0;">
+          <iframe x-show="$store.brain3d.open" :src="$store.brain3d.open ? '/brain3d' : ''"
+                  style="width:100%; height:100%; border:none; display:block;"
+                  title="Visualización 3D del grafo de memoria">
+          </iframe>
+        </div>
       </div>
     </div>
 


### PR DESCRIPTION
## Why
After the modal-open fix (#149), clicking the brain opened the modal but the 3D graph rendered in a ~150px strip at the top with a large black void below.

Two chained bugs (found by measuring the live DOM with a headless browser):
1. **Iframe collapsed to 150px.** The modal's inner flex column had both `x-show` and inline `display:flex`. Alpine's `x-show` overwrites `display` when toggling, replacing `display:flex` with `block` — so the iframe was no longer inside a flex container and fell back to its intrinsic 150px height, squashing everything.
2. **Canvas frozen.** `3d-force-graph` locks its canvas to the container's size at creation and never resizes, so even after the container grew the canvas stayed tiny.

## What
1. `dashboard.html`: removed the redundant `x-show` from the inner modal container (the outer `#brain3d-modal` already gates visibility) so its `display:flex` survives, and wrapped the iframe in a `flex:1; min-height:0` box with the iframe at `height:100%`.
2. `brain3d.html`: added a `ResizeObserver` that keeps the `ForceGraph3D` canvas synced to its container size.

## Verification (headless browser, measured)
- iframe element height: **150px → 948px**
- graph canvas height: **150px → 709px**
- Screenshot: the full force-directed graph renders with nodes + edges ("169 nodos · 143 relaciones"), legend, detail panel, and orbit controls.