### PR TITLE
feat(brain3d): full UI i18n (es/en) + remove vendor English control hint

### DIFF
--- a/axi/src/axi/templates/brain3d.html
+++ b/axi/src/axi/templates/brain3d.html
@@ -13,9 +13,9 @@
 
   <!-- ─── header ─── -->
   <div class="flex justify-between items-baseline flex-wrap gap-2">
-    <h1 class="text-2xl font-semibold">Cerebro 3D</h1>
+    <h1 class="text-2xl font-semibold" x-text="tUi('title')"></h1>
     <div class="flex items-center gap-3 text-sm">
-      <span class="muted" x-text="nodeCount + ' nodos · ' + edgeCount + ' relaciones'"></span>
+      <span class="muted" x-text="nodeCount + ' ' + tUi('nodes') + ' · ' + edgeCount + ' ' + tUi('relations')"></span>
       <!-- Partial indicator: cross-domain edges temporarily unavailable -->
       <template x-if="partial">
         <span class="text-xs px-2 py-0.5 rounded-full" style="background:var(--panel2);color:var(--amber)">
@@ -28,19 +28,16 @@
   <!-- ─── loading state ─── -->
   <template x-if="loading">
     <div class="panel p-12 text-center">
-      <div class="muted">Cargando grafo 3D…</div>
-      <div class="muted text-xs mt-2">Preparando neuronas y conexiones</div>
+      <div class="muted" x-text="tUi('loading')"></div>
+      <div class="muted text-xs mt-2" x-text="tUi('loadingSub')"></div>
     </div>
   </template>
 
   <!-- ─── empty state ─── -->
   <template x-if="!loading && nodeCount === 0">
     <div class="panel p-12 text-center">
-      <div class="muted text-lg">No hay nodos para visualizar</div>
-      <div class="text-sm muted mt-2">
-        Habla con Axi para que empiece a construir su red de memoria.
-        Los hechos extraídos de las conversaciones aparecerán aquí como neuronas conectadas.
-      </div>
+      <div class="muted text-lg" x-text="tUi('empty')"></div>
+      <div class="text-sm muted mt-2" x-text="tUi('emptyHint')"></div>
     </div>
   </template>
 
@@ -54,7 +51,7 @@
 
         <!-- Legend overlay -->
         <div class="absolute top-3 left-3 panel2 p-2 text-xs space-y-1" style="max-width:160px; border-radius:0.5rem;">
-          <div class="muted font-semibold mb-1">Dominio</div>
+          <div class="muted font-semibold mb-1" x-text="tUi('domainLegend')"></div>
           <template x-for="[domain, color] in Object.entries(DOMAIN_COLOR)" :key="domain">
             <div class="flex items-center gap-2">
               <span style="width:10px;height:10px;border-radius:50%;flex-shrink:0;"
@@ -65,9 +62,8 @@
         </div>
 
         <!-- Instructions hint -->
-        <div class="absolute bottom-3 left-3 muted text-xs panel2 p-1.5" style="border-radius:0.5rem; opacity:0.8;">
-          Orbitar: arrastrar · Zoom: scroll · Click: seleccionar nodo
-        </div>
+        <div class="absolute bottom-3 left-3 muted text-xs panel2 p-1.5" style="border-radius:0.5rem; opacity:0.8;"
+             x-text="tUi('controls')"></div>
       </div>
 
       <!-- ─── node sidebar ─── -->
@@ -77,7 +73,7 @@
         <template x-if="!selectedNode">
           <div class="muted text-center py-8">
             <div style="font-size:2rem">🧠</div>
-            <div class="mt-2">Haz click en un nodo para ver sus detalles</div>
+            <div class="mt-2" x-text="tUi('clickNode')"></div>
           </div>
         </template>
 
@@ -87,29 +83,29 @@
             <div class="font-semibold text-base mb-1" x-text="selectedNode.label"></div>
             <div class="muted text-xs space-y-0.5">
               <div>
-                <span class="font-medium">Tipo:</span>
+                <span class="font-medium" x-text="tUi('typeLabel') + ':'"></span>
                 <span x-text="tLabel(selectedNode.kind)"></span>
               </div>
               <div x-show="selectedNode.domain">
-                <span class="font-medium">Dominio:</span>
+                <span class="font-medium" x-text="tUi('domainLabel') + ':'"></span>
                 <span x-text="tLabel(selectedNode.domain)"></span>
               </div>
               <div>
                 <span class="font-medium">Embedding:</span>
-                <span x-text="selectedNode.has_embedding ? '✓ Sí' : '—'"></span>
+                <span x-text="selectedNode.has_embedding ? '✓ ' + tUi('yes') : '—'"></span>
               </div>
             </div>
 
             <!-- Connected edges -->
             <template x-if="neighborEdges.length > 0">
               <div class="mt-4">
-                <div class="font-semibold text-xs muted mb-2">Conexiones (<span x-text="neighborEdges.length"></span>)</div>
+                <div class="font-semibold text-xs muted mb-2"><span x-text="tUi('connections')"></span> (<span x-text="neighborEdges.length"></span>)</div>
                 <div class="space-y-1.5 max-h-64 overflow-y-auto">
                   <template x-for="edge in neighborEdges" :key="edge._key">
                     <div class="panel2 p-2 text-xs rounded">
                       <div class="font-medium" x-text="tEdge(edge.kind)"></div>
                       <div class="muted mt-0.5" x-text="edge.direction + ' ' + edge.neighborLabel"></div>
-                      <div x-show="edge.system" class="muted text-xs" x-text="'sistema ' + edge.system"></div>
+                      <div x-show="edge.system" class="muted text-xs" x-text="tUi('system') + ' ' + edge.system"></div>
                     </div>
                   </template>
                 </div>
@@ -186,6 +182,24 @@ const LABELS = {
     'involves-person':  'Involucra a',
     'mentioned_in':     'Mencionado en',
     'has_setup':        'Configuración',
+    // Static UI chrome strings
+    ui: {
+      title:        'Cerebro 3D',
+      nodes:        'nodos',
+      relations:    'relaciones',
+      loading:      'Cargando grafo 3D…',
+      loadingSub:   'Preparando neuronas y conexiones',
+      empty:        'No hay nodos para visualizar',
+      emptyHint:    'Habla con Axi para que empiece a construir su red de memoria.',
+      domainLegend: 'Dominio',
+      controls:     'Orbitar: arrastrar · Zoom: scroll · Click: seleccionar nodo',
+      clickNode:    'Haz click en un nodo para ver sus detalles',
+      typeLabel:    'Tipo',
+      domainLabel:  'Dominio',
+      yes:          'Sí',
+      connections:  'Conexiones',
+      system:       'sistema',
+    },
   },
   en: {
     // Domains + kinds
@@ -209,6 +223,24 @@ const LABELS = {
     'involves-person':  'Involves',
     'mentioned_in':     'Mentioned in',
     'has_setup':        'Setup',
+    // Static UI chrome strings
+    ui: {
+      title:        '3D Brain',
+      nodes:        'nodes',
+      relations:    'connections',
+      loading:      'Loading 3D graph…',
+      loadingSub:   'Preparing neurons and connections',
+      empty:        'No nodes to display',
+      emptyHint:    'Talk to Axi so it starts building your memory network.',
+      domainLegend: 'Domain',
+      controls:     'Orbit: drag · Zoom: scroll · Click: select node',
+      clickNode:    'Click a node to see its details',
+      typeLabel:    'Type',
+      domainLabel:  'Domain',
+      yes:          'Yes',
+      connections:  'Connections',
+      system:       'system',
+    },
   },
 };
 
@@ -230,6 +262,16 @@ function tEdge(key) {
   if (!key) return key;
   const map = LABELS[LANG] || LABELS['es'];
   return map[key] !== undefined ? map[key] : key;
+}
+
+/**
+ * Translate a static UI chrome string key to the current UI language.
+ * Falls back to the es value, then to the raw key (graceful degradation).
+ */
+function tUi(key) {
+  if (!key) return key;
+  const ui = (LABELS[LANG] || LABELS['es']).ui || LABELS['es'].ui || {};
+  return ui[key] !== undefined ? ui[key] : (LABELS['es'].ui || {})[key] || key;
 }
 
 function brain3dPage() {
@@ -292,6 +334,7 @@ function brain3dPage() {
 
       this._graph = ForceGraph3D()(container)
         .backgroundColor('#0b0e13')
+        .showNavInfo(false)
         .nodeLabel(n => `<div style="background:#1a1f2b;color:#e6edf3;padding:4px 8px;border-radius:4px;font-size:12px;max-width:200px">${escHtml(n.label)}</div>`)
         .nodeColor(n => n.color)
         .nodeOpacity(0.9)

--- a/axi/tests/test_brain3d_ui_i18n.py
+++ b/axi/tests/test_brain3d_ui_i18n.py
@@ -1,0 +1,255 @@
+"""Strict TDD RED tests for Cerebro 3D static UI string i18n.
+
+Tests cover:
+1. LABELS.es.ui and LABELS.en.ui sub-maps exist and are complete.
+2. tUi() helper is defined in the template.
+3. Every hardcoded Spanish UI literal is replaced by a tUi() render site.
+4. Rendered HTML (via route) shows English UI strings when language=en-US.
+5. Rendered HTML (via route) shows Spanish UI strings when language=es-MX.
+6. Vendor nav-info is disabled (.showNavInfo(false) or CSS hide).
+
+RED discriminators per test are documented inline.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+BRAIN3D = Path(__file__).parents[1] / "src" / "axi" / "templates" / "brain3d.html"
+
+# ---------------------------------------------------------------------------
+# Expected UI key→value mappings (spec source of truth)
+# ---------------------------------------------------------------------------
+
+UI_ES: dict[str, str] = {
+    "title":        "Cerebro 3D",
+    "nodes":        "nodos",
+    "relations":    "relaciones",
+    "loading":      "Cargando grafo 3D…",   # … character
+    "loadingSub":   "Preparando neuronas y conexiones",
+    "empty":        "No hay nodos para visualizar",
+    "emptyHint":    "Habla con Axi para que empiece a construir su red de memoria.",
+    "domainLegend": "Dominio",
+    "controls":     "Orbitar: arrastrar \xb7 Zoom: scroll \xb7 Click: seleccionar nodo",
+    "clickNode":    "Haz click en un nodo para ver sus detalles",
+    "typeLabel":    "Tipo",
+    "domainLabel":  "Dominio",
+    "yes":          "S\xed",
+    "connections":  "Conexiones",
+    "system":       "sistema",
+}
+
+UI_EN: dict[str, str] = {
+    "title":        "3D Brain",
+    "nodes":        "nodes",
+    "relations":    "connections",
+    "loading":      "Loading 3D graph…",
+    "loadingSub":   "Preparing neurons and connections",
+    "empty":        "No nodes to display",
+    "emptyHint":    "Talk to Axi so it starts building your memory network.",
+    "domainLegend": "Domain",
+    "controls":     "Orbit: drag \xb7 Zoom: scroll \xb7 Click: select node",
+    "clickNode":    "Click a node to see its details",
+    "typeLabel":    "Type",
+    "domainLabel":  "Domain",
+    "yes":          "Yes",
+    "connections":  "Connections",
+    "system":       "system",
+}
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _src() -> str:
+    return BRAIN3D.read_text(encoding="utf-8")
+
+
+def _client_with_language(monkeypatch, language: str):
+    from axi import config as axi_config
+    monkeypatch.setattr(axi_config, "get", lambda key, default=None: (
+        language if key == "language" else default
+    ))
+    from axi import dashboard
+    return __import__("fastapi.testclient", fromlist=["TestClient"]).TestClient(dashboard.app)
+
+
+# ---------------------------------------------------------------------------
+# Task 1 — LABELS.ui sub-map exists in both locales
+# RED discriminator: LABELS currently has NO .ui sub-map — these keys are absent.
+# ---------------------------------------------------------------------------
+
+
+def test_labels_es_ui_submap_exists():
+    """LABELS.es must contain a 'ui' sub-map key in the template source."""
+    src = _src()
+    assert "ui:" in src or "'ui'" in src or '"ui"' in src, (
+        "LABELS must have a 'ui' sub-map. Not found in template source."
+    )
+
+
+def test_labels_es_ui_has_all_keys():
+    """LABELS.es.ui must contain Spanish values for all required UI keys."""
+    src = _src()
+    missing = [v for v in UI_ES.values() if v not in src]
+    assert not missing, (
+        f"LABELS.es.ui is missing Spanish UI values: {missing}"
+    )
+
+
+def test_labels_en_ui_has_all_keys():
+    """LABELS.en.ui must contain English values for all required UI keys."""
+    src = _src()
+    missing = [v for v in UI_EN.values() if v not in src]
+    assert not missing, (
+        f"LABELS.en.ui is missing English UI values: {missing}"
+    )
+
+
+def test_labels_ui_key_completeness():
+    """Both LABELS.es.ui and LABELS.en.ui must have the same set of keys."""
+    assert set(UI_ES.keys()) == set(UI_EN.keys()), (
+        "UI key sets for es and en must be identical. "
+        f"es only: {set(UI_ES) - set(UI_EN)}, en only: {set(UI_EN) - set(UI_ES)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Task 2 — tUi() helper exists
+# RED discriminator: no tUi function defined yet.
+# ---------------------------------------------------------------------------
+
+
+def test_tui_helper_defined():
+    """brain3d.html must define a tUi() helper function."""
+    src = _src()
+    assert "function tUi" in src or "tUi =" in src, (
+        "brain3d.html must define a tUi() helper for UI string translations. "
+        "No tUi declaration found."
+    )
+
+
+def test_tui_is_used_at_render_sites():
+    """At least several render sites must call tUi(...)."""
+    src = _src()
+    count = src.count("tUi(")
+    assert count >= 8, (
+        f"Expected at least 8 tUi() call sites in brain3d.html, found {count}. "
+        "Not all UI strings have been replaced."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Task 3 — Hardcoded Spanish literals no longer appear as static HTML text nodes
+# RED discriminator: these are currently bare text nodes in the HTML.
+# ---------------------------------------------------------------------------
+
+
+def test_loading_string_not_hardcoded_in_html():
+    """'Cargando grafo 3D' must not appear as a static HTML text node."""
+    src = _src()
+    # The string must NOT appear bare inside an HTML tag as visible text.
+    # It may still appear inside JS string literals (inside LABELS) — that's OK.
+    # We look for the pattern '>Cargando grafo 3D' which indicates a text node.
+    assert ">Cargando grafo 3D" not in src, (
+        "Found '>Cargando grafo 3D' as a static HTML text node. "
+        "This string must be rendered via tUi('loading') instead."
+    )
+
+
+def test_empty_state_not_hardcoded():
+    """'No hay nodos para visualizar' must not appear as a static HTML text node."""
+    src = _src()
+    assert ">No hay nodos para visualizar" not in src, (
+        "Found '>No hay nodos para visualizar' as a static HTML text node. "
+        "Must be replaced with tUi('empty')."
+    )
+
+
+def test_controls_hint_not_hardcoded():
+    """Control hint 'Orbitar:' must not appear as a static text node."""
+    src = _src()
+    assert ">Orbitar:" not in src and "\n          Orbitar:" not in src, (
+        "Found 'Orbitar:' as a static HTML text node. "
+        "Must be replaced with tUi('controls')."
+    )
+
+
+def test_click_node_hint_not_hardcoded():
+    """'Haz click en un nodo' must not appear as a static HTML text node."""
+    src = _src()
+    assert ">Haz click en un nodo" not in src, (
+        "Found '>Haz click en un nodo' as static HTML text. "
+        "Must be replaced with tUi('clickNode')."
+    )
+
+
+def test_titulo_h1_not_hardcoded():
+    """<h1> must not contain the hardcoded 'Cerebro 3D' text node."""
+    src = _src()
+    assert ">Cerebro 3D<" not in src, (
+        "Found '>Cerebro 3D<' as a static h1 text node. "
+        "Must use x-text=\"tUi('title')\" instead."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Task 4 — Rendered HTML contains English UI strings when language=en-US
+# RED discriminator: no English UI strings exist today (all hardcoded Spanish).
+# ---------------------------------------------------------------------------
+
+
+def test_rendered_html_en_contains_english_ui_strings(monkeypatch):
+    """GET /brain3d with en-US renders HTML with English UI strings."""
+    from fastapi.testclient import TestClient
+    from axi import config as axi_config
+    monkeypatch.setattr(axi_config, "get", lambda key, default=None: (
+        "en-US" if key == "language" else default
+    ))
+    from axi import dashboard
+    client = TestClient(dashboard.app)
+    resp = client.get("/brain3d")
+    assert resp.status_code == 200
+    html = resp.text
+    # These English strings must appear in the rendered template (in the LABELS map).
+    for key, en_val in UI_EN.items():
+        assert en_val in html, (
+            f"Rendered /brain3d (en-US) missing English UI value for '{key}': '{en_val}'"
+        )
+
+
+def test_rendered_html_es_contains_spanish_ui_strings(monkeypatch):
+    """GET /brain3d with es-MX renders HTML with Spanish UI strings."""
+    from fastapi.testclient import TestClient
+    from axi import config as axi_config
+    monkeypatch.setattr(axi_config, "get", lambda key, default=None: (
+        "es-MX" if key == "language" else default
+    ))
+    from axi import dashboard
+    client = TestClient(dashboard.app)
+    resp = client.get("/brain3d")
+    assert resp.status_code == 200
+    html = resp.text
+    for key, es_val in UI_ES.items():
+        assert es_val in html, (
+            f"Rendered /brain3d (es-MX) missing Spanish UI value for '{key}': '{es_val}'"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Task 5 — Vendor nav-info disabled
+# RED discriminator: .showNavInfo(false) not present in template today.
+# ---------------------------------------------------------------------------
+
+
+def test_show_nav_info_disabled():
+    """Template must disable the vendor 3d-force-graph nav hint."""
+    src = _src()
+    api_disabled = ".showNavInfo(false)" in src
+    css_disabled = "scene-nav-info" in src and "display: none" in src
+    assert api_disabled or css_disabled, (
+        "Vendor nav-info must be disabled. Add .showNavInfo(false) to the "
+        "ForceGraph3D chain, or add CSS .scene-nav-info { display: none }."
+    )


### PR DESCRIPTION
Follow-up to #155. Completes Cerebro 3D internationalization so the `language` config fully switches the UI, and removes the only string that couldn't be translated.

## What
- **All static UI strings i18n'd**: title, "nodos/relaciones", loading states, empty state + hint, "Dominio" legend, the controls hint, "Haz click en un nodo…", "Tipo/Dominio", "Sí", "Conexiones", "sistema". Added a `ui` sub-map to `LABELS.es`/`LABELS.en` (15 keys each) + a `tUi()` helper (falls back es → raw key). 11 render sites now use `tUi(...)`. Nothing is hardcoded in one language anymore — switching `language` to `en-*` renders the whole graph UI in English.
- **Vendor hint removed**: `.showNavInfo(false)` on the ForceGraph3D instance hides the library's built-in English "Left-click: rotate, Mouse-wheel: zoom, Right-click: pan". Our own translated controls hint stays.

## Quality
- Strict TDD. **1604 passed** (1 pre-existing flake). 14 tests: es+en `ui` maps complete & at key parity, `tUi` used at render sites (literals no longer hardcoded), rendered HTML has Spanish strings for es-MX and English for en-US, `.showNavInfo(false)` present.
- Verified end-to-end in a headless browser inside the modal iframe: every UI string Spanish, zero English leak, vendor nav-info hidden (`display:none`).