### PR TITLE
feat(dashboard): Cerebro 3D polish — Spanish labels (i18n) + hide duplicated header in modal

### DIFF
--- a/axi/src/axi/dashboard.py
+++ b/axi/src/axi/dashboard.py
@@ -1956,7 +1956,12 @@ def graph_page(request: Request):
 @app.get("/brain3d", response_class=HTMLResponse)
 def brain3d_page(request: Request):
     """3D interactive visualization of the semantic memory graph."""
-    return templates.TemplateResponse(request, "brain3d.html", {})
+    raw_lang = str(config.get("language", "es-MX"))
+    # Normalize locale tag to 2-letter code: es-MX → es, en-US → en, etc.
+    lang = raw_lang.split("-")[0].lower() if "-" in raw_lang else raw_lang[:2].lower()
+    if lang not in ("es", "en"):
+        lang = "es"
+    return templates.TemplateResponse(request, "brain3d.html", {"lang": lang})
 
 
 @app.get("/api/graph")

--- a/axi/src/axi/templates/brain3d.html
+++ b/axi/src/axi/templates/brain3d.html
@@ -2,6 +2,13 @@
 {% block title %}Cerebro 3D · Axi{% endblock %}
 
 {% block content %}
+<!-- When this page is loaded inside the dashboard's brain modal iframe, the
+     modal already provides its own header ("🧠 Cerebro 3D · Cerrar"), so the
+     global nav header from _base.html (LifeOS logo, clock, VRAM, menu) is
+     redundant and looks like a nested/duplicated header. Hide it when embedded.
+     Standalone navigation to /brain3d still shows the full nav. -->
+<style>html.embedded body > header { display: none !important; }</style>
+<script>if (window.self !== window.top) document.documentElement.classList.add('embedded');</script>
 <div class="space-y-4" x-data="brain3dPage()" x-init="load()">
 
   <!-- ─── header ─── -->

--- a/axi/src/axi/templates/brain3d.html
+++ b/axi/src/axi/templates/brain3d.html
@@ -52,7 +52,7 @@
             <div class="flex items-center gap-2">
               <span style="width:10px;height:10px;border-radius:50%;flex-shrink:0;"
                     :style="'background:' + color"></span>
-              <span x-text="domain"></span>
+              <span x-text="tLabel(domain)"></span>
             </div>
           </template>
         </div>
@@ -81,11 +81,11 @@
             <div class="muted text-xs space-y-0.5">
               <div>
                 <span class="font-medium">Tipo:</span>
-                <span x-text="selectedNode.kind"></span>
+                <span x-text="tLabel(selectedNode.kind)"></span>
               </div>
               <div x-show="selectedNode.domain">
                 <span class="font-medium">Dominio:</span>
-                <span x-text="selectedNode.domain"></span>
+                <span x-text="tLabel(selectedNode.domain)"></span>
               </div>
               <div>
                 <span class="font-medium">Embedding:</span>
@@ -100,7 +100,7 @@
                 <div class="space-y-1.5 max-h-64 overflow-y-auto">
                   <template x-for="edge in neighborEdges" :key="edge._key">
                     <div class="panel2 p-2 text-xs rounded">
-                      <div class="font-medium" x-text="edge.kind"></div>
+                      <div class="font-medium" x-text="tEdge(edge.kind)"></div>
                       <div class="muted mt-0.5" x-text="edge.direction + ' ' + edge.neighborLabel"></div>
                       <div x-show="edge.system" class="muted text-xs" x-text="'sistema ' + edge.system"></div>
                     </div>
@@ -133,7 +133,12 @@ function escHtml(str) {
     .replace(/'/g, '&#39;');
 }
 
+// UI language injected by the server from the 'language' config key.
+// 'es-MX' → 'es', 'en-US' → 'en'. Defaults to 'es'.
+const LANG = '{{ lang | default("es") }}';
+
 // Domain-to-color map — consistent palette across all renders.
+// Keys are canonical English identifiers; displayed text uses tLabel/tEdge.
 const DOMAIN_COLOR = {
   relationships: '#FF6B9D',  // pink
   health:        '#22cc55',  // green
@@ -147,6 +152,78 @@ const DOMAIN_COLOR = {
   spirituality:  '#ff44aa',  // rose
   default:       '#888888',  // grey
 };
+
+// i18n label maps for domain/kind keys and edge kind keys.
+// Add a new locale by extending with a new top-level key.
+// Unknown keys fall back to the raw canonical key (graceful degradation).
+const LABELS = {
+  es: {
+    // Domains + kinds
+    relationships: 'Relaciones',
+    health:        'Salud',
+    finance:       'Finanzas',
+    conversation:  'Conversación',
+    fact:          'Hecho',
+    event:         'Evento',
+    'lifeos-events': 'Evento',
+    meeting:       'Reunión',
+    exercise:      'Ejercicio',
+    learning:      'Aprendizaje',
+    spirituality:  'Espiritualidad',
+    person:        'Persona',
+    default:       'General',
+    // Edge kinds
+    'similar-to':       'Similar a',
+    'same-day':         'Mismo día',
+    'happened-at':      'Ocurrió en',
+    'involves-person':  'Involucra a',
+    'mentioned_in':     'Mencionado en',
+    'has_setup':        'Configuración',
+  },
+  en: {
+    // Domains + kinds
+    relationships: 'Relationships',
+    health:        'Health',
+    finance:       'Finance',
+    conversation:  'Conversation',
+    fact:          'Fact',
+    event:         'Event',
+    'lifeos-events': 'Event',
+    meeting:       'Meeting',
+    exercise:      'Exercise',
+    learning:      'Learning',
+    spirituality:  'Spirituality',
+    person:        'Person',
+    default:       'General',
+    // Edge kinds
+    'similar-to':       'Similar to',
+    'same-day':         'Same day',
+    'happened-at':      'Happened at',
+    'involves-person':  'Involves',
+    'mentioned_in':     'Mentioned in',
+    'has_setup':        'Setup',
+  },
+};
+
+/**
+ * Translate a domain or node kind key to the current UI language.
+ * Falls back to the raw key when no translation exists (future-safe).
+ */
+function tLabel(key) {
+  if (!key) return key;
+  const map = LABELS[LANG] || LABELS['es'];
+  return map[key] !== undefined ? map[key] : key;
+}
+
+/**
+ * Translate an edge kind key to the current UI language.
+ * Falls back to the raw key when no translation exists.
+ */
+function tEdge(key) {
+  if (!key) return key;
+  const map = LABELS[LANG] || LABELS['es'];
+  return map[key] !== undefined ? map[key] : key;
+}
 
 function brain3dPage() {
   return {

--- a/axi/tests/test_brain3d_i18n.py
+++ b/axi/tests/test_brain3d_i18n.py
@@ -1,0 +1,245 @@
+"""Strict TDD RED tests for Cerebro 3D i18n label layer.
+
+Tests cover:
+1. Route /brain3d passes lang from config (es-MX → 'es', en-US → 'en').
+2. LABELS map completeness: every DOMAIN_COLOR key has es + en entries.
+3. Rendered HTML in Spanish contains translated labels (Relaciones, Salud, etc.).
+4. Rendered HTML does NOT contain bare raw keys as sole visible legend text.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+BRAIN3D = Path(__file__).parents[1] / "src" / "axi" / "templates" / "brain3d.html"
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _template_source() -> str:
+    return BRAIN3D.read_text(encoding="utf-8")
+
+
+def _client_with_language(monkeypatch, language: str) -> TestClient:
+    """Return a TestClient backed by dashboard.app with config language overridden."""
+    from axi import config as axi_config
+    monkeypatch.setattr(axi_config, "get", lambda key, default=None: (
+        language if key == "language" else default
+    ))
+    from axi import dashboard
+    return TestClient(dashboard.app)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Test 1: Route passes lang=es for es-MX config
+# RED discriminator: route currently passes {} — no lang in context.
+# ──────────────────────────────────────────────────────────────────────────────
+
+def test_brain3d_route_passes_lang_es_for_es_mx(monkeypatch):
+    """GET /brain3d with config language=es-MX → HTML contains lang='es' marker."""
+    client = _client_with_language(monkeypatch, "es-MX")
+    resp = client.get("/brain3d")
+    assert resp.status_code == 200
+    html = resp.text
+    # The template must emit a lang marker: data-lang="es" or const LANG = 'es'
+    assert 'data-lang="es"' in html or "const LANG = 'es'" in html or 'lang: "es"' in html, (
+        "GET /brain3d with language=es-MX must embed lang='es' in the rendered HTML. "
+        "Got no such marker — route is passing {} instead of {lang: 'es'}."
+    )
+
+
+def test_brain3d_route_passes_lang_en_for_en_us(monkeypatch):
+    """GET /brain3d with config language=en-US → HTML contains lang='en' marker."""
+    client = _client_with_language(monkeypatch, "en-US")
+    resp = client.get("/brain3d")
+    assert resp.status_code == 200
+    html = resp.text
+    assert 'data-lang="en"' in html or "const LANG = 'en'" in html or 'lang: "en"' in html, (
+        "GET /brain3d with language=en-US must embed lang='en' in the rendered HTML. "
+        "Got no such marker — route is passing {} instead of {lang: 'en'}."
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Test 2: LABELS completeness — every DOMAIN_COLOR key has es + en translations
+# RED discriminator: LABELS map does not exist yet in the template.
+# ──────────────────────────────────────────────────────────────────────────────
+
+# Extract DOMAIN_COLOR keys from the source directly so this test stays in sync.
+_DOMAIN_COLOR_KEYS = [
+    "relationships", "health", "finance", "conversation", "fact",
+    "event", "meeting", "exercise", "learning", "spirituality", "default",
+]
+
+# Expected Spanish translations for each DOMAIN_COLOR key.
+_EXPECTED_ES = {
+    "relationships": "Relaciones",
+    "health": "Salud",
+    "finance": "Finanzas",
+    "conversation": "Conversación",
+    "fact": "Hecho",
+    "event": "Evento",
+    "meeting": "Reunión",
+    "exercise": "Ejercicio",
+    "learning": "Aprendizaje",
+    "spirituality": "Espiritualidad",
+    "default": "General",
+}
+
+# Expected English translations for each DOMAIN_COLOR key.
+_EXPECTED_EN = {
+    "relationships": "Relationships",
+    "health": "Health",
+    "finance": "Finance",
+    "conversation": "Conversation",
+    "fact": "Fact",
+    "event": "Event",
+    "meeting": "Meeting",
+    "exercise": "Exercise",
+    "learning": "Learning",
+    "spirituality": "Spirituality",
+    "default": "General",
+}
+
+
+def test_labels_map_exists_in_template():
+    """brain3d.html must define a LABELS map with 'es' and 'en' sub-maps."""
+    src = _template_source()
+    assert "const LABELS" in src or "var LABELS" in src or "let LABELS" in src, (
+        "brain3d.html must define a LABELS map for i18n translations. "
+        "No LABELS declaration found."
+    )
+
+
+def test_labels_map_has_es_entries():
+    """LABELS.es must contain translations for every DOMAIN_COLOR key."""
+    src = _template_source()
+    for key, es_label in _EXPECTED_ES.items():
+        assert es_label in src, (
+            f"LABELS.es is missing Spanish translation for '{key}': expected '{es_label}'"
+        )
+
+
+def test_labels_map_has_en_entries():
+    """LABELS.en must contain translations for every DOMAIN_COLOR key."""
+    src = _template_source()
+    for key, en_label in _EXPECTED_EN.items():
+        # "Fact", "Event", etc. — must appear in the en section of LABELS
+        assert en_label in src, (
+            f"LABELS.en is missing English translation for '{key}': expected '{en_label}'"
+        )
+
+
+def test_labels_map_has_edge_translations():
+    """LABELS must contain translations for the known edge kind keys."""
+    src = _template_source()
+    expected_edge_es = [
+        "Similar a", "Mismo día", "Ocurrió en", "Involucra a",
+        "Mencionado en", "Configuración",
+    ]
+    for label in expected_edge_es:
+        assert label in src, (
+            f"LABELS is missing edge translation: '{label}'"
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Test 3: tLabel and tEdge helpers are defined in the template
+# RED discriminator: helpers don't exist yet.
+# ──────────────────────────────────────────────────────────────────────────────
+
+def test_tlabel_helper_defined():
+    """brain3d.html must define a tLabel() helper function."""
+    src = _template_source()
+    assert "function tLabel" in src or "tLabel(" in src, (
+        "brain3d.html must define a tLabel() helper for domain/kind translations."
+    )
+
+
+def test_tedge_helper_defined():
+    """brain3d.html must define a tEdge() helper function."""
+    src = _template_source()
+    assert "function tEdge" in src or "tEdge(" in src, (
+        "brain3d.html must define a tEdge() helper for edge kind translations."
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Test 4: Render sites use tLabel / tEdge — not raw domain/kind
+# RED discriminator: template still uses raw x-text="domain" etc.
+# ──────────────────────────────────────────────────────────────────────────────
+
+def test_legend_uses_tlabel():
+    """Legend overlay must call tLabel(domain) not raw x-text='domain'."""
+    src = _template_source()
+    # After the fix, legend should not expose raw domain key directly
+    # (the raw `x-text="domain"` line must be replaced with a tLabel call).
+    assert "tLabel(domain)" in src or "tLabel(" in src, (
+        "Legend overlay must use tLabel(domain) instead of raw x-text='domain'."
+    )
+    # Raw binding should be gone from legend context
+    assert 'x-text="domain"' not in src, (
+        "Legend overlay still uses raw x-text='domain' — must be replaced with tLabel(domain)."
+    )
+
+
+def test_node_kind_uses_tlabel():
+    """Node detail Tipo must call tLabel(selectedNode.kind) not raw binding."""
+    src = _template_source()
+    assert "tLabel(selectedNode.kind)" in src, (
+        "Node detail kind must use tLabel(selectedNode.kind) instead of raw x-text='selectedNode.kind'."
+    )
+
+
+def test_node_domain_uses_tlabel():
+    """Node detail Dominio must call tLabel(selectedNode.domain) not raw binding."""
+    src = _template_source()
+    assert "tLabel(selectedNode.domain)" in src, (
+        "Node detail domain must use tLabel(selectedNode.domain) instead of raw x-text='selectedNode.domain'."
+    )
+
+
+def test_edge_kind_uses_tedge():
+    """Edge kind display must call tEdge(edge.kind) not raw binding."""
+    src = _template_source()
+    assert "tEdge(edge.kind)" in src, (
+        "Edge kind display must use tEdge(edge.kind) instead of raw x-text='edge.kind'."
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Test 5: Served HTML in Spanish contains translated labels
+# RED discriminator: route currently passes {} — no lang context, template
+#                    doesn't inject lang, labels render as raw keys.
+# ──────────────────────────────────────────────────────────────────────────────
+
+def test_rendered_html_contains_spanish_labels(monkeypatch):
+    """GET /brain3d with es-MX renders HTML that includes Spanish label strings."""
+    client = _client_with_language(monkeypatch, "es-MX")
+    resp = client.get("/brain3d")
+    assert resp.status_code == 200
+    html = resp.text
+    # The LABELS map must be in the HTML so the JS can use them at runtime.
+    # We check the Spanish label strings are present as JS data.
+    for key, es_label in _EXPECTED_ES.items():
+        assert es_label in html, (
+            f"Rendered /brain3d HTML (es-MX) is missing Spanish label '{es_label}' for key '{key}'."
+        )
+
+
+def test_rendered_html_contains_english_labels_for_en_us(monkeypatch):
+    """GET /brain3d with en-US renders HTML that includes English label strings."""
+    client = _client_with_language(monkeypatch, "en-US")
+    resp = client.get("/brain3d")
+    assert resp.status_code == 200
+    html = resp.text
+    # Both lang maps must be in the HTML (template always includes LABELS in full).
+    for key, en_label in _EXPECTED_EN.items():
+        assert en_label in html, (
+            f"Rendered /brain3d HTML (en-US) is missing English label '{en_label}' for key '{key}'."
+        )


### PR DESCRIPTION
Two Cerebro 3D fixes Héctor flagged.

## 1. Spanish/English labels (i18n)
The graph showed raw English DB keys (relationships, health, conversation, similar-to, same-day, …) in the legend, node-detail (kind/domain), and edge types. Added a `LABELS` map (es + en) with `tLabel()` / `tEdge()` helpers; the language is derived from the existing `language` config (`es-MX` → `es`, default `es`, `en-*` → `en`). Spanish by default, English available — the canonical keys (and DOMAIN_COLOR/color lookup) are unchanged, only the displayed text is translated, with graceful fallback to the raw key for any unknown future type.
- Legend: Relaciones / Salud / Finanzas / Conversación / Hecho / Evento / Reunión / Ejercicio / Aprendizaje / Espiritualidad / General
- Edges: Similar a / Mismo día / Ocurrió en / Involucra a / Mencionado en / Configuración

## 2. Hide the duplicated nav header when embedded
The brain modal loads `/brain3d` in an iframe; `/brain3d` extends `_base.html`, which renders the global nav header (LifeOS logo, clock, VRAM, menu). Inside the modal — which already has its own header — that nav showed up a second time (looked like a nested/looping header). Now `/brain3d` detects the iframe context (`window.self !== window.top`) and hides the base header via CSS when embedded; standalone navigation to `/brain3d` still shows the full nav.

## Quality
- Strict TDD. **1589 passed** (2 pre-existing flakes). 14 i18n tests (route passes lang; LABELS es+en complete for every DOMAIN_COLOR key; render sites use the helpers; rendered HTML contains Spanish labels — and English for en-US).
- Both verified end-to-end in a headless browser inside the actual modal iframe: legend renders in Spanish AND the duplicated header is hidden (`display:none`).