### PR TITLE
feat(bridge): skip low-value (bare-keyword/empty) entries so they never enter the graph

### DIFF
--- a/axi/src/axi/domain_bridge.py
+++ b/axi/src/axi/domain_bridge.py
@@ -232,15 +232,19 @@ def _is_low_value(label: str, entry: Any) -> bool:
         has_raw = bool(raw and raw.strip())
         data = getattr(entry, "data", None)
         has_data = bool(data)
+        body = getattr(entry, "body", None)
+        has_body = bool(body and body.strip())
         # Also treat any entry with a meaningful numeric field (amount, duration,
         # duration_minutes, etc.) as having real content — finance/exercise entries
         # often carry no raw_utterance but do have structured numeric values.
-        has_numeric = bool(
-            getattr(entry, "amount", None)
-            or getattr(entry, "duration_minutes", None)
-            or getattr(entry, "duration", None)
+        # Use `is not None` (not truthiness) so zero values (e.g. amount=0 for a
+        # free transaction, duration_minutes=0) are treated as present numeric data.
+        has_numeric = (
+            getattr(entry, "amount", None) is not None
+            or getattr(entry, "duration_minutes", None) is not None
+            or getattr(entry, "duration", None) is not None
         )
-        if not has_raw and not has_data and not has_numeric:
+        if not has_raw and not has_data and not has_body and not has_numeric:
             return True
 
     return False
@@ -488,9 +492,10 @@ def backfill_all_domains(
             any_remaining = True
             entry = pending[domain].pop(0)
             try:
-                create_fact_node_for_entry(domain, entry)
-                result[domain] += 1
-                total_created += 1
+                node_id = create_fact_node_for_entry(domain, entry)
+                if node_id is not None:
+                    result[domain] += 1
+                    total_created += 1
             except Exception as exc:  # noqa: BLE001
                 log.warning(
                     "backfill_all_domains: failed for domain=%r entry=%r: %s",

--- a/axi/src/axi/domain_bridge.py
+++ b/axi/src/axi/domain_bridge.py
@@ -193,10 +193,63 @@ _DOMAIN_CONFIGS: dict[str, DomainConfig] = {
 }
 
 
+# ─── low-value filter ────────────────────────────────────────────────────────
+
+
+def _is_low_value(label: str, entry: Any) -> bool:
+    """Return True when *label* is clearly contentless and must not become a graph node.
+
+    Conservative filter — only drop true garbage; keep anything with signal.
+
+    Rules (evaluated in order; first match wins):
+    1. Strip the label. If empty → True (low value).
+    2. If the stripped label contains ANY digit → False (keep).
+       Vitals/finance/sleep all carry numbers: "dormí 10.7h", "presión 120/86",
+       "gasté 450 en super".
+    3. If ALL three conditions hold → True (low value — bare keyword):
+       a. The stripped label is a SINGLE token (no whitespace).
+       b. The single token is short (≤ 14 chars).
+       c. The entry carries NO real content:
+          - ``raw_utterance`` is falsy/empty/whitespace-only, AND
+          - ``data`` is empty/missing, AND
+          - no meaningful numeric field (``amount``, ``duration_minutes``,
+            ``duration``) is set — finance/exercise entries with a real value
+            must always be kept even when they lack a raw_utterance.
+    4. Otherwise → False (keep).  Multi-word labels, long single tokens, or
+       entries with non-empty raw_utterance, data, or numeric fields are
+       preserved.
+    """
+    stripped = label.strip()
+    if not stripped:
+        return True
+
+    if any(ch.isdigit() for ch in stripped):
+        return False
+
+    # Single-token short bare-keyword check.
+    if len(stripped.split()) == 1 and len(stripped) <= 14:
+        raw = getattr(entry, "raw_utterance", None)
+        has_raw = bool(raw and raw.strip())
+        data = getattr(entry, "data", None)
+        has_data = bool(data)
+        # Also treat any entry with a meaningful numeric field (amount, duration,
+        # duration_minutes, etc.) as having real content — finance/exercise entries
+        # often carry no raw_utterance but do have structured numeric values.
+        has_numeric = bool(
+            getattr(entry, "amount", None)
+            or getattr(entry, "duration_minutes", None)
+            or getattr(entry, "duration", None)
+        )
+        if not has_raw and not has_data and not has_numeric:
+            return True
+
+    return False
+
+
 # ─── core: create_fact_node_for_entry ────────────────────────────────────────
 
 
-def create_fact_node_for_entry(domain: str, entry: Any) -> int:
+def create_fact_node_for_entry(domain: str, entry: Any) -> int | None:
     """Create a fact node for a domain entry and register it in domain_node_map.
 
     Steps:
@@ -223,6 +276,13 @@ def create_fact_node_for_entry(domain: str, entry: Any) -> int:
 
     cfg = _DOMAIN_CONFIGS[domain]
     label = cfg.renderer(entry)
+
+    if _is_low_value(label, entry):
+        log.debug(
+            "bridge: skipping low-value entry label=%r domain=%r",
+            label, domain,
+        )
+        return None
 
     extra: dict[str, Any] = {}
     if cfg.extra_data_fn is not None:

--- a/axi/src/axi/store.py
+++ b/axi/src/axi/store.py
@@ -1743,7 +1743,7 @@ def get_node_for_domain_entry(domain: str, entry_id: str) -> int | None:
 # ─────────────────── fact-node creation (Slice 2) ────────────────────────────
 
 
-def create_fact_node_for_interaction(interaction: Any) -> int:
+def create_fact_node_for_interaction(interaction: Any) -> int | None:
     """Thin shim: create a fact node for a relationships interaction.
 
     Delegates entirely to domain_bridge.create_fact_node_for_entry so there is

--- a/axi/tests/test_domain_bridge.py
+++ b/axi/tests/test_domain_bridge.py
@@ -533,3 +533,199 @@ def test_backfill_all_domains_fetches_with_generous_limit():
         "Without an explicit generous limit the backfill silently truncates "
         "to the store default (e.g. 300) and never reaches old entries."
     )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Review-fix tests — low-value filter edge cases
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+# ─── FIX 1: falsy-zero in has_numeric ───────────────────────────────────────
+
+@dataclass
+class FinanceEntryStub:
+    """Minimal duck-typed finance entry."""
+    id: str = "fe-001"
+    raw_utterance: str | None = None
+    title: str | None = "muestra"
+    amount: float | None = None
+    data: dict | None = None
+
+
+@dataclass
+class ExerciseEntryStub:
+    """Minimal duck-typed exercise entry."""
+    id: str = "ex-001"
+    raw_utterance: str | None = None
+    title: str | None = "correr"
+    duration_minutes: int | None = None
+    data: dict | None = None
+
+
+class TestIsLowValueFalsyZero:
+    """FIX 1 — amount=0 or duration_minutes=0 must be treated as real content."""
+
+    def test_finance_amount_zero_is_kept(self):
+        """FINANCE entry with amount=0 (free transaction), short title, no raw → NOT low-value.
+
+        RED: fails when has_numeric uses bool(getattr(..., 'amount', None))
+        because bool(0) is False, so the entry is wrongly dropped.
+        GREEN: passes once the check uses `is not None`.
+        """
+        from axi.domain_bridge import _is_low_value
+
+        entry = FinanceEntryStub(amount=0, title="muestra", raw_utterance=None, data=None)
+        result = _is_low_value("muestra", entry)
+        assert result is False, (
+            "amount=0 must count as a present numeric field; entry must NOT be low-value"
+        )
+
+    def test_exercise_duration_minutes_zero_is_kept(self):
+        """EXERCISE entry with duration_minutes=0, short title, no raw → NOT low-value.
+
+        RED: fails when has_numeric uses bool(getattr(..., 'duration_minutes', None))
+        because bool(0) is False, so the entry is wrongly dropped.
+        GREEN: passes once the check uses `is not None`.
+        """
+        from axi.domain_bridge import _is_low_value
+
+        entry = ExerciseEntryStub(duration_minutes=0, title="correr", raw_utterance=None, data=None)
+        result = _is_low_value("correr", entry)
+        assert result is False, (
+            "duration_minutes=0 must count as a present numeric field; entry must NOT be low-value"
+        )
+
+    def test_finance_amount_zero_creates_node(self):
+        """create_fact_node_for_entry returns a node_id (not None) for amount=0 entry.
+
+        RED: drops the entry (returns None) when has_numeric uses truthiness check.
+        GREEN: creates the node once `is not None` check is in place.
+        """
+        from unittest.mock import patch, MagicMock
+        from axi import domain_bridge
+
+        entry = FinanceEntryStub(id="fe-zero-001", amount=0, title="muestra", raw_utterance=None, data=None)
+
+        with (
+            patch("axi.store.get_node_for_domain_entry", return_value=None),
+            patch("axi.store.add_node", return_value=42) as mock_add,
+            patch("axi.store.upsert_domain_node_map"),
+            patch("axi.store.trigger_embed_for_node"),
+        ):
+            node_id = domain_bridge.create_fact_node_for_entry("finance", entry)
+
+        assert node_id is not None, (
+            "create_fact_node_for_entry must create a node for a finance entry with amount=0"
+        )
+
+
+# ─── FIX 2: backfill counter only counts real creations ─────────────────────
+
+class TestBackfillCounterSkipsLowValue:
+    """FIX 2 — low-value skips (None return) must NOT increment backfill counters."""
+
+    def test_low_value_skip_does_not_consume_node_limit_budget(self):
+        """Backfill with 1 real entry + 1 low-value entry and node_limit=1 →
+        the real entry is created and counts as 1; the low-value does not burn the budget.
+
+        RED: fails when the counter increments unconditionally (create_fact_node_for_entry
+        returns None for the low-value entry, but result[domain] and total_created are
+        still incremented, exhausting the budget before the real entry is processed).
+        GREEN: passes once the counter only increments when the return value is not None.
+        """
+        from unittest.mock import patch, MagicMock
+        from types import SimpleNamespace
+        from axi.domain_bridge import backfill_all_domains
+
+        low_value_entry = SimpleNamespace(id="lv-001", title="muestra", raw_utterance=None, data=None, amount=None, duration_minutes=None, duration=None)
+        real_entry = SimpleNamespace(id="real-001", title="presión 120/80", raw_utterance="presión 120/80", data=None, amount=None, duration_minutes=None, duration=None)
+
+        def _fake_fetch(domain, *, days, limit=None):
+            return [low_value_entry, real_entry]
+
+        created_ids: list[str] = []
+
+        def _fake_create(domain, entry):
+            if entry.id == "lv-001":
+                return None  # low-value skip
+            created_ids.append(entry.id)
+            return 99
+
+        with (
+            patch("axi.domain_bridge._fetch_domain_entries", side_effect=_fake_fetch),
+            patch("axi.store.get_node_for_domain_entry", return_value=None),
+            patch("axi.domain_bridge.create_fact_node_for_entry", side_effect=_fake_create),
+            patch("axi.store.checkpoint"),
+        ):
+            result = backfill_all_domains(days=90, domains=["health"], node_limit=1)
+
+        assert result["health"] == 1, (
+            f"result['health'] should be 1 (only the real entry), got {result['health']}"
+        )
+        assert "real-001" in created_ids, "The real entry must have been processed"
+
+
+# ─── FIX 3: has_data should consider `body` ─────────────────────────────────
+
+@dataclass
+class RelationshipsEntryStub:
+    """Minimal duck-typed relationships interaction entry."""
+    id: str = "ri-001"
+    raw_utterance: str | None = None
+    title: str | None = "charla"
+    body: str | None = None
+    data: dict | None = None
+
+
+class TestIsLowValueBodyContent:
+    """FIX 3 — non-empty body must count as real content and prevent low-value drop."""
+
+    def test_short_title_no_raw_no_data_but_body_is_kept(self):
+        """Relationships entry with short title, no raw_utterance, no data, but
+        non-empty body → NOT low-value.
+
+        RED: fails when _is_low_value ignores entry.body.
+        GREEN: passes once body is included in the 'has content' check.
+        """
+        from axi.domain_bridge import _is_low_value
+
+        entry = RelationshipsEntryStub(
+            title="charla",
+            raw_utterance=None,
+            data=None,
+            body="Spoke about the project status and next steps.",
+        )
+        result = _is_low_value("charla", entry)
+        assert result is False, (
+            "Entry with non-empty body must NOT be low-value even with a short single-word title"
+        )
+
+    def test_empty_body_still_low_value(self):
+        """Entry with short title, no raw, no data, and empty body → still low-value."""
+        from axi.domain_bridge import _is_low_value
+
+        entry = RelationshipsEntryStub(
+            title="charla",
+            raw_utterance=None,
+            data=None,
+            body="",
+        )
+        result = _is_low_value("charla", entry)
+        assert result is True, (
+            "Entry with empty body and no other content must still be low-value"
+        )
+
+    def test_none_body_still_low_value(self):
+        """Entry with short title, no raw, no data, body=None → still low-value."""
+        from axi.domain_bridge import _is_low_value
+
+        entry = RelationshipsEntryStub(
+            title="charla",
+            raw_utterance=None,
+            data=None,
+            body=None,
+        )
+        result = _is_low_value("charla", entry)
+        assert result is True, (
+            "Entry with body=None and no other content must still be low-value"
+        )

--- a/axi/tests/test_domain_bridge_low_value_filter.py
+++ b/axi/tests/test_domain_bridge_low_value_filter.py
@@ -1,0 +1,302 @@
+"""Tests for the low-value-entry filter in domain_bridge.py.
+
+TDD order: RED tests written first, GREEN follows after implementation.
+
+Covered tasks:
+  LV.1 — _is_low_value: unit table (helper does not exist yet → RED)
+  LV.2 — create_fact_node_for_entry skips low-value entries → returns None  (RED)
+  LV.3 — create_fact_node_for_entry keeps real entries → node IS created     (regression)
+  LV.4 — bridge_entry returns None for low-value, without raising             (regression)
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+# ─── shared stubs ──────────────────────────────────────────────────────────────
+
+
+@dataclass
+class _HealthStub:
+    """Minimal duck-typed health entry for low-value filter tests."""
+    id: str = "he-lv-001"
+    kind: str = "vital"
+    raw_utterance: str | None = None
+    title: str | None = None
+    data: dict = field(default_factory=dict)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Task LV.1 — _is_low_value unit table
+# RED: helper does not exist yet → ImportError / AttributeError
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestIsLowValueDropCases:
+    """Labels that MUST be classified as low-value (True → skip)."""
+
+    def test_empty_string_is_low_value(self):
+        """Empty string → low value."""
+        from axi.domain_bridge import _is_low_value
+        assert _is_low_value("", _HealthStub()) is True
+
+    def test_whitespace_only_is_low_value(self):
+        """Whitespace-only string → low value."""
+        from axi.domain_bridge import _is_low_value
+        assert _is_low_value("   ", _HealthStub()) is True
+
+    def test_bare_keyword_dormir_is_low_value(self):
+        """'dormir' — single token, short, no raw, no data → low value."""
+        from axi.domain_bridge import _is_low_value
+        entry = _HealthStub(raw_utterance=None, data={})
+        assert _is_low_value("dormir", entry) is True
+
+    def test_bare_keyword_despertar_is_low_value(self):
+        """'despertar' — single token, short, no raw, no data → low value."""
+        from axi.domain_bridge import _is_low_value
+        entry = _HealthStub(raw_utterance=None, data={})
+        assert _is_low_value("despertar", entry) is True
+
+    def test_bare_keyword_pulsos_is_low_value(self):
+        """'pulsos' — single token, short, no raw, no data → low value."""
+        from axi.domain_bridge import _is_low_value
+        entry = _HealthStub(raw_utterance=None, data={})
+        assert _is_low_value("pulsos", entry) is True
+
+    def test_single_token_at_boundary_14_chars_no_content_is_low_value(self):
+        """Single token exactly 14 chars, no raw/data → low value."""
+        from axi.domain_bridge import _is_low_value
+        entry = _HealthStub(raw_utterance=None, data={})
+        label = "a" * 14  # 14 chars, single token, no digit
+        assert _is_low_value(label, entry) is True
+
+
+class TestIsLowValueKeepCases:
+    """Labels that MUST be kept (False → do not skip)."""
+
+    def test_sleep_with_number_is_kept(self):
+        """'dormí 10.7h' — contains digit → keep."""
+        from axi.domain_bridge import _is_low_value
+        assert _is_low_value("dormí 10.7h", _HealthStub()) is False
+
+    def test_presion_with_numbers_is_kept(self):
+        """'presión 120/86, pulso 56' — contains digits → keep."""
+        from axi.domain_bridge import _is_low_value
+        assert _is_low_value("presión 120/86, pulso 56", _HealthStub()) is False
+
+    def test_multi_number_label_is_kept(self):
+        """'113, 82 y 55 de pulso.' — contains digits → keep."""
+        from axi.domain_bridge import _is_low_value
+        assert _is_low_value("113, 82 y 55 de pulso.", _HealthStub()) is False
+
+    def test_finance_label_with_amount_is_kept(self):
+        """'gasté 450 en super' — contains digit → keep."""
+        from axi.domain_bridge import _is_low_value
+        assert _is_low_value("gasté 450 en super", _HealthStub()) is False
+
+    def test_exercise_label_with_duration_is_kept(self):
+        """'caminé 45 min' — contains digit → keep."""
+        from axi.domain_bridge import _is_low_value
+        assert _is_low_value("caminé 45 min", _HealthStub()) is False
+
+    def test_multi_word_label_without_digit_is_kept(self):
+        """Multi-word labels without digits are kept (not bare keywords)."""
+        from axi.domain_bridge import _is_low_value
+        assert _is_low_value("gratitud: amanecí con salud", _HealthStub()) is False
+
+    def test_single_token_long_is_kept(self):
+        """Single token > 14 chars (no digit) is NOT a bare keyword → keep."""
+        from axi.domain_bridge import _is_low_value
+        entry = _HealthStub(raw_utterance=None, data={})
+        label = "a" * 15  # 15 chars, over the short threshold
+        assert _is_low_value(label, entry) is False
+
+    def test_single_token_short_with_raw_utterance_is_kept(self):
+        """Single short token BUT entry has raw_utterance → keep (real content)."""
+        from axi.domain_bridge import _is_low_value
+        entry = _HealthStub(raw_utterance="dormí mal", data={})
+        assert _is_low_value("dormir", entry) is False
+
+    def test_single_token_short_with_data_is_kept(self):
+        """Single short token BUT entry has non-empty data → keep."""
+        from axi.domain_bridge import _is_low_value
+        entry = _HealthStub(raw_utterance=None, data={"hours": 6})
+        assert _is_low_value("dormir", entry) is False
+
+    def test_single_token_with_amount_is_kept(self):
+        """Single short token BUT entry has non-zero amount (finance) → keep."""
+        from axi.domain_bridge import _is_low_value
+
+        @dataclass
+        class _FinanceStub:
+            id: str = "fi-001"
+            kind: str = "expense"
+            raw_utterance: str | None = None
+            title: str = "gasolina"
+            amount: float = 600.0
+
+        entry = _FinanceStub()
+        # "gasolina" — single token, 8 chars, no digit in label, no raw_utterance
+        # BUT amount=600 → has real content → keep.
+        assert _is_low_value("gasolina", entry) is False
+
+    def test_single_token_with_duration_minutes_is_kept(self):
+        """Single short token with duration_minutes (exercise) → keep."""
+        from axi.domain_bridge import _is_low_value
+
+        @dataclass
+        class _ExerciseStub:
+            id: str = "ex-001"
+            kind: str = "run"
+            raw_utterance: str | None = None
+            title: str = "correr"
+            duration_minutes: int = 45
+
+        entry = _ExerciseStub()
+        assert _is_low_value("correr", entry) is False
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Task LV.2 — create_fact_node_for_entry SKIPS low-value entries
+# RED: current code does not have the filter → creates the node instead
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def test_create_fact_node_skips_low_value_entry():
+    """LV.2 RED — entry rendering to 'pulsos' (no raw, no data) → no node created, returns None."""
+    import axi.store as store
+    from axi.domain_bridge import create_fact_node_for_entry
+
+    # Craft a health entry that renders to "pulsos" via the health renderer.
+    # The renderer will try raw_utterance (None), then title ("pulsos"), and return "pulsos".
+    entry = _HealthStub(id="he-lv-skip-001", raw_utterance=None, title="pulsos", data={})
+
+    result = create_fact_node_for_entry("health", entry)
+
+    # Filter must prevent node creation and return None.
+    assert result is None, (
+        f"Expected None for low-value label 'pulsos', got {result!r}. "
+        "The bridge must skip entries whose rendered label is bare-keyword."
+    )
+
+    # Confirm no node or map row was created.
+    conn = store._connect()
+    map_row = conn.execute(
+        "SELECT * FROM domain_node_map WHERE domain='health' AND entry_id=?",
+        (entry.id,),
+    ).fetchone()
+    assert map_row is None, (
+        "domain_node_map must NOT contain a row for the skipped low-value entry."
+    )
+
+
+def test_create_fact_node_skips_empty_label_entry():
+    """LV.2 triangulate — entry rendering to '' → no node created, returns None."""
+    import axi.store as store
+    from axi.domain_bridge import create_fact_node_for_entry
+
+    # An entry with whitespace-only raw_utterance AND whitespace-only title
+    # AND no kind falls back to 'health: ' (has 'health' prefix with colon+space).
+    # To get truly empty label we mock the renderer.
+    entry = _HealthStub(id="he-lv-empty-001", raw_utterance=None, title=None, data={})
+
+    with patch("axi.domain_bridge._DOMAIN_CONFIGS") as mock_configs:
+        mock_cfg = MagicMock()
+        mock_cfg.renderer.return_value = ""
+        mock_cfg.extra_data_fn = None
+        mock_configs.__getitem__ = lambda self, key: mock_cfg
+        mock_configs.__contains__ = lambda self, key: True
+
+        result = create_fact_node_for_entry("health", entry)
+
+    assert result is None, (
+        f"Expected None for empty rendered label, got {result!r}."
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Task LV.3 — create_fact_node_for_entry KEEPS real entries (regression)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def test_create_fact_node_keeps_real_health_entry():
+    """LV.3 regression — 'presión 120/86, pulso 56' → node IS created and mapped."""
+    import axi.store as store
+    from axi.domain_bridge import create_fact_node_for_entry
+
+    entry = _HealthStub(
+        id="he-lv-keep-001",
+        raw_utterance="presión 120/86, pulso 56",
+        data={},
+    )
+
+    result = create_fact_node_for_entry("health", entry)
+
+    assert result is not None, "Real health entry must produce a node."
+    assert isinstance(result, int)
+    assert result > 0
+
+    conn = store._connect()
+    node = conn.execute("SELECT label FROM nodes WHERE id = ?", (result,)).fetchone()
+    assert node is not None
+    assert "presión" in node["label"]
+
+    map_row = conn.execute(
+        "SELECT node_id FROM domain_node_map WHERE domain='health' AND entry_id=?",
+        (entry.id,),
+    ).fetchone()
+    assert map_row is not None, "domain_node_map must have a row for real entry."
+    assert int(map_row["node_id"]) == result
+
+
+def test_create_fact_node_keeps_multi_number_label():
+    """LV.3 triangulate — '113, 82 y 55 de pulso.' → node IS created."""
+    import axi.store as store
+    from axi.domain_bridge import create_fact_node_for_entry
+
+    entry = _HealthStub(
+        id="he-lv-keep-002",
+        raw_utterance="113, 82 y 55 de pulso.",
+        data={},
+    )
+
+    result = create_fact_node_for_entry("health", entry)
+    assert result is not None, "Multi-number health entry must produce a node."
+    assert isinstance(result, int)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Task LV.4 — bridge_entry returns None for low-value (best-effort, no raise)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def test_bridge_entry_returns_none_for_low_value():
+    """LV.4 — bridge_entry('health', low-value-entry) returns None without raising."""
+    from axi.domain_bridge import bridge_entry
+
+    entry = _HealthStub(id="he-lv-be-001", raw_utterance=None, title="dormir", data={})
+
+    result = bridge_entry("health", entry)
+
+    assert result is None, (
+        f"bridge_entry must return None for low-value entry, got {result!r}."
+    )
+
+
+def test_bridge_entry_returns_int_for_real_entry():
+    """LV.4 regression — bridge_entry for real entry still returns int."""
+    from axi.domain_bridge import bridge_entry
+
+    entry = _HealthStub(
+        id="he-lv-be-002",
+        raw_utterance="dormí 8.5h muy bien",
+        data={},
+    )
+
+    result = bridge_entry("health", entry)
+    assert isinstance(result, int), f"Expected int node_id, got {result!r}."
+    assert result > 0


### PR DESCRIPTION
## Why
Some entries rendered to meaningless graph nodes ("dormir", "despertar", "pulsos" — bare keywords, no real content), cluttering the Cerebro 3D. The source data path is already clean, so the durable defense is at the bridge: skip low-value entries no matter where they come from.

(The 3 existing garbage nodes were also cleaned from the live graph: 28 → 25 nodes.)

## What
`_is_low_value(label, entry)` gates `create_fact_node_for_entry`: returns None (no node, no domain_node_map row) when the rendered label is contentless. Conservative rule:
- Empty/whitespace label → drop.
- **Any digit in the label → keep** (every vital/finance/sleep/exercise label carries numbers).
- Single short token (≤14 chars) with no `raw_utterance`, no `data`, no `body`, and no numeric field present → drop (the bare-keyword garbage).
- Everything else → keep.

## Quality
- Strict TDD. **1640 passed.** 30 tests: drops the actual garbage ("dormir"/"despertar"/"pulsos"/empty); keeps every realistic entry across all domains.
- Fresh-context review (per-domain over-drop analysis) → PASS, 0 critical. Its findings fixed: `amount=0`/`duration=0` now count as content (`is not None`, not truthiness — protects free transactions / zero-duration); `body` content kept (relationships); backfill counter only counts real creations (low-value skips don't consume `node_limit`); return type `int | None`.