### PR TITLE
fix(dashboard): /api/snapshot degrades gracefully when memory.db is unreadable (no more blank UI)

### DIFF
--- a/axi/src/axi/dashboard.py
+++ b/axi/src/axi/dashboard.py
@@ -1195,15 +1195,6 @@ def _memory_snapshot() -> dict[str, Any]:
     return result
 
 
-def _fact_count() -> int:
-    try:
-        c = store._connect()  # noqa: SLF001
-        return c.execute("SELECT COUNT(*) AS n FROM nodes WHERE kind='fact'").fetchone()["n"]
-    except Exception as e:  # noqa: BLE001
-        log.warning("fact count unavailable (memory.db degraded): %s", e)
-        return 0
-
-
 @app.post("/api/cmd/{name}")
 def cmd(name: str):
     log.info("/api/cmd/%s invoked", name)

--- a/axi/src/axi/dashboard.py
+++ b/axi/src/axi/dashboard.py
@@ -1004,13 +1004,17 @@ def _recent_conversations(limit: int = 10) -> list[dict[str, Any]]:
 
 
 def _recent_facts(limit: int = 30) -> list[dict[str, Any]]:
-    c = store._connect()  # noqa: SLF001
-    rows = c.execute(
-        "SELECT id, label, data, domain, created_at, created_tz "
-        "FROM nodes WHERE kind = 'fact' "
-        "ORDER BY created_at DESC LIMIT ?",
-        (limit,),
-    ).fetchall()
+    try:
+        c = store._connect()  # noqa: SLF001
+        rows = c.execute(
+            "SELECT id, label, data, domain, created_at, created_tz "
+            "FROM nodes WHERE kind = 'fact' "
+            "ORDER BY created_at DESC LIMIT ?",
+            (limit,),
+        ).fetchall()
+    except Exception as e:  # noqa: BLE001
+        log.warning("recent facts unavailable (memory.db degraded): %s", e)
+        return []
     out = []
     for r in rows:
         try:
@@ -1111,10 +1115,7 @@ def snapshot():
             "vision_enabled": bool(config.get("vision_enabled", True)),
             "tts_enabled": bool(config.get("tts_enabled", True)),
         },
-        "memory": {
-            "conversation_turns": _safe_conversation_count(),
-            "facts_count": _fact_count(),
-        },
+        "memory": _memory_snapshot(),
         "recent_conversations": _recent_conversations(10),
         "recent_facts": _recent_facts(20),
         "unread_critical_events": events.unread_critical_count(),
@@ -1154,9 +1155,53 @@ def _safe_conversation_count() -> int:
         return 0
 
 
+def _memory_snapshot() -> dict[str, Any]:
+    """Return memory stats with graceful degradation on DB failure.
+
+    Each DB read is attempted independently. If any fails, ``degraded`` is set
+    to True so the frontend can show a discreet recovery indicator without
+    blanking the UI. Safe defaults (0 / []) are used for failed reads.
+    """
+    degraded = False
+    reason_parts: list[str] = []
+
+    try:
+        conversation_turns: int = store.conversation_count()
+    except Exception as e:  # noqa: BLE001
+        log.warning("conversation count unavailable (memory.db degraded): %s", e)
+        conversation_turns = 0
+        degraded = True
+        reason_parts.append(f"conversation_count: {e}")
+
+    try:
+        c = store._connect()  # noqa: SLF001
+        facts_count: int = c.execute(
+            "SELECT COUNT(*) AS n FROM nodes WHERE kind='fact'"
+        ).fetchone()["n"]
+    except Exception as e:  # noqa: BLE001
+        log.warning("fact count unavailable (memory.db degraded): %s", e)
+        facts_count = 0
+        degraded = True
+        reason_parts.append(f"facts_count: {e}")
+
+    result: dict[str, Any] = {
+        "conversation_turns": conversation_turns,
+        "facts_count": facts_count,
+    }
+    if degraded:
+        result["degraded"] = True
+        if reason_parts:
+            result["degraded_reason"] = "; ".join(reason_parts)
+    return result
+
+
 def _fact_count() -> int:
-    c = store._connect()  # noqa: SLF001
-    return c.execute("SELECT COUNT(*) AS n FROM nodes WHERE kind='fact'").fetchone()["n"]
+    try:
+        c = store._connect()  # noqa: SLF001
+        return c.execute("SELECT COUNT(*) AS n FROM nodes WHERE kind='fact'").fetchone()["n"]
+    except Exception as e:  # noqa: BLE001
+        log.warning("fact count unavailable (memory.db degraded): %s", e)
+        return 0
 
 
 @app.post("/api/cmd/{name}")

--- a/axi/src/axi/templates/dashboard.html
+++ b/axi/src/axi/templates/dashboard.html
@@ -211,6 +211,10 @@
         <div class="font-semibold mb-1" style="color:var(--pink)">💾 Memoria</div>
         <div class="muted text-xs">Hechos recordados: <span x-text="($store.snap.memory && $store.snap.memory.facts_count) || 0"></span></div>
         <div class="muted text-xs">Conversaciones: <span x-text="($store.snap.memory && $store.snap.memory.conversation_turns) || 0"></span></div>
+        <div x-show="$store.snap.memory && $store.snap.memory.degraded"
+             style="margin-top:0.4rem;padding:0.25rem 0.5rem;border-radius:4px;background:rgba(255,200,0,0.12);border:1px solid rgba(255,200,0,0.35);color:#c8a000;font-size:0.7rem;line-height:1.3">
+          Memoria en recuperación — tus datos están a salvo en disco
+        </div>
       </div>
       <div id="popover-ears" x-show="open === 'ears'"
            class="panel2 p-3 text-sm absolute z-50" style="min-width:200px; display:none; top:1rem; right:1rem">
@@ -349,7 +353,7 @@
       <div class="panel p-4">
         <div class="text-sm muted mb-3">Services</div>
         <div class="space-y-2 text-sm">
-          <template x-for="[name, state] in Object.entries($store.snap.services)" :key="name">
+          <template x-for="[name, state] in Object.entries($store.snap.services || {})" :key="name">
             <div class="flex justify-between">
               <span x-text="name"></span>
               <span :style="state === 'active' ? 'color: var(--green)' : 'color: var(--red)'" x-text="state"></span>

--- a/axi/src/axi/templates/dashboard.html
+++ b/axi/src/axi/templates/dashboard.html
@@ -465,7 +465,7 @@
       <div class="panel p-4">
         <div class="flex justify-between items-baseline mb-3">
           <div class="font-semibold">Hechos en memoria de largo plazo</div>
-          <div class="muted text-xs" x-text="$store.snap.memory.facts_count + ' total'"></div>
+          <div class="muted text-xs" x-text="(($store.snap.memory && $store.snap.memory.facts_count) || 0) + ' total'"></div>
         </div>
         <template x-if="$store.snap.recent_facts.length === 0">
           <div class="muted text-sm py-4">Aún no se han extraído hechos. Habla con Axi vía Meta+Shift+Espacio y se irán acumulando aquí.</div>
@@ -487,7 +487,7 @@
       <div class="panel p-4">
         <div class="flex justify-between items-baseline mb-3">
           <div class="font-semibold">Conversaciones recientes</div>
-          <div class="muted text-xs" x-text="$store.snap.memory.conversation_turns + ' turnos guardados'"></div>
+          <div class="muted text-xs" x-text="(($store.snap.memory && $store.snap.memory.conversation_turns) || 0) + ' turnos guardados'"></div>
         </div>
         <template x-if="$store.snap.recent_conversations.length === 0">
           <div class="muted text-sm py-4">No hay conversaciones todavía.</div>

--- a/axi/tests/test_snapshot_graceful_degradation.py
+++ b/axi/tests/test_snapshot_graceful_degradation.py
@@ -130,25 +130,9 @@ class TestSnapshotDegradeOnDatabaseError:
 # ──────────────────────────────────────────────────────────────────
 
 class TestHelpersSafeDefaults:
-    """_fact_count() → 0 and _recent_facts() → [] on DB failure."""
-
-    def test_fact_count_returns_zero_on_recovery_error(self, monkeypatch):
-        """_fact_count must return 0 instead of propagating RecoveryError."""
-        from axi import dashboard, store
-
-        def _raise(): raise store.RecoveryError("db gone")
-        monkeypatch.setattr(store, "_connect", _raise)
-        result = dashboard._fact_count()
-        assert result == 0
-
-    def test_fact_count_returns_zero_on_database_error(self, monkeypatch):
-        """_fact_count must return 0 instead of propagating DatabaseError."""
-        from axi import dashboard, store
-
-        def _raise(): raise _sc3_dbapi.DatabaseError("disk I/O error")
-        monkeypatch.setattr(store, "_connect", _raise)
-        result = dashboard._fact_count()
-        assert result == 0
+    """_recent_facts() → [] on DB failure. (Fact-count degradation is covered at
+    the snapshot level — see TestSnapshotDegradeOn* — since the inline count in
+    _memory_snapshot replaced the old _fact_count helper.)"""
 
     def test_recent_facts_returns_empty_list_on_recovery_error(self, monkeypatch):
         """_recent_facts must return [] instead of propagating RecoveryError."""

--- a/axi/tests/test_snapshot_graceful_degradation.py
+++ b/axi/tests/test_snapshot_graceful_degradation.py
@@ -1,0 +1,218 @@
+"""Tests for /api/snapshot graceful degradation when memory.db is unavailable.
+
+The endpoint must NEVER return HTTP 500 due to DB failures. Instead it must:
+- Return HTTP 200 with all non-DB fields intact
+- Return safe defaults for memory fields (counts=0, lists=[])
+- Set memory.degraded=True when any DB read failed
+
+RED criteria: `_fact_count` and `_recent_facts` currently call `store._connect()`
+without a guard, so RecoveryError/DatabaseError propagates → 500.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+import sqlcipher3.dbapi2 as _sc3_dbapi
+
+
+# ──────────────────────────────────────────────────────────────────
+# Helpers / fixtures
+# ──────────────────────────────────────────────────────────────────
+
+def _minimal_monkeypatches(monkeypatch, dashboard):
+    """Patch everything that touches external state so snapshot is stable."""
+    monkeypatch.setattr(dashboard, "_daemon_cmd", lambda *_a, **_k: "idle")
+    monkeypatch.setattr(dashboard, "_llama_alive", lambda: False)
+    monkeypatch.setattr(dashboard, "_service_state", lambda *_a, **_k: "active")
+    monkeypatch.setattr(dashboard, "_vram_snapshot", lambda: {
+        "name": "test", "used_mb": 0, "total_mb": 0, "util_pct": 0,
+    })
+    monkeypatch.setattr(dashboard, "_ram_snapshot", lambda: {
+        "used": 0, "total": 1, "pct": 0.0,
+    })
+    monkeypatch.setattr(dashboard, "_cpu_pct", lambda: 0.0)
+
+
+# ──────────────────────────────────────────────────────────────────
+# Task 1 — /api/snapshot returns 200 even when DB raises RecoveryError
+# ──────────────────────────────────────────────────────────────────
+
+class TestSnapshotDegradeOnRecoveryError:
+    """The endpoint must not propagate RecoveryError as an HTTP 500."""
+
+    @pytest.fixture
+    def client_db_recovery_error(self, monkeypatch):
+        from axi import dashboard, store
+
+        _minimal_monkeypatches(monkeypatch, dashboard)
+
+        def _raise_recovery(*_a, **_k):
+            raise store.RecoveryError("memory.db temporarily unreadable")
+
+        # Patch store._connect so every DB-touching call explodes.
+        monkeypatch.setattr(store, "_connect", _raise_recovery)
+        # _safe_conversation_count calls store.conversation_count, not _connect directly.
+        monkeypatch.setattr(store, "conversation_count", _raise_recovery)
+        monkeypatch.setattr(store, "recent_conversations", _raise_recovery)
+
+        return TestClient(dashboard.app)
+
+    def test_snapshot_returns_200_on_recovery_error(self, client_db_recovery_error):
+        """HTTP 200 — not 500 — when DB raises RecoveryError."""
+        r = client_db_recovery_error.get("/api/snapshot")
+        assert r.status_code == 200, f"Expected 200, got {r.status_code}: {r.text}"
+
+    def test_snapshot_non_db_fields_present_on_recovery_error(self, client_db_recovery_error):
+        """services, vram, ram are unaffected by the DB failure."""
+        data = client_db_recovery_error.get("/api/snapshot").json()
+        assert "services" in data
+        assert "vram" in data
+        assert "ram" in data
+        assert "state" in data
+
+    def test_snapshot_memory_degraded_true_on_recovery_error(self, client_db_recovery_error):
+        """memory.degraded must be True when the DB raised."""
+        data = client_db_recovery_error.get("/api/snapshot").json()
+        memory = data.get("memory", {})
+        assert memory.get("degraded") is True
+
+    def test_snapshot_memory_safe_defaults_on_recovery_error(self, client_db_recovery_error):
+        """conversation_turns and facts_count default to 0 on DB failure."""
+        data = client_db_recovery_error.get("/api/snapshot").json()
+        memory = data.get("memory", {})
+        assert memory.get("conversation_turns") == 0
+        assert memory.get("facts_count") == 0
+
+    def test_snapshot_recent_lists_empty_on_recovery_error(self, client_db_recovery_error):
+        """recent_conversations and recent_facts default to [] on DB failure."""
+        data = client_db_recovery_error.get("/api/snapshot").json()
+        assert data.get("recent_conversations") == []
+        assert data.get("recent_facts") == []
+
+
+# ──────────────────────────────────────────────────────────────────
+# Task 2 — /api/snapshot returns 200 when DB raises DatabaseError
+# ──────────────────────────────────────────────────────────────────
+
+class TestSnapshotDegradeOnDatabaseError:
+    """The endpoint must not propagate DatabaseError as an HTTP 500."""
+
+    @pytest.fixture
+    def client_db_database_error(self, monkeypatch):
+        from axi import dashboard, store
+
+        _minimal_monkeypatches(monkeypatch, dashboard)
+
+        def _raise_db_error(*_a, **_k):
+            raise _sc3_dbapi.DatabaseError("disk I/O error")
+
+        monkeypatch.setattr(store, "_connect", _raise_db_error)
+        monkeypatch.setattr(store, "conversation_count", _raise_db_error)
+        monkeypatch.setattr(store, "recent_conversations", _raise_db_error)
+
+        return TestClient(dashboard.app)
+
+    def test_snapshot_returns_200_on_database_error(self, client_db_database_error):
+        """HTTP 200 — not 500 — when DB raises DatabaseError."""
+        r = client_db_database_error.get("/api/snapshot")
+        assert r.status_code == 200, f"Expected 200, got {r.status_code}: {r.text}"
+
+    def test_snapshot_memory_degraded_true_on_database_error(self, client_db_database_error):
+        """memory.degraded must be True when DatabaseError was caught."""
+        data = client_db_database_error.get("/api/snapshot").json()
+        memory = data.get("memory", {})
+        assert memory.get("degraded") is True
+
+
+# ──────────────────────────────────────────────────────────────────
+# Task 3 — Unit tests for individual helpers
+# ──────────────────────────────────────────────────────────────────
+
+class TestHelpersSafeDefaults:
+    """_fact_count() → 0 and _recent_facts() → [] on DB failure."""
+
+    def test_fact_count_returns_zero_on_recovery_error(self, monkeypatch):
+        """_fact_count must return 0 instead of propagating RecoveryError."""
+        from axi import dashboard, store
+
+        def _raise(): raise store.RecoveryError("db gone")
+        monkeypatch.setattr(store, "_connect", _raise)
+        result = dashboard._fact_count()
+        assert result == 0
+
+    def test_fact_count_returns_zero_on_database_error(self, monkeypatch):
+        """_fact_count must return 0 instead of propagating DatabaseError."""
+        from axi import dashboard, store
+
+        def _raise(): raise _sc3_dbapi.DatabaseError("disk I/O error")
+        monkeypatch.setattr(store, "_connect", _raise)
+        result = dashboard._fact_count()
+        assert result == 0
+
+    def test_recent_facts_returns_empty_list_on_recovery_error(self, monkeypatch):
+        """_recent_facts must return [] instead of propagating RecoveryError."""
+        from axi import dashboard, store
+
+        def _raise(): raise store.RecoveryError("db gone")
+        monkeypatch.setattr(store, "_connect", _raise)
+        result = dashboard._recent_facts(10)
+        assert result == []
+
+    def test_recent_facts_returns_empty_list_on_database_error(self, monkeypatch):
+        """_recent_facts must return [] instead of propagating DatabaseError."""
+        from axi import dashboard, store
+
+        def _raise(): raise _sc3_dbapi.DatabaseError("disk I/O error")
+        monkeypatch.setattr(store, "_connect", _raise)
+        result = dashboard._recent_facts(10)
+        assert result == []
+
+
+# ──────────────────────────────────────────────────────────────────
+# Task 4 — Happy path: DB works → real counts, degraded absent/False
+# ──────────────────────────────────────────────────────────────────
+
+class TestSnapshotHappyPath:
+    """When the DB works, snapshot returns real data and memory.degraded is absent or False."""
+
+    @pytest.fixture
+    def client_db_ok(self, monkeypatch):
+        from axi import dashboard, store
+
+        _minimal_monkeypatches(monkeypatch, dashboard)
+
+        # Stub _memory_snapshot to return known healthy values.
+        monkeypatch.setattr(dashboard, "_memory_snapshot", lambda: {
+            "conversation_turns": 7,
+            "facts_count": 42,
+        })
+        monkeypatch.setattr(dashboard, "_recent_conversations", lambda n=10: [
+            {"id": 1, "ts": 0, "ts_human": "now", "user": "hi", "axi": "hello", "has_screenshot": False}
+        ])
+        monkeypatch.setattr(dashboard, "_recent_facts", lambda n=30: [
+            {"id": 1, "label": "test fact", "domain": "health", "category": None,
+             "created_ts": 0, "created_human": "now", "created_tz": "UTC"}
+        ])
+
+        return TestClient(dashboard.app)
+
+    def test_snapshot_happy_path_has_real_counts(self, client_db_ok):
+        """Real counts flow through when DB is healthy."""
+        data = client_db_ok.get("/api/snapshot").json()
+        memory = data.get("memory", {})
+        assert memory.get("facts_count") == 42
+        assert memory.get("conversation_turns") == 7
+
+    def test_snapshot_happy_path_degraded_is_false_or_absent(self, client_db_ok):
+        """memory.degraded must be False or absent when DB is healthy."""
+        data = client_db_ok.get("/api/snapshot").json()
+        memory = data.get("memory", {})
+        # Degraded flag should be absent or explicitly False.
+        assert not memory.get("degraded", False)
+
+    def test_snapshot_happy_path_recent_lists_populated(self, client_db_ok):
+        """recent_conversations and recent_facts are populated when DB works."""
+        data = client_db_ok.get("/api/snapshot").json()
+        assert len(data.get("recent_conversations", [])) == 1
+        assert len(data.get("recent_facts", [])) == 1


### PR DESCRIPTION
## Why
When recovery raises `RecoveryError` (or memory.db transiently throws a disk I/O error), `/api/snapshot` returned HTTP 500. The frontend left `$store.snap` null → `<template x-if="$store.snap">` never rendered → the whole dashboard (organs, incl. the brain) went blank and clicking did nothing. This is what made "el cerebro no hace nada" during the 2026-06-24 incident.

## What
`/api/snapshot` now NEVER 500s because the DB is unavailable — it returns **200 with safe defaults and `memory.degraded=true`**:
- All DB-touching snapshot helpers are guarded (catch `RecoveryError` / `DatabaseError` / `Exception` → safe default + log): the fact count and recent-facts/conversations reads. Non-DB fields (services, vram, ram, cpu — from systemd/nvidia//proc) are unaffected, so the dashboard still renders.
- New `_memory_snapshot()` builds the memory section and sets `degraded=true` + a short reason when a read fails; the keys (`conversation_turns`, `facts_count`) stay present (0) so nothing downstream breaks. `degraded` is absent when healthy.
- Frontend: a discreet amber "Memoria en recuperación — tus datos están a salvo en disco" banner when degraded, plus null-guards (`$store.snap.services || {}`, `$store.snap.memory && …`) so a partial snapshot can never throw.

## Quality
- Strict TDD. **1574 passed.**
- 12 tests incl. the discriminator: `store._connect` raising `RecoveryError`/`DatabaseError` → `/api/snapshot` returns **200** (500 on old code), `memory.degraded=true`, counts 0, lists [].
- Fresh-context verification: full audit of the snapshot DB touchpoints — **zero unguarded paths remain**. Review polish applied: guarded the brain-modal memory counters and removed the now-dead `_fact_count` helper.

Closes the user-facing half of the 2026-06-24 recovery-cascade follow-ups (engram axi/memory-db-corruption-root-cause). Remaining: single-process-recovery serialization (#2).