### PR TITLE
fix(store): atomic memory.db restore — never clobber the live file on a failed recovery

### DIFF
--- a/axi/src/axi/store.py
+++ b/axi/src/axi/store.py
@@ -506,9 +506,31 @@ def _repair_corrupt_db(db_path: Path, key: str) -> sqlcipher3.Connection:
             continue
         # At least one healthy (integrity-passing) backup exists.
         healthy_backup_seen = True
+        # Atomic restore: copy to a temp file, verify it opens, THEN swap in
+        # place with os.replace().  db_path is never mutated until a verified-
+        # good file is ready — if anything fails before the swap, db_path is
+        # left exactly as it was (invariant: no clobber on failed restore).
+        tmp = db_path.parent / f"{db_path.name}.restore-tmp-{os.getpid()}"
         try:
-            shutil.copy2(str(candidate), str(db_path))
+            shutil.copy2(str(candidate), str(tmp))
+            verify = _try_open(tmp, key)
+            if verify is None:
+                tmp.unlink(missing_ok=True)
+                log.warning(
+                    "recovery: temp restore of %s did not open — skipping",
+                    candidate.name,
+                )
+                _emit_recovery_event(
+                    "warning",
+                    f"recovery step 3: temp restore of {candidate.name} did not open — skipping",
+                    {"backup_file": candidate.name},
+                )
+                continue
+            verify.close()
+            # Temp file is verified good.  Clear stale WAL/SHM of the live file
+            # BEFORE the atomic swap so readers never see a mismatched WAL.
             _remove_wal_sidecars(db_path)
+            os.replace(str(tmp), str(db_path))
             conn = _try_open(db_path, key)
             if conn is not None:
                 log.warning("recovery: restored from healthy backup %s", candidate.name)
@@ -518,6 +540,17 @@ def _repair_corrupt_db(db_path: Path, key: str) -> sqlcipher3.Connection:
                     {"backup_file": candidate.name, "strategy": "restore_backup"},
                 )
                 return conn
+            # os.replace succeeded but final open failed — unusual (possible
+            # concurrent writer); fall through to try next candidate.
+            log.warning(
+                "recovery: restore of %s: swap succeeded but final open failed — skipping",
+                candidate.name,
+            )
+            _emit_recovery_event(
+                "warning",
+                f"recovery step 3: restore of {candidate.name}: swap ok but open failed — skipping",
+                {"backup_file": candidate.name},
+            )
         except (OSError, sqlcipher3.dbapi2.DatabaseError) as cand_err:
             log.warning("recovery: restore of %s failed (%s) — skipping", candidate.name, cand_err)
             _emit_recovery_event(
@@ -525,6 +558,12 @@ def _repair_corrupt_db(db_path: Path, key: str) -> sqlcipher3.Connection:
                 f"recovery step 3: restore of {candidate.name} failed ({cand_err}) — skipping",
                 {"backup_file": candidate.name, "error": str(cand_err)},
             )
+        finally:
+            # Never leave a temp file behind regardless of outcome.
+            try:
+                tmp.unlink(missing_ok=True)
+            except Exception:  # noqa: BLE001
+                pass
 
     # Step 4 — last resort: rebuild an empty schema — BUT only when there is
     # genuinely nothing to recover.  If at least one backup passed the integrity

--- a/axi/src/axi/store.py
+++ b/axi/src/axi/store.py
@@ -507,10 +507,14 @@ def _repair_corrupt_db(db_path: Path, key: str) -> sqlcipher3.Connection:
         # At least one healthy (integrity-passing) backup exists.
         healthy_backup_seen = True
         # Atomic restore: copy to a temp file, verify it opens, THEN swap in
-        # place with os.replace().  db_path is never mutated until a verified-
-        # good file is ready — if anything fails before the swap, db_path is
-        # left exactly as it was (invariant: no clobber on failed restore).
-        tmp = db_path.parent / f"{db_path.name}.restore-tmp-{os.getpid()}"
+        # place with os.replace().  Invariant: db_path is never left holding
+        # unverified or partial bytes.  The only mutation is an atomic swap to
+        # a backup that already passed open-verification.  In the rare case
+        # where os.replace succeeds but the subsequent _try_open(db_path) fails,
+        # db_path holds verified-good backup bytes — strictly better than the
+        # original corrupt content.  Any earlier failure (copy error, temp-open
+        # failure) leaves db_path completely untouched.
+        tmp = db_path.parent / f"{db_path.name}.restore-tmp-{os.getpid()}-{threading.get_ident()}-{secrets.token_hex(4)}"
         try:
             shutil.copy2(str(candidate), str(tmp))
             verify = _try_open(tmp, key)
@@ -572,9 +576,9 @@ def _repair_corrupt_db(db_path: Path, key: str) -> sqlcipher3.Connection:
     # so Axi fails loudly and a human can intervene.
     if healthy_backup_seen:
         msg = (
-            "recovery aborted: healthy backups exist but every restore attempt "
-            "failed — refusing to wipe memory.db to prevent data loss; "
-            "manual recovery required"
+            "recovery aborted: could not bring memory.db back to a healthy open "
+            "state from any backup — refusing to wipe memory.db to prevent data "
+            "loss; manual recovery required"
         )
         log.error("recovery: %s", msg)
         try:

--- a/axi/tests/test_memory_resilience.py
+++ b/axi/tests/test_memory_resilience.py
@@ -8,7 +8,6 @@ Layer 3: Startup auto-recovery ladder (store._connect corruption recovery)
 """
 from __future__ import annotations
 
-import shutil
 from pathlib import Path
 from unittest.mock import MagicMock, patch, call
 
@@ -671,6 +670,136 @@ class TestStartupRecovery:
         assert leftover_tmp == [], (
             f"restore temp file(s) left behind: {leftover_tmp}"
         )
+
+    def test_try_open_raises_database_error_on_temp_leaves_db_path_untouched(
+        self, tmp_path, monkeypatch
+    ):
+        """FIX 3 — production-path: _try_open RAISES DatabaseError (not returns None)
+        on the temp-file open, exactly as in the 2026-06-24 btrfs incident.
+
+        Discriminates old vs new:
+        - OLD code (pre-atomic): shutil.copy2 went directly to db_path; a raise
+          from _try_open never occurred there; db_path was already clobbered.
+        - NEW code (atomic): copy goes to a temp; _try_open(tmp) raises
+          DatabaseError → caught by `except (OSError, DatabaseError)` → tmp.unlink()
+          in finally → os.replace never called → db_path untouched.
+
+        Asserts:
+        - _repair_corrupt_db raises RecoveryError (healthy_backup_seen=True,
+          no restore succeeded).
+        - db_path bytes are identical to original (no clobber).
+        - No .restore-tmp-* file is left behind.
+        """
+        db = tmp_path / "memory.db"
+        key = "a" * 64
+
+        original_bytes = b"\xff" * 4096
+        db.write_bytes(original_bytes)
+
+        # Healthy backup — passes integrity_check.
+        healthy_bak = tmp_path / "memory.db.incident-btrfs.bak"
+        c = sqlcipher3.connect(str(healthy_bak), check_same_thread=False, isolation_level=None)
+        c.execute(f"PRAGMA key = \"x'{key}'\"")
+        c.execute("CREATE TABLE nodes (id INTEGER PRIMARY KEY, label TEXT)")
+        c.execute("INSERT INTO nodes (label) VALUES ('btrfs-incident-data')")
+        c.close()
+
+        monkeypatch.setattr(store, "DB_PATH", db)
+        monkeypatch.setattr(store, "STATE_DIR", tmp_path)
+
+        real_try_open = store._try_open
+
+        def _raising_try_open(path, k):
+            p = str(path)
+            # Simulate btrfs I/O decrypt error on the temp file open (or live path).
+            if p == str(db) or ".restore-tmp-" in p:
+                raise sqlcipher3.dbapi2.DatabaseError("file is not a database")
+            return real_try_open(path, k)
+
+        monkeypatch.setattr(store, "_try_open", _raising_try_open)
+
+        with pytest.raises(store.RecoveryError):
+            store._repair_corrupt_db(db, key)
+
+        # db_path must be untouched.
+        assert db.exists(), "db_path must not be unlinked"
+        assert db.read_bytes() == original_bytes, (
+            "db_path was clobbered — os.replace must not run when temp open raises"
+        )
+
+        # No temp file left behind.
+        leftover = list(tmp_path.glob("memory.db.restore-tmp-*"))
+        assert leftover == [], f"restore temp file(s) left behind: {leftover}"
+
+    def test_swap_ok_but_reopen_fails_leaves_db_path_with_verified_backup_bytes(
+        self, tmp_path, monkeypatch
+    ):
+        """FIX 4 — swap-ok-but-reopen-fails corner: after os.replace, db_path holds
+        verified-good backup bytes even though the subsequent _try_open(db_path) fails.
+
+        Discriminates the invariant:
+        - _try_open(tmp) (pre-replace) SUCCEEDS → tmp is verified good.
+        - os.replace(tmp, db_path) runs → db_path now contains backup bytes.
+        - _try_open(db_path) (post-replace) returns None or raises → loop continues.
+        - After all candidates exhausted, RecoveryError is raised.
+        - db_path holds the verified backup bytes, NOT the original corrupt bytes.
+
+        This documents and locks the intended behavior: a swap that occurred but
+        whose post-replace reopen failed leaves db_path strictly better than before
+        (verified backup vs corrupt original).
+        """
+        db = tmp_path / "memory.db"
+        key = "a" * 64
+
+        corrupt_bytes = b"\xff" * 4096
+        db.write_bytes(corrupt_bytes)
+
+        # Healthy backup with distinct content.
+        healthy_bak = tmp_path / "memory.db.swap-reopen.bak"
+        c = sqlcipher3.connect(str(healthy_bak), check_same_thread=False, isolation_level=None)
+        c.execute(f"PRAGMA key = \"x'{key}'\"")
+        c.execute("CREATE TABLE t (v TEXT)")
+        c.execute("INSERT INTO t VALUES ('swap-corner-case')")
+        c.close()
+
+        # Capture backup bytes so we can assert db_path ends up holding them.
+        backup_bytes = Path(str(healthy_bak)).read_bytes()
+
+        monkeypatch.setattr(store, "DB_PATH", db)
+        monkeypatch.setattr(store, "STATE_DIR", tmp_path)
+
+        real_try_open = store._try_open
+        calls: list[str] = []
+
+        def _selective_try_open(path, k):
+            p = str(path)
+            calls.append(p)
+            # Temp open (pre-replace) succeeds — backup is verified good.
+            if ".restore-tmp-" in p:
+                return real_try_open(path, k)
+            # Live db_path open (step 2 WAL reset AND post-replace) returns None
+            # — simulates a transient lock or delayed fsync after swap.
+            if p == str(db):
+                return None
+            return real_try_open(path, k)
+
+        monkeypatch.setattr(store, "_try_open", _selective_try_open)
+
+        with pytest.raises(store.RecoveryError):
+            store._repair_corrupt_db(db, key)
+
+        # db_path must now hold the verified backup bytes, not the original corrupt bytes.
+        assert db.exists(), "db_path must exist after swap"
+        assert db.read_bytes() != corrupt_bytes, (
+            "db_path still holds corrupt bytes — os.replace did not run"
+        )
+        assert db.read_bytes() == backup_bytes, (
+            "db_path does not hold the verified backup bytes after swap-ok-reopen-fail"
+        )
+
+        # No temp file must linger.
+        leftover = list(tmp_path.glob("memory.db.restore-tmp-*"))
+        assert leftover == [], f"restore temp file(s) left behind: {leftover}"
 
     def test_connect_triggers_repair_when_open_raises(self, tmp_path, monkeypatch):
         """_connect() must call _repair_corrupt_db when _try_open raises DatabaseError."""

--- a/axi/tests/test_memory_resilience.py
+++ b/axi/tests/test_memory_resilience.py
@@ -406,14 +406,18 @@ class TestStartupRecovery:
     def test_healthy_backup_restore_fails_raises_recovery_error(
         self, tmp_path, monkeypatch
     ):
-        """SAFETY: healthy backup exists but restore raises OSError → MUST raise
-        RecoveryError, MUST NOT wipe db_path to empty.
+        """SAFETY: healthy backup exists but restore fails (temp open returns None) →
+        MUST raise RecoveryError, MUST NOT wipe db_path to empty.
 
-        Discriminates old vs new:
+        Discriminates old vs new (updated for atomic-restore flow):
         - OLD behavior: exits step-3 loop with no success, falls to step 4,
           calls db_path.unlink() and returns an empty-schema connection.
         - NEW behavior: detects healthy_backup_seen=True, refuses to wipe,
           raises RecoveryError so the caller learns recoverable data exists.
+
+        Patching strategy (atomic-restore aware): block _try_open on the temp
+        file path (simulating transient I/O after copy to temp), which is the
+        failure mode that triggered the June-24 real incident.
         """
         db = tmp_path / "memory.db"
         key = "a" * 64
@@ -432,20 +436,20 @@ class TestStartupRecovery:
         # Capture the original bytes of db_path before recovery.
         original_bytes = db.read_bytes()
 
-        # Monkeypatch shutil.copy2 so the restore step always raises OSError.
-        real_copy2 = shutil.copy2
-        call_count = {"n": 0}
+        # Block _try_open on the live db_path (step 2 WAL reset, already fails
+        # because it's garbage) AND on any restore-tmp path (atomic restore
+        # temp-open step) — simulates transient I/O error after copy to temp.
+        real_try_open = store._try_open
 
-        def _failing_copy2(src, dst, **kwargs):
-            call_count["n"] += 1
-            # Only fail copies that target db_path (restores); allow backups.
-            if str(dst) == str(db):
-                raise OSError("disk I/O error — btrfs failure")
-            return real_copy2(src, dst, **kwargs)
+        def _failing_try_open(path, k):
+            p = str(path)
+            if p == str(db) or ".restore-tmp-" in p:
+                return None
+            return real_try_open(path, k)
 
         monkeypatch.setattr(store, "DB_PATH", db)
         monkeypatch.setattr(store, "STATE_DIR", tmp_path)
-        monkeypatch.setattr("axi.store.shutil.copy2", _failing_copy2)
+        monkeypatch.setattr(store, "_try_open", _failing_try_open)
 
         # Must raise RecoveryError (not return an empty connection).
         with pytest.raises(store.RecoveryError):
@@ -465,6 +469,9 @@ class TestStartupRecovery:
 
         OLD: returned a live sqlcipher3.Connection to an empty schema → silent loss.
         NEW: raises, never returns, so no caller can mistake 'empty connection' for success.
+
+        Patching strategy (atomic-restore aware): block _try_open on temp path
+        to simulate the failure mode where copy succeeds but the file won't open.
         """
         db = tmp_path / "memory.db"
         key = "a" * 64
@@ -478,16 +485,17 @@ class TestStartupRecovery:
         c.execute("INSERT INTO t VALUES ('must-not-lose')")
         c.close()
 
-        real_copy2 = shutil.copy2
+        real_try_open = store._try_open
 
-        def _failing_copy2(src, dst, **kwargs):
-            if str(dst) == str(db):
-                raise OSError("disk I/O error")
-            return real_copy2(src, dst, **kwargs)
+        def _failing_try_open(path, k):
+            p = str(path)
+            if p == str(db) or ".restore-tmp-" in p:
+                return None
+            return real_try_open(path, k)
 
         monkeypatch.setattr(store, "DB_PATH", db)
         monkeypatch.setattr(store, "STATE_DIR", tmp_path)
-        monkeypatch.setattr("axi.store.shutil.copy2", _failing_copy2)
+        monkeypatch.setattr(store, "_try_open", _failing_try_open)
 
         result = None
         raised = False
@@ -551,6 +559,118 @@ class TestStartupRecovery:
 
         rows = conn.execute("SELECT content FROM memories").fetchall()
         assert [r[0] for r in rows] == ["survive-recovery"]
+
+    # ── Atomic-restore tests (2026-06-24 clobber fix) ────────────────────────
+
+    def test_failed_restore_does_not_clobber_db_path(self, tmp_path, monkeypatch):
+        """ATOMIC RESTORE — RED test: db_path must be UNTOUCHED when the post-restore
+        open of the temp (or in-place) file fails.
+
+        Discriminates old vs new:
+        - OLD code: shutil.copy2(candidate, db_path) runs BEFORE verifying the file
+          opens → db_path is overwritten with the (stale) backup bytes even when
+          _try_open subsequently fails.  db_path.read_bytes() != original_bytes → FAIL.
+        - NEW code: copy goes to a temp file; _try_open(tmp) fails → tmp.unlink();
+          os.replace is NEVER called → db_path is untouched → PASS.
+
+        The monkeypatch returns None from _try_open when the path is the live db_path
+        (old code) OR when the path ends with ".restore-tmp-*" (new code), simulating
+        a transient btrfs disk-I/O error after copy.
+        """
+        db = tmp_path / "memory.db"
+        key = "a" * 64
+
+        # Original (corrupt) db_path — known bytes so we can assert no change.
+        original_bytes = b"\xff" * 4096
+        db.write_bytes(original_bytes)
+
+        # A healthy backup that passes integrity_check.
+        healthy_bak = tmp_path / "memory.db.clobber-test.bak"
+        c = sqlcipher3.connect(
+            str(healthy_bak), check_same_thread=False, isolation_level=None
+        )
+        c.execute(f"PRAGMA key = \"x'{key}'\"")
+        c.execute("CREATE TABLE nodes (id INTEGER PRIMARY KEY, label TEXT)")
+        c.execute("INSERT INTO nodes (label) VALUES ('do-not-lose')")
+        c.close()
+
+        monkeypatch.setattr(store, "DB_PATH", db)
+        monkeypatch.setattr(store, "STATE_DIR", tmp_path)
+
+        real_try_open = store._try_open
+
+        def _failing_open_for_restore(path, k):
+            # Fail when called on the live db_path (old code path) OR
+            # on any restore-tmp file (new code path) — simulates transient I/O.
+            p = str(path)
+            if p == str(db) or ".restore-tmp-" in p:
+                return None
+            return real_try_open(path, k)
+
+        monkeypatch.setattr(store, "_try_open", _failing_open_for_restore)
+
+        # Must raise RecoveryError (healthy_backup_seen=True but restore failed).
+        with pytest.raises(store.RecoveryError):
+            store._repair_corrupt_db(db, key)
+
+        # INVARIANT: db_path bytes must be identical to what we put there.
+        assert db.exists(), "db_path must not be unlinked"
+        assert db.read_bytes() == original_bytes, (
+            "db_path was clobbered during a failed restore attempt — "
+            "shutil.copy2 ran directly onto db_path before verifying the open succeeded"
+        )
+
+        # No temp file must linger.
+        leftover_tmp = list(tmp_path.glob("memory.db.restore-tmp-*"))
+        assert leftover_tmp == [], (
+            f"restore temp file(s) left behind: {leftover_tmp}"
+        )
+
+    def test_successful_restore_swaps_atomically(self, tmp_path, monkeypatch):
+        """ATOMIC RESTORE — GREEN path: healthy backup + successful open → db_path
+        contains restored content, returns working connection, no temp file left.
+
+        Discriminates old vs new:
+        - OLD: works by luck (copy2 directly to db_path, _try_open succeeds) but
+          is non-atomic.  This test passes on old code too — it is a regression
+          guard that ensures new atomic code does not break the happy path.
+        - NEW: temp file created, verified, os.replace atomically swaps in → same
+          observable result but with atomicity guarantee.
+        """
+        db = tmp_path / "memory.db"
+        key = "a" * 64
+
+        # Corrupt main file.
+        db.write_bytes(b"\xff" * 4096)
+
+        # Healthy backup with distinct data.
+        healthy_bak = tmp_path / "memory.db.atomic-ok.bak"
+        c = sqlcipher3.connect(
+            str(healthy_bak), check_same_thread=False, isolation_level=None
+        )
+        c.execute(f"PRAGMA key = \"x'{key}'\"")
+        c.execute("CREATE TABLE memories (id INTEGER PRIMARY KEY, content TEXT)")
+        c.execute("INSERT INTO memories (content) VALUES ('atomic-swap-ok')")
+        c.close()
+
+        monkeypatch.setattr(store, "DB_PATH", db)
+        monkeypatch.setattr(store, "STATE_DIR", tmp_path)
+
+        conn = store._repair_corrupt_db(db, key)
+        assert conn is not None, "successful restore must return a valid connection"
+
+        # db_path now has the restored content.
+        rows = conn.execute("SELECT content FROM memories").fetchall()
+        assert [r[0] for r in rows] == ["atomic-swap-ok"], (
+            "restored data not found after successful recovery"
+        )
+        conn.close()
+
+        # No temp file must linger.
+        leftover_tmp = list(tmp_path.glob("memory.db.restore-tmp-*"))
+        assert leftover_tmp == [], (
+            f"restore temp file(s) left behind: {leftover_tmp}"
+        )
 
     def test_connect_triggers_repair_when_open_raises(self, tmp_path, monkeypatch):
         """_connect() must call _repair_corrupt_db when _try_open raises DatabaseError."""


### PR DESCRIPTION
## Why
On 2026-06-24 the live 169-node memory.db was replaced by an old 136-node backup. Root cause: `_repair_corrupt_db` step 3 did `shutil.copy2(candidate, db_path)` **in place** before verifying the restored file opens. When the post-copy open hit a transient btrfs "disk I/O error", db_path was left as that stale/half backup — and concurrent readers could see a half-written file mid-copy. (#142 stopped the wipe-to-empty, but not this clobber.)

## What
Restore is now **atomic**: build the restored file as a temp in the same directory, verify it opens, then `os.replace(tmp, db_path)` (atomic rename within the filesystem). The live db_path is never mutated unless a fully-verified-good file is swapped in; readers see the old or the new file, never a half.

- Temp name is process+thread+random unique (`restore-tmp-<pid>-<tid>-<token>`) so concurrent recoveries never collide.
- `verify.close()` runs before the rename (no open handle during `os.replace`); stale `-wal`/`-shm` cleared before the swap.
- #142 preserved: if healthy backups exist but no restore yields a healthy open, still **RecoveryError** (never wipe).
- Temp file is unlinked on every path (finally) — no leaks.

## Quality
- Strict TDD. **1560 passed, 6 skipped.**
- Dual blind adversarial review (sonnet + opus) → both APPROVE, core invariant (no clobber) verified by full path-trace. Their suggestions applied: thread-unique temp, accurate comment + RecoveryError message, and two added tests — one reproducing the **real incident** (`_try_open` raises `DatabaseError` on the temp → db_path bytes unchanged) and one locking the swap-ok-but-reopen-fails corner.

First of the data-integrity follow-ups from the 2026-06-24 recovery cascade (engram axi/memory-db-corruption-root-cause). Remaining: single-process-recovery serialization, graceful API degradation on RecoveryError.