### PR TITLE
test(sw): make CACHE_VERSION test version-agnostic (was hardcoded v10)

### DIFF
--- a/axi/tests/test_slice4_vendor.py
+++ b/axi/tests/test_slice4_vendor.py
@@ -36,9 +36,17 @@ def test_graph_html_references_vendored_cytoscape():
 # ── 4.4 — sw.js CACHE_VERSION bumped and new vendor files in precache ────────
 
 def test_sw_cache_version_bumped():
-    """Task 4.4 RED: sw.js CACHE_VERSION is 'axi-shell-v10' (bumped from v9)."""
+    """sw.js declares a versioned CACHE_VERSION (axi-shell-v<N>).
+
+    Version-agnostic on purpose: hardcoding a specific number (originally
+    'axi-shell-v10') broke this test on every legitimate cache bump. We only
+    care that a numbered shell-cache version exists.
+    """
+    import re
     sw_content = (STATIC_DIR / "sw.js").read_text()
-    assert "axi-shell-v10" in sw_content
+    assert re.search(r"CACHE_VERSION\s*=\s*['\"]axi-shell-v\d+['\"]", sw_content), (
+        "sw.js must declare a numbered CACHE_VERSION like axi-shell-v11"
+    )
 
 
 def test_sw_precache_includes_3d_force_graph():


### PR DESCRIPTION
## Why
`test_sw_cache_version_bumped` hardcoded `assert "axi-shell-v10" in sw_content`. Bumping the service-worker cache version to v11 (in the brain3d modal fix #149) broke it — and it would break again on every future legitimate bump. Main was left red.

## What
Assert a **numbered pattern** `CACHE_VERSION = 'axi-shell-v<N>'` (regex) instead of a specific number. The test still verifies a versioned shell cache exists; it no longer snapshots a value that is meant to change.

Green against the current v11.