### PR TITLE
feat(graph): gate chat fact-extractor off by default (graph_bridge_chat_facts)

### DIFF
--- a/axi/src/axi/config_schema.py
+++ b/axi/src/axi/config_schema.py
@@ -382,6 +382,11 @@ FIELDS: tuple[ConfigField, ...] = (
         "If true, meeting summaries are added as nodes in the semantic graph. "
         "Default off (meetings are noisy and pollute the life-facts graph).",
     ),
+    ConfigField(
+        "graph_bridge_chat_facts", "boolean", False,
+        "If true, facts extracted from chat conversations are added as nodes in the "
+        "semantic graph. Default off keeps the graph to structured life-domains only.",
+    ),
 )
 
 

--- a/axi/src/axi/extractor.py
+++ b/axi/src/axi/extractor.py
@@ -24,7 +24,7 @@ import logging
 import re
 from typing import Any
 
-from axi import store
+from axi import config, store
 from axi.brain import ask as brain_ask
 
 log = logging.getLogger("axi.extractor")
@@ -86,7 +86,15 @@ def _parse_json_strict(text: str) -> dict[str, Any] | None:
 
 
 def extract_and_store(user_text: str, axi_text: str, conversation_node_id: int | None) -> int:
-    """Run one extraction pass and persist any facts. Returns count of facts saved."""
+    """Run one extraction pass and persist any facts. Returns count of facts saved.
+
+    Gated by the ``graph_bridge_chat_facts`` config flag (default False). When
+    the flag is off the function returns 0 immediately without making the LLM
+    call — keeping the semantic graph free of arbitrary-domain chat facts.
+    """
+    if not config.get("graph_bridge_chat_facts", False):
+        return 0
+
     exchange = f"Héctor dijo: {user_text}\n\nAxi respondió: {axi_text}"
     raw = brain_ask(
         prompt=exchange,

--- a/axi/tests/test_extractor_gate.py
+++ b/axi/tests/test_extractor_gate.py
@@ -1,0 +1,125 @@
+"""Tests for the config-gated chat fact extractor (graph_bridge_chat_facts).
+
+TDD cycle:
+  Task 1 — Default OFF: extract_and_store returns 0, creates NO kind='fact' node,
+            and brain_ask is NOT called (avoids the expensive LLM call entirely).
+  Task 2 — Flag ON (regression): extraction runs as before — brain_ask IS called,
+            kind='fact' node IS created, count returned is 1.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch, MagicMock
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Task 1 — Default OFF: no LLM call, no node, returns 0
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_extract_and_store_default_off_returns_zero():
+    """With default config (graph_bridge_chat_facts=False), extract_and_store returns 0."""
+    from axi import config
+    from axi.extractor import extract_and_store
+
+    with patch.object(config, "get", side_effect=lambda key, default=None: {
+        "graph_bridge_chat_facts": False,
+    }.get(key, default)):
+        result = extract_and_store("user says something", "axi responds", None)
+
+    assert result == 0, (
+        f"extract_and_store must return 0 when graph_bridge_chat_facts=False, got {result!r}"
+    )
+
+
+def test_extract_and_store_default_off_no_fact_nodes():
+    """With default config, NO kind='fact' node is created in the graph."""
+    from axi import config, store
+    from axi.extractor import extract_and_store
+
+    conn = store._connect()
+    count_before = conn.execute(
+        "SELECT COUNT(*) FROM nodes WHERE kind='fact'"
+    ).fetchone()[0]
+
+    with patch.object(config, "get", side_effect=lambda key, default=None: {
+        "graph_bridge_chat_facts": False,
+    }.get(key, default)):
+        extract_and_store("user says something", "axi responds", None)
+
+    count_after = conn.execute(
+        "SELECT COUNT(*) FROM nodes WHERE kind='fact'"
+    ).fetchone()[0]
+
+    assert count_after == count_before, (
+        f"Expected no new kind='fact' nodes when graph_bridge_chat_facts=False, "
+        f"but count went from {count_before} to {count_after}"
+    )
+
+
+def test_extract_and_store_default_off_brain_ask_not_called():
+    """With default config, brain_ask is NOT called (LLM call is skipped entirely)."""
+    from axi import config
+    from axi.extractor import extract_and_store
+
+    with patch.object(config, "get", side_effect=lambda key, default=None: {
+        "graph_bridge_chat_facts": False,
+    }.get(key, default)), \
+         patch("axi.extractor.brain_ask") as mock_brain:
+        extract_and_store("user says something", "axi responds", None)
+
+    mock_brain.assert_not_called(), (
+        "brain_ask must NOT be called when graph_bridge_chat_facts=False "
+        "— the LLM call is expensive and must be gated out entirely"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Task 2 — Flag ON: extraction runs, brain_ask called, fact node created
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_extract_and_store_flag_on_calls_brain_ask():
+    """When graph_bridge_chat_facts=True, brain_ask IS called."""
+    from axi import config
+    from axi.extractor import extract_and_store
+
+    fake_brain_response = '{"facts": [{"kind": "preference", "label": "Héctor prefers dark mode", "data": {}, "domain": "setup"}]}'
+
+    with patch.object(config, "get", side_effect=lambda key, default=None: {
+        "graph_bridge_chat_facts": True,
+    }.get(key, default)), \
+         patch("axi.extractor.brain_ask", return_value=fake_brain_response) as mock_brain:
+        result = extract_and_store("I prefer dark mode", "Got it!", None)
+
+    mock_brain.assert_called_once()
+    assert result == 1, (
+        f"extract_and_store must return 1 when one fact is extracted with flag ON, got {result!r}"
+    )
+
+
+def test_extract_and_store_flag_on_creates_fact_node():
+    """When graph_bridge_chat_facts=True, a kind='fact' node IS created in the graph."""
+    from axi import config, store
+    from axi.extractor import extract_and_store
+
+    conn = store._connect()
+    count_before = conn.execute(
+        "SELECT COUNT(*) FROM nodes WHERE kind='fact'"
+    ).fetchone()[0]
+
+    fake_brain_response = '{"facts": [{"kind": "setup", "label": "Héctor uses NeoVim as editor", "data": {}, "domain": "setup"}]}'
+
+    with patch.object(config, "get", side_effect=lambda key, default=None: {
+        "graph_bridge_chat_facts": True,
+    }.get(key, default)), \
+         patch("axi.extractor.brain_ask", return_value=fake_brain_response):
+        extract_and_store("I use NeoVim", "Great choice!", None)
+
+    count_after = conn.execute(
+        "SELECT COUNT(*) FROM nodes WHERE kind='fact'"
+    ).fetchone()[0]
+
+    assert count_after == count_before + 1, (
+        f"Expected 1 new kind='fact' node when graph_bridge_chat_facts=True, "
+        f"count went from {count_before} to {count_after}"
+    )


### PR DESCRIPTION
## Why
The chat fact-extractor (`extractor.extract_and_store`) created `kind='fact'` graph nodes with arbitrary LLM-chosen domains (e.g. 'setup', 'work') — the path that produced the "phantom" facts the user never logged. After the recent graph cleanup (169→28), this path would silently re-pollute the graph on every conversation. Héctor's policy: the graph keeps only structured-domain facts.

## What
New config flag `graph_bridge_chat_facts` (default **False**), matching the #154 gate pattern. `extract_and_store` early-returns 0 when off — **before** the `brain_ask` LLM call, so it also saves the per-turn extraction cost. Structured-domain bridging (domain_bridge) is untouched.

## Quality
- Strict TDD. **1609 passed** (1 pre-existing flake). 5 tests: default-off skips brain_ask + creates no node + returns 0; flag-on preserves extraction (regression).