### PR TITLE
feat(graph): link & display facts by real event date in the user's timezone (fixes 'todo ligado')

### DIFF
--- a/axi/src/axi/config_schema.py
+++ b/axi/src/axi/config_schema.py
@@ -18,6 +18,23 @@ from typing import Any
 log = logging.getLogger("axi.config_schema")
 
 
+def _detect_system_timezone() -> str:
+    """Return the IANA timezone name for the current machine.
+
+    Uses tzlocal.get_localzone_name() which reads /etc/localtime or the
+    TZ environment variable.  Falls back to 'UTC' if tzlocal is missing,
+    raises, or returns None.
+    """
+    try:
+        import tzlocal
+        name = tzlocal.get_localzone_name()
+        if name:
+            return str(name)
+    except Exception:
+        pass
+    return "UTC"
+
+
 class ConfigError(ValueError):
     """Raised when a config value fails validation.
 
@@ -98,7 +115,7 @@ _DEFAULT_WHISPER_PROMPT = (
 FIELDS: tuple[ConfigField, ...] = (
     # ─────── identity / locale ───────
     ConfigField(
-        "timezone", "string", "America/Mexico_City",
+        "timezone", "string", _detect_system_timezone(),
         "IANA timezone name used for dashboard timestamps.",
     ),
     ConfigField(

--- a/axi/src/axi/dashboard.py
+++ b/axi/src/axi/dashboard.py
@@ -1961,7 +1961,8 @@ def brain3d_page(request: Request):
     lang = raw_lang.split("-")[0].lower() if "-" in raw_lang else raw_lang[:2].lower()
     if lang not in ("es", "en"):
         lang = "es"
-    return templates.TemplateResponse(request, "brain3d.html", {"lang": lang})
+    tz = str(config.get("timezone", "UTC"))
+    return templates.TemplateResponse(request, "brain3d.html", {"lang": lang, "tz": tz})
 
 
 @app.get("/api/graph")

--- a/axi/src/axi/dashboard.py
+++ b/axi/src/axi/dashboard.py
@@ -2083,7 +2083,7 @@ def graph_full(limit: int = 500) -> dict[str, Any]:
 
     # ── System A: nodes ──────────────────────────────────────────────────────
     node_rows = c.execute(
-        "SELECT id, kind, label, domain, embedding FROM nodes "
+        "SELECT id, kind, label, domain, embedding, occurred_at FROM nodes "
         "ORDER BY created_at DESC LIMIT ?",
         (limit,),
     ).fetchall()
@@ -2095,6 +2095,7 @@ def graph_full(limit: int = 500) -> dict[str, Any]:
             "kind": r["kind"],
             "domain": r["domain"] or "",
             "has_embedding": r["embedding"] is not None,
+            "occurred_at": r["occurred_at"],  # real event epoch (float) or null
         }
         for r in node_rows
     ]

--- a/axi/src/axi/domain_bridge.py
+++ b/axi/src/axi/domain_bridge.py
@@ -573,7 +573,7 @@ def backfill_all_domains(
 
 def backfill_node_occurred_at(
     *,
-    days: int = 365,
+    days: int = 36500,
     limit: int | None = None,
 ) -> int:
     """Idempotent helper: fill occurred_at on nodes that have NULL occurred_at.
@@ -588,7 +588,12 @@ def backfill_node_occurred_at(
     - Domains that fail to fetch are skipped with a warning (never raises).
 
     Args:
-        days:  Look-back window passed to _fetch_domain_entries (default 365).
+        days:  Look-back window passed to _fetch_domain_entries.
+               Default is 36500 (≈100 years) so ALL existing entries are
+               considered — a one-time migration must not silently skip nodes
+               whose real event date is older than the previous 365-day window.
+               Pass a smaller value only when testing or when a bounded run is
+               explicitly desired.
         limit: Optional cap on total nodes updated in a single run.
 
     Returns:
@@ -641,13 +646,14 @@ def backfill_node_occurred_at(
                 continue
 
             try:
-                conn.execute(
+                cur = conn.execute(
                     "UPDATE nodes SET occurred_at=? WHERE id=? AND occurred_at IS NULL",
                     (epoch, node_id),
                 )
                 # In autocommit mode (isolation_level=None) the UPDATE commits
-                # automatically. No explicit commit needed.
-                updated += 1
+                # automatically. Use rowcount so concurrent callers don't both
+                # increment when only one wins the SQLite write lock.
+                updated += cur.rowcount
             except Exception as exc:  # noqa: BLE001
                 log.warning(
                     "backfill_node_occurred_at: failed to update node_id=%r: %s", node_id, exc

--- a/axi/src/axi/domain_bridge.py
+++ b/axi/src/axi/domain_bridge.py
@@ -8,6 +8,9 @@ For every supported domain (health, relationships, …), this module provides:
 - create_fact_node_for_entry(domain, entry): core (raises on error).
 - create_fact_node_for_interaction(interaction): backward-compat shim →
   create_fact_node_for_entry('relationships', interaction).
+- backfill_node_occurred_at(): one-time helper to fill occurred_at on
+  previously backfilled nodes that were inserted before the occurred_at
+  column existed. Idempotent and bounded.
 
 Thread safety: all DB writes go through axi.store._tx() (thread-local
 connections). trigger_embed_for_node uses a queue — no connection is shared
@@ -18,6 +21,7 @@ from __future__ import annotations
 import logging
 import time as _time
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Any, Callable
 
 log = logging.getLogger("axi.domain_bridge")
@@ -250,6 +254,49 @@ def _is_low_value(label: str, entry: Any) -> bool:
     return False
 
 
+# ─── event-date extraction ───────────────────────────────────────────────────
+
+
+def _entry_occurred_at(entry: Any) -> float | None:
+    """Extract the real event timestamp from a domain entry.
+
+    Priority: entry.ts → entry.created_at → None.
+    Accepts datetime objects, ISO-format strings, or numeric epoch values.
+    Returns a float Unix epoch (UTC seconds) or None when no timestamp is
+    available or the value cannot be parsed.
+    """
+    for attr in ("ts", "created_at"):
+        raw = getattr(entry, attr, None)
+        if raw is None:
+            continue
+        # Already a number (epoch seconds).
+        if isinstance(raw, (int, float)):
+            return float(raw)
+        # datetime object.
+        if isinstance(raw, datetime):
+            # Attach UTC when naive (treat as UTC, consistent with the rest of the stack).
+            if raw.tzinfo is None:
+                raw = raw.replace(tzinfo=timezone.utc)
+            return raw.timestamp()
+        # ISO string (e.g. "2026-06-24 12:19:52+00:00").
+        if isinstance(raw, str):
+            raw_s = raw.strip()
+            if not raw_s:
+                continue
+            try:
+                dt = datetime.fromisoformat(raw_s)
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=timezone.utc)
+                return dt.timestamp()
+            except (ValueError, TypeError):
+                log.debug(
+                    "_entry_occurred_at: could not parse timestamp string %r — skipping",
+                    raw_s,
+                )
+                continue
+    return None
+
+
 # ─── core: create_fact_node_for_entry ────────────────────────────────────────
 
 
@@ -292,7 +339,8 @@ def create_fact_node_for_entry(domain: str, entry: Any) -> int | None:
     if cfg.extra_data_fn is not None:
         extra = cfg.extra_data_fn(entry)
 
-    node_id = store.add_node("fact", label, data=extra or None, domain=domain)
+    occurred_at = _entry_occurred_at(entry)
+    node_id = store.add_node("fact", label, data=extra or None, domain=domain, occurred_at=occurred_at)
     store.upsert_domain_node_map(domain, entry_id, node_id)
     store.trigger_embed_for_node(node_id)
     return node_id
@@ -518,6 +566,94 @@ def backfill_all_domains(
         log.warning("backfill_all_domains: post-backfill checkpoint failed: %s", _exc)
 
     return result
+
+
+# ─── one-time occurred_at backfill helper ───────────────────────────────────
+
+
+def backfill_node_occurred_at(
+    *,
+    days: int = 365,
+    limit: int | None = None,
+) -> int:
+    """Idempotent helper: fill occurred_at on nodes that have NULL occurred_at.
+
+    For each node in domain_node_map where occurred_at IS NULL, fetches the
+    source domain entry and sets occurred_at from the entry's real timestamp
+    (via _entry_occurred_at — same logic as create_fact_node_for_entry).
+
+    This is a one-time migration helper to fix backfilled nodes that were
+    inserted before the occurred_at column existed. Safe to run multiple times:
+    - Nodes with occurred_at already set are skipped (SELECT before UPDATE).
+    - Domains that fail to fetch are skipped with a warning (never raises).
+
+    Args:
+        days:  Look-back window passed to _fetch_domain_entries (default 365).
+        limit: Optional cap on total nodes updated in a single run.
+
+    Returns:
+        Number of nodes whose occurred_at was updated in this run.
+    """
+    from axi import store
+
+    conn = store._connect()  # noqa: SLF001
+
+    # Find nodes with occurred_at IS NULL that have a domain_node_map entry.
+    # Join gives us the domain and entry_id so we can look up the source entry.
+    rows = conn.execute(
+        "SELECT n.id AS node_id, d.domain, d.entry_id "
+        "FROM nodes n "
+        "JOIN domain_node_map d ON d.node_id = n.id "
+        "WHERE n.occurred_at IS NULL"
+    ).fetchall()
+
+    if not rows:
+        return 0
+
+    # Group by domain for efficient batch fetching.
+    by_domain: dict[str, dict[str, int]] = {}  # domain → {entry_id: node_id}
+    for row in rows:
+        domain = row["domain"]
+        if domain not in by_domain:
+            by_domain[domain] = {}
+        by_domain[domain][row["entry_id"]] = int(row["node_id"])
+
+    updated = 0
+    for domain, entry_map in by_domain.items():
+        if limit is not None and updated >= limit:
+            break
+        try:
+            entries = _fetch_domain_entries(domain, days=days)
+        except Exception as exc:  # noqa: BLE001
+            log.warning("backfill_node_occurred_at: fetch failed for domain=%r: %s", domain, exc)
+            continue
+
+        for entry in entries:
+            if limit is not None and updated >= limit:
+                break
+            entry_id = str(entry.id)
+            node_id = entry_map.get(entry_id)
+            if node_id is None:
+                continue
+
+            epoch = _entry_occurred_at(entry)
+            if epoch is None:
+                continue
+
+            try:
+                conn.execute(
+                    "UPDATE nodes SET occurred_at=? WHERE id=? AND occurred_at IS NULL",
+                    (epoch, node_id),
+                )
+                # In autocommit mode (isolation_level=None) the UPDATE commits
+                # automatically. No explicit commit needed.
+                updated += 1
+            except Exception as exc:  # noqa: BLE001
+                log.warning(
+                    "backfill_node_occurred_at: failed to update node_id=%r: %s", node_id, exc
+                )
+
+    return updated
 
 
 # ─── backward-compat shim ────────────────────────────────────────────────────

--- a/axi/src/axi/linkers.py
+++ b/axi/src/axi/linkers.py
@@ -73,12 +73,19 @@ def run_happened_at_linker(
     window_days: int = _DEFAULT_WINDOW_DAYS,
     window_s: float = _HAPPENED_AT_WINDOW_S,
 ) -> int:
-    """Link fact-nodes to meeting nodes when fact.created_at ∈ [meeting.start_time ± window_s].
+    """Link fact-nodes to meeting nodes when fact event time ∈ [meeting.start_time ± window_s].
 
     Edge direction: meeting_node → fact_node (kind='happened-at').
 
+    The fact's event time is COALESCE(occurred_at, created_at): the real event
+    timestamp when available, falling back to the graph-insertion time when not.
+    This fixes the backfill bug where all backfilled nodes share the same
+    created_at and would incorrectly link to meetings inserted on the same day.
+
     Only meetings that have a node_id (linked to a System-A node) are considered.
-    Only fact-nodes in the recent *window_days* days are processed.
+    Fact-nodes are fetched without a window filter on event time because a
+    backfilled fact may have created_at=today but occurred_at=5 days ago (inside
+    an older meeting's window). The meeting window cutoff still bounds the search.
 
     Returns the number of new 'happened-at' edges created.
     """
@@ -95,11 +102,12 @@ def run_happened_at_linker(
     if not meetings:
         return 0
 
-    # Fetch recent fact-nodes.
+    # Fetch ALL fact-nodes (no cutoff on created_at/occurred_at) because
+    # a backfilled fact's occurred_at may fall inside an older meeting's window
+    # even if created_at is recent. The meeting window cutoff bounds the search.
     fact_nodes = conn.execute(
-        "SELECT id, created_at FROM nodes "
-        "WHERE kind='fact' AND created_at > ?",
-        (cutoff,),
+        "SELECT id, COALESCE(occurred_at, created_at) AS event_ts FROM nodes "
+        "WHERE kind='fact'",
     ).fetchall()
 
     if not fact_nodes:
@@ -114,7 +122,7 @@ def run_happened_at_linker(
 
         for fact in fact_nodes:
             fact_id = int(fact["id"])
-            fact_ts = float(fact["created_at"])
+            fact_ts = float(fact["event_ts"])
             if lo <= fact_ts <= hi:
                 try:
                     if _safe_insert_edge(conn, meeting_node_id, fact_id, "happened-at"):
@@ -205,30 +213,33 @@ def run_same_day_linker(
     with kind='same-day'.
 
     Only fact-nodes in the recent *window_days* window are processed.
-    Within that window, nodes are grouped by UTC date string (YYYY-MM-DD).
-    For each group, every ordered pair (lower_id, higher_id) gets one edge.
-    Self-links are excluded.  Idempotent via SELECT-before-INSERT.
+    Within that window, nodes are grouped by UTC date string (YYYY-MM-DD)
+    using COALESCE(occurred_at, created_at) as the event date.
 
-    Design note: We choose same-day over mood-correlates-with because
-    health.Entry has no explicit mood field (mood_pre/mood_post live on
-    Interaction in the relationships domain). The same-day linker is simpler,
-    fully defensible, and uses only System-A data — no cross-DB read required.
+    Using occurred_at (instead of created_at) fixes the backfill "todo ligado"
+    bug: entries backfilled on the same day share the same created_at but have
+    different real event dates stored in occurred_at.  Only nodes whose real
+    event date (or insertion date when occurred_at is NULL) falls within the
+    window are considered.
 
     Returns the number of new 'same-day' edges created.
     """
     cutoff = time.time() - window_days * 86400
 
+    # Use COALESCE(occurred_at, created_at) as the canonical event timestamp.
+    # The window cutoff is also applied to the same expression so nodes are
+    # included based on their real event date, not their insertion date.
     rows = conn.execute(
-        "SELECT id, created_at FROM nodes "
-        "WHERE kind='fact' AND created_at > ? "
-        "ORDER BY created_at ASC",
+        "SELECT id, COALESCE(occurred_at, created_at) AS event_ts FROM nodes "
+        "WHERE kind='fact' AND COALESCE(occurred_at, created_at) > ? "
+        "ORDER BY COALESCE(occurred_at, created_at) ASC",
         (cutoff,),
     ).fetchall()
 
-    # Group by UTC date string.
+    # Group by UTC date string derived from the real event timestamp.
     by_day: dict[str, list[int]] = {}
     for row in rows:
-        ts = float(row["created_at"])
+        ts = float(row["event_ts"])
         day_key = datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%d")
         by_day.setdefault(day_key, []).append(int(row["id"]))
 

--- a/axi/src/axi/linkers.py
+++ b/axi/src/axi/linkers.py
@@ -5,7 +5,7 @@ present in memory.db.  All linkers are IDEMPOTENT (SELECT-before-INSERT) and
 bounded to a recent window to avoid full-table scans.
 
 Linkers implemented:
-  - run_happened_at_linker   : meeting node → fact node when fact.created_at ∈ [meeting.start_time ± 1h]
+  - run_happened_at_linker   : meeting node → fact node when COALESCE(fact.occurred_at, fact.created_at) ∈ [meeting.start_time ± 1h]
   - run_involves_person_linker: fact node → person node when fact.data.person_id is bridged via domain_node_map
   - run_same_day_linker      : fact node ↔ fact node when both share the same UTC calendar day
 
@@ -102,12 +102,21 @@ def run_happened_at_linker(
     if not meetings:
         return 0
 
-    # Fetch ALL fact-nodes (no cutoff on created_at/occurred_at) because
-    # a backfilled fact's occurred_at may fall inside an older meeting's window
-    # even if created_at is recent. The meeting window cutoff bounds the search.
+    # Fetch fact-nodes whose event time falls within the relevant range.
+    # Use COALESCE(occurred_at, created_at) as the canonical event timestamp
+    # (same expression used in the inner match loop below).
+    #
+    # The lower bound is the oldest meeting start_time minus window_s, so no
+    # fact that could legitimately match ANY meeting in this run is excluded.
+    # This restores bounded complexity (O(meetings × window)) without
+    # re-introducing the backfill bug: the cutoff is on the EVENT time
+    # (occurred_at when set), not created_at.
+    oldest_meeting_start = min(float(m["start_time"]) for m in meetings)
+    fact_cutoff = oldest_meeting_start - window_s
     fact_nodes = conn.execute(
         "SELECT id, COALESCE(occurred_at, created_at) AS event_ts FROM nodes "
-        "WHERE kind='fact'",
+        "WHERE kind='fact' AND COALESCE(occurred_at, created_at) > ?",
+        (fact_cutoff,),
     ).fetchall()
 
     if not fact_nodes:
@@ -247,9 +256,9 @@ def run_same_day_linker(
     for day_key, node_ids in by_day.items():
         if len(node_ids) < 2:
             continue
-        # Cap fan-out per day: link each node to its K nearest-by-created_at neighbors
-        # (node_ids are sorted by created_at ASC already).  This bounds the per-day
-        # edge count to MAX_SAME_DAY_PAIRS_PER_DAY instead of O(N²).
+        # Cap fan-out per day: link each node to its K nearest-by-event_ts neighbors
+        # (node_ids are sorted by COALESCE(occurred_at, created_at) ASC already).
+        # This bounds the per-day edge count to MAX_SAME_DAY_PAIRS_PER_DAY instead of O(N²).
         day_pairs_created = 0
         # K nearest neighbors per node (window of K consecutive nodes in time order).
         _K_NEAREST = 5

--- a/axi/src/axi/linkers.py
+++ b/axi/src/axi/linkers.py
@@ -7,14 +7,14 @@ bounded to a recent window to avoid full-table scans.
 Linkers implemented:
   - run_happened_at_linker   : meeting node → fact node when COALESCE(fact.occurred_at, fact.created_at) ∈ [meeting.start_time ± 1h]
   - run_involves_person_linker: fact node → person node when fact.data.person_id is bridged via domain_node_map
-  - run_same_day_linker      : fact node ↔ fact node when both share the same UTC calendar day
+  - run_same_day_linker      : fact node ↔ fact node when both share the same LOCAL calendar day (configured tz)
 
 Each function:
   - Accepts a live sqlcipher3 connection (same connection the caller uses).
   - Returns an int count of NEW edges created this run.
   - Logs warnings on per-row failures but never propagates exceptions.
 
-run_auto_linkers(conn, *, window_days=90):
+run_auto_linkers(conn, *, window_days=90, tz_name="UTC"):
   - Runs all three linkers over a recent bounded window.
   - Returns {happened_at: int, involves_person: int, same_day: int}.
 """
@@ -24,6 +24,7 @@ import json
 import logging
 import time
 from datetime import datetime, timezone
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 log = logging.getLogger("axi.linkers")
 
@@ -214,16 +215,21 @@ def run_same_day_linker(
     conn,
     *,
     window_days: int = _DEFAULT_WINDOW_DAYS,
+    tz_name: str = "UTC",
 ) -> int:
-    """Link pairs of fact-nodes that share the same UTC calendar day.
+    """Link pairs of fact-nodes that share the same LOCAL calendar day.
 
-    This is a time-proximity linker: two facts on the same day are likely
-    contextually related even without semantic similarity.  Edges are created
-    with kind='same-day'.
+    Two facts on the same calendar day (in the user's configured timezone) are
+    likely contextually related even without semantic similarity.  Edges are
+    created with kind='same-day'.
 
     Only fact-nodes in the recent *window_days* window are processed.
-    Within that window, nodes are grouped by UTC date string (YYYY-MM-DD)
-    using COALESCE(occurred_at, created_at) as the event date.
+    Within that window, nodes are grouped by their LOCAL date string (YYYY-MM-DD)
+    using COALESCE(occurred_at, created_at) as the event timestamp and *tz_name*
+    as the calendar-day reference timezone.
+
+    The look-back window cutoff is epoch-based (tz-agnostic) — only the
+    day_key bucketing uses the local tz.
 
     Using occurred_at (instead of created_at) fixes the backfill "todo ligado"
     bug: entries backfilled on the same day share the same created_at but have
@@ -231,8 +237,27 @@ def run_same_day_linker(
     event date (or insertion date when occurred_at is NULL) falls within the
     window are considered.
 
-    Returns the number of new 'same-day' edges created.
+    Args:
+        conn: Live sqlcipher3 connection to memory.db.
+        window_days: How many days back to look for candidates (default 90).
+        tz_name: IANA timezone name used for calendar-day bucketing (e.g.
+            'America/Mexico_City').  Defaults to 'UTC'.  If the name is
+            invalid, logs a warning and falls back to UTC so the linker
+            never crashes due to a misconfigured timezone.
+
+    Returns:
+        Number of new 'same-day' edges created.
     """
+    # Resolve tz once before the grouping loop.
+    try:
+        local_tz = ZoneInfo(tz_name)
+    except (ZoneInfoNotFoundError, KeyError, Exception):
+        log.warning(
+            "same-day linker: unknown timezone %r — falling back to UTC",
+            tz_name,
+        )
+        local_tz = timezone.utc
+
     cutoff = time.time() - window_days * 86400
 
     # Use COALESCE(occurred_at, created_at) as the canonical event timestamp.
@@ -245,11 +270,11 @@ def run_same_day_linker(
         (cutoff,),
     ).fetchall()
 
-    # Group by UTC date string derived from the real event timestamp.
+    # Group by LOCAL date string derived from the real event timestamp.
     by_day: dict[str, list[int]] = {}
     for row in rows:
         ts = float(row["event_ts"])
-        day_key = datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%d")
+        day_key = datetime.fromtimestamp(ts, tz=local_tz).strftime("%Y-%m-%d")
         by_day.setdefault(day_key, []).append(int(row["id"]))
 
     created = 0
@@ -288,6 +313,7 @@ def run_auto_linkers(
     conn,
     *,
     window_days: int = _DEFAULT_WINDOW_DAYS,
+    tz_name: str = "UTC",
 ) -> dict[str, int]:
     """Run all three cross-domain auto-linkers over the recent *window_days* window.
 
@@ -297,6 +323,9 @@ def run_auto_linkers(
     Args:
         conn: Active sqlcipher3 connection to memory.db (System A).
         window_days: How many days back to look for candidates (default 90).
+        tz_name: IANA timezone name passed to the same-day linker for calendar-day
+            bucketing (default 'UTC').  Pass config.get('timezone', 'UTC') from
+            the caller site so 'same day' means the user's local calendar day.
 
     Returns:
         {"happened_at": int, "involves_person": int, "same_day": int}
@@ -318,7 +347,7 @@ def run_auto_linkers(
         log.warning("run_auto_linkers: involves_person failed", exc_info=True)
 
     try:
-        result["same_day"] = run_same_day_linker(conn, window_days=window_days)
+        result["same_day"] = run_same_day_linker(conn, window_days=window_days, tz_name=tz_name)
     except Exception:  # noqa: BLE001
         log.warning("run_auto_linkers: same_day failed", exc_info=True)
 

--- a/axi/src/axi/store.py
+++ b/axi/src/axi/store.py
@@ -1789,11 +1789,13 @@ def run_periodic_embed_drain(*, embed_limit: int = 50, similarity_threshold: flo
 
     try:
         from axi.linkers import run_auto_linkers
+        from axi import config as _cfg
         c = _connect()
         # Ensure row_factory is set so linkers can use row["col"] access.
         import sqlcipher3 as _sc3
         c.row_factory = _sc3.Row
-        run_auto_linkers(c)
+        _tz = str(_cfg.get("timezone", "UTC"))
+        run_auto_linkers(c, tz_name=_tz)
     except Exception as _e:  # noqa: BLE001
         log.warning("run_periodic_embed_drain: run_auto_linkers failed", exc_info=True)
         try:

--- a/axi/src/axi/store.py
+++ b/axi/src/axi/store.py
@@ -943,6 +943,8 @@ def init_db() -> None:
             log.warning("init_db: could not create vec_nodes table: %s", _vec_exc)
         # Slice 2: domain_node_map bridge table.
         _create_domain_node_map(c)
+        # Event-date column: stores the real event timestamp (vs. insertion time).
+        migrate_nodes_occurred_at()
         # Events live in their own DB (telemetry isolated from user memory).
         # Open it here so the schema exists and any legacy events are migrated
         # at startup rather than lazily on the first write.
@@ -995,16 +997,29 @@ def add_node(
     label: str,
     data: dict[str, Any] | None = None,
     domain: str | None = None,
+    occurred_at: float | None = None,
 ) -> int:
-    """Insert a node, mirror text into FTS, return its id."""
+    """Insert a node, mirror text into FTS, return its id.
+
+    Args:
+        kind:       Node kind ('fact', 'person', 'event', …).
+        label:      Short human-readable description.
+        data:       Optional JSON-serialisable dict of extra properties.
+        domain:     Domain key ('health', 'finance', …) or None.
+        occurred_at: Real event timestamp (Unix epoch UTC). NULL when the
+                     event date is unknown (conversation nodes, etc.). Stored
+                     separately from created_at (graph-insertion time) so
+                     linkers can group by the actual event day rather than the
+                     day data was backfilled into the graph.
+    """
     now = time.time()
     payload = json.dumps(data or {}, ensure_ascii=False)
     tz = _current_tz()
     with _tx() as c:
         cur = c.execute(
-            "INSERT INTO nodes(kind, label, data, domain, created_at, updated_at, created_tz) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?)",
-            (kind, label, payload, domain, now, now, tz),
+            "INSERT INTO nodes(kind, label, data, domain, created_at, updated_at, created_tz, occurred_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (kind, label, payload, domain, now, now, tz, occurred_at),
         )
         node_id = cur.lastrowid
         c.execute(
@@ -1423,6 +1438,27 @@ def migrate_nodes_embedding() -> None:
     for col, col_type in new_cols:
         if col not in existing:
             c.execute(f"ALTER TABLE nodes ADD COLUMN {col} {col_type}")
+
+
+def migrate_nodes_occurred_at() -> None:
+    """Idempotent migration: add occurred_at column to the nodes table.
+
+    occurred_at stores the real event moment (Unix epoch UTC) — the timestamp
+    of the domain entry this node represents. It is NULL for nodes created
+    without a source entry (e.g. conversation nodes, person nodes).
+
+    Linkers use COALESCE(occurred_at, created_at) so existing nodes without
+    an event date fall back to the insertion timestamp (backward-compatible).
+
+    Safe to call multiple times (guarded by PRAGMA table_info).
+    """
+    c = _connect()
+    existing = {r[1] for r in c.execute("PRAGMA table_info(nodes)").fetchall()}
+    if "occurred_at" not in existing:
+        c.execute("ALTER TABLE nodes ADD COLUMN occurred_at REAL")
+        c.execute(
+            "CREATE INDEX IF NOT EXISTS idx_nodes_occurred ON nodes(occurred_at)"
+        )
 
 
 # ─────────────────── sqlite-vec virtual table (Slice 1, FORK-VEC path A) ────

--- a/axi/src/axi/templates/brain3d.html
+++ b/axi/src/axi/templates/brain3d.html
@@ -94,6 +94,10 @@
                 <span class="font-medium">Embedding:</span>
                 <span x-text="selectedNode.has_embedding ? '✓ ' + tUi('yes') : '—'"></span>
               </div>
+              <div x-show="selectedNode.occurred_at != null">
+                <span class="font-medium" x-text="tUi('date') + ':'"></span>
+                <span x-text="selectedNode.occurred_at ? new Date(selectedNode.occurred_at * 1000).toLocaleDateString() : '—'"></span>
+              </div>
             </div>
 
             <!-- Connected edges -->
@@ -196,6 +200,7 @@ const LABELS = {
       clickNode:    'Haz click en un nodo para ver sus detalles',
       typeLabel:    'Tipo',
       domainLabel:  'Dominio',
+      date:         'Fecha',
       yes:          'Sí',
       connections:  'Conexiones',
       system:       'sistema',
@@ -237,6 +242,7 @@ const LABELS = {
       clickNode:    'Click a node to see its details',
       typeLabel:    'Type',
       domainLabel:  'Domain',
+      date:         'Date',
       yes:          'Yes',
       connections:  'Connections',
       system:       'system',
@@ -317,7 +323,15 @@ function brain3dPage() {
         // Color by domain when set; most nodes (conversations/facts) carry a
         // kind but no domain, so fall back to kind, then to the grey default.
         const color = DOMAIN_COLOR[n.domain] || DOMAIN_COLOR[n.kind] || DOMAIN_COLOR['default'];
-        const gn = { id: n.id, label: n.label, kind: n.kind, domain: n.domain, has_embedding: n.has_embedding, color };
+        const gn = {
+          id: n.id,
+          label: n.label,
+          kind: n.kind,
+          domain: n.domain,
+          has_embedding: n.has_embedding,
+          occurred_at: n.occurred_at ?? null,  // real event epoch or null
+          color,
+        };
         nodeById[n.id] = gn;
         return gn;
       });

--- a/axi/src/axi/templates/brain3d.html
+++ b/axi/src/axi/templates/brain3d.html
@@ -96,7 +96,7 @@
               </div>
               <div x-show="selectedNode.occurred_at != null">
                 <span class="font-medium" x-text="tUi('date') + ':'"></span>
-                <span x-text="selectedNode.occurred_at ? new Date(selectedNode.occurred_at * 1000).toLocaleDateString() : '—'"></span>
+                <span x-text="selectedNode.occurred_at ? new Date(selectedNode.occurred_at * 1000).toLocaleDateString(LANG === 'en' ? 'en-US' : 'es-ES', { timeZone: TZ }) : '—'"></span>
               </div>
             </div>
 
@@ -143,6 +143,10 @@ function escHtml(str) {
 // UI language injected by the server from the 'language' config key.
 // 'es-MX' → 'es', 'en-US' → 'en'. Defaults to 'es'.
 const LANG = '{{ lang | default("es") }}';
+
+// IANA timezone injected by the server from config.timezone.
+// Used for toLocaleDateString() so displayed dates match the user's local calendar day.
+const TZ = '{{ tz | default("UTC") }}';
 
 // Domain-to-color map — consistent palette across all renders.
 // Keys are canonical English identifiers; displayed text uses tLabel/tEdge.

--- a/axi/tests/test_graph_event_date.py
+++ b/axi/tests/test_graph_event_date.py
@@ -1,0 +1,753 @@
+"""Tests for the 'todo ligado' bug fix: semantic graph linkers must use the
+real event date (occurred_at) instead of the graph-insertion date (created_at).
+
+TDD order: ALL tests in this file were written RED-first before any
+implementation exists. GREEN comes after the production code changes.
+
+Bug: backfilled entries are all inserted on the same day (created_at = now),
+so same-day and happened-at linkers wrongly treat them as co-occurring, forming
+a meaningless dense mesh. Fix: store the real event timestamp in occurred_at
+(NULL when unknown) and use COALESCE(occurred_at, created_at) in all linkers.
+
+Test coverage (one test file, structured by task):
+  T1 — add_node stores occurred_at correctly
+  T2 — domain_bridge extracts occurred_at from entry.ts
+  T3 — same-day linker uses occurred_at, NOT created_at (headline)
+  T4 — happened-at linker uses occurred_at, NOT created_at
+  T5 — backfill_node_occurred_at: fills NULL rows from live entries
+  T6 — /api/graph/full includes occurred_at; brain3d.html references it
+"""
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone, timedelta
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+# ─── shared helpers ──────────────────────────────────────────────────────────
+
+
+def _day_epoch(days_ago: int = 0) -> float:
+    """Return the Unix epoch for midnight UTC on a day relative to today."""
+    today = datetime.now(tz=timezone.utc).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+    target = today - timedelta(days=days_ago)
+    return target.timestamp()
+
+
+def _insert_node(
+    conn,
+    *,
+    kind: str = "fact",
+    label: str = "test",
+    domain: str = "health",
+    created_at: float | None = None,
+    occurred_at: float | None = None,
+    data: dict | None = None,
+) -> int:
+    """Insert a node with explicit created_at/occurred_at for test control."""
+    now = created_at if created_at is not None else time.time()
+    cur = conn.execute(
+        "INSERT INTO nodes(kind, label, data, domain, created_at, updated_at, occurred_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (kind, label, json.dumps(data or {}), domain, now, now, occurred_at),
+    )
+    conn.commit()
+    return cur.lastrowid
+
+
+def _insert_meeting(conn, *, start_time: float, title: str = "Test Meeting") -> int:
+    cur = conn.execute(
+        "INSERT INTO meetings(start_time, source, data_dir, status, created_at) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (start_time, "manual", "/tmp/test", "done", time.time()),
+    )
+    conn.commit()
+    return cur.lastrowid
+
+
+def _edge_exists(conn, from_id: int, to_id: int, kind: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM edges WHERE from_id=? AND to_id=? AND kind=? LIMIT 1",
+        (from_id, to_id, kind),
+    ).fetchone()
+    return row is not None
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# T1 — add_node stores occurred_at
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_add_node_stores_occurred_at_when_provided():
+    """T1a RED: add_node(occurred_at=X) → nodes row has occurred_at=X."""
+    import axi.store as store
+
+    nid = store.add_node("fact", "test event", occurred_at=123456789.0)
+
+    row = store.get_node(nid)
+    assert row is not None
+    # occurred_at must be stored and retrievable.
+    assert row["occurred_at"] == pytest.approx(123456789.0), (
+        "occurred_at column was not persisted by add_node; "
+        "schema migration + add_node signature change required"
+    )
+
+
+def test_add_node_stores_null_occurred_at_by_default():
+    """T1b RED: add_node() without occurred_at → occurred_at IS NULL."""
+    import axi.store as store
+
+    nid = store.add_node("fact", "no event date")
+
+    row = store.get_node(nid)
+    assert row is not None
+    assert row["occurred_at"] is None, (
+        "occurred_at should default to NULL when not provided; "
+        "verify the default is None and the column exists"
+    )
+
+
+def test_add_node_occurred_at_does_not_change_created_at():
+    """T1c: providing occurred_at must not alter created_at (insertion time)."""
+    import axi.store as store
+
+    before = time.time()
+    nid = store.add_node("fact", "timestamped", occurred_at=1000.0)
+    after = time.time()
+
+    row = store.get_node(nid)
+    assert row is not None
+    assert row["occurred_at"] == pytest.approx(1000.0)
+    # created_at must be the actual insertion time, not occurred_at.
+    assert before <= float(row["created_at"]) <= after, (
+        "created_at should be the insertion timestamp, not occurred_at"
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# T2 — domain_bridge extracts occurred_at from entry.ts
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@dataclass
+class _FakeEntryWithTs:
+    """Minimal duck-typed domain entry with a ts datetime."""
+    id: str = "fake-001"
+    kind: str = "vital"
+    raw_utterance: str = "test entry"
+    ts: object = None          # may be datetime, ISO string, or float epoch
+    created_at: object = None  # fallback
+
+
+def test_bridge_extracts_occurred_at_from_entry_ts_datetime():
+    """T2a RED: entry.ts is a datetime → occurred_at on the node matches its epoch."""
+    from axi.domain_bridge import create_fact_node_for_entry
+    import axi.store as store
+
+    known_dt = datetime(2026, 6, 11, 12, 19, 52, tzinfo=timezone.utc)
+    expected_epoch = known_dt.timestamp()
+
+    entry = _FakeEntryWithTs(id="bridge-dt-001", raw_utterance="health vital", ts=known_dt)
+
+    node_id = create_fact_node_for_entry("health", entry)
+    assert node_id is not None
+
+    row = store.get_node(node_id)
+    assert row is not None
+    assert row["occurred_at"] == pytest.approx(expected_epoch, abs=1), (
+        f"Bridge should store entry.ts epoch ({expected_epoch}) as occurred_at; "
+        f"got {row['occurred_at']}"
+    )
+
+
+def test_bridge_extracts_occurred_at_from_entry_ts_iso_string():
+    """T2b RED: entry.ts is an ISO string → occurred_at matches parsed epoch."""
+    from axi.domain_bridge import create_fact_node_for_entry
+    import axi.store as store
+
+    iso_str = "2026-06-24 12:19:52+00:00"
+    known_dt = datetime(2026, 6, 24, 12, 19, 52, tzinfo=timezone.utc)
+    expected_epoch = known_dt.timestamp()
+
+    entry = _FakeEntryWithTs(id="bridge-iso-002", raw_utterance="health bp", ts=iso_str)
+
+    node_id = create_fact_node_for_entry("health", entry)
+    assert node_id is not None
+
+    row = store.get_node(node_id)
+    assert row is not None
+    assert row["occurred_at"] == pytest.approx(expected_epoch, abs=1), (
+        f"Bridge should parse ISO string entry.ts to epoch; got {row['occurred_at']}"
+    )
+
+
+def test_bridge_falls_back_to_created_at_when_ts_absent():
+    """T2c RED: entry.ts is None but entry.created_at is a datetime → occurred_at from created_at."""
+    from axi.domain_bridge import create_fact_node_for_entry
+    import axi.store as store
+
+    known_dt = datetime(2026, 5, 1, 8, 0, 0, tzinfo=timezone.utc)
+    expected_epoch = known_dt.timestamp()
+
+    entry = _FakeEntryWithTs(
+        id="bridge-ca-003",
+        raw_utterance="health sleep",
+        ts=None,
+        created_at=known_dt,
+    )
+
+    node_id = create_fact_node_for_entry("health", entry)
+    assert node_id is not None
+
+    row = store.get_node(node_id)
+    assert row is not None
+    assert row["occurred_at"] == pytest.approx(expected_epoch, abs=1), (
+        "Bridge should fall back to entry.created_at when entry.ts is absent"
+    )
+
+
+def test_bridge_stores_null_occurred_at_when_no_timestamp():
+    """T2d RED: entry with neither ts nor created_at → occurred_at IS NULL."""
+    from axi.domain_bridge import create_fact_node_for_entry
+    import axi.store as store
+
+    entry = _FakeEntryWithTs(
+        id="bridge-null-004",
+        raw_utterance="health no date",
+        ts=None,
+        created_at=None,
+    )
+
+    node_id = create_fact_node_for_entry("health", entry)
+    assert node_id is not None
+
+    row = store.get_node(node_id)
+    assert row is not None
+    assert row["occurred_at"] is None, (
+        "occurred_at should be NULL when no timestamp is available on the entry"
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# T3 — same-day linker uses occurred_at, NOT created_at (the headline test)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_same_day_linker_does_not_link_same_created_at_different_occurred_at():
+    """T3a RED (headline): Two nodes with SAME created_at but DIFFERENT occurred_at days
+    must NOT be linked as same-day.
+
+    This directly validates the backfill bug: all backfilled nodes share the
+    same created_at (insertion day) but have different real event dates.
+    Current code (links by created_at) would link them — wrong.
+    After fix (links by COALESCE(occurred_at, created_at)) they must NOT link.
+    """
+    import axi.store as store
+    from axi.linkers import run_same_day_linker
+
+    conn = store._connect()
+
+    # Shared created_at simulates batch backfill on the same day.
+    shared_created_at = _day_epoch(0) + 3600  # today 01:00 UTC
+
+    # Fact A: really happened 5 days ago.
+    day5_ago = _day_epoch(5) + 3600
+    # Fact B: really happened 10 days ago.
+    day10_ago = _day_epoch(10) + 3600
+
+    nid_a = _insert_node(
+        conn,
+        label="Backfilled event A (5 days ago)",
+        created_at=shared_created_at,
+        occurred_at=day5_ago,
+    )
+    nid_b = _insert_node(
+        conn,
+        label="Backfilled event B (10 days ago)",
+        created_at=shared_created_at,
+        occurred_at=day10_ago,
+    )
+
+    run_same_day_linker(conn)
+
+    # With the fix, these must NOT be linked (different occurred_at days).
+    linked = (
+        _edge_exists(conn, nid_a, nid_b, "same-day")
+        or _edge_exists(conn, nid_b, nid_a, "same-day")
+    )
+    assert not linked, (
+        "same-day linker wrongly linked two nodes that share created_at but have "
+        "DIFFERENT occurred_at days. This is the backfill 'todo ligado' bug. "
+        "Linker must use COALESCE(occurred_at, created_at) instead of created_at."
+    )
+
+
+def test_same_day_linker_links_different_created_at_same_occurred_at():
+    """T3b RED: Two nodes with DIFFERENT created_at but SAME occurred_at day
+    MUST be linked as same-day.
+
+    Validates the positive case: nodes inserted at different times but
+    representing the same real-world day should form the same-day cluster.
+    Current code (links by created_at) would NOT link them — wrong.
+    After fix they must be linked.
+    """
+    import axi.store as store
+    from axi.linkers import run_same_day_linker
+
+    conn = store._connect()
+
+    # Different insertion times (e.g. two separate backfill runs).
+    insert_time_a = _day_epoch(0) + 3600   # today 01:00 UTC
+    insert_time_b = _day_epoch(1) + 3600   # yesterday 01:00 UTC (different created_at day)
+
+    # Both events really happened on the same day (3 days ago).
+    same_event_day = _day_epoch(3) + 3600
+
+    nid_a = _insert_node(
+        conn,
+        label="Event A (same real day, different insert time)",
+        created_at=insert_time_a,
+        occurred_at=same_event_day,
+    )
+    nid_b = _insert_node(
+        conn,
+        label="Event B (same real day, different insert time)",
+        created_at=insert_time_b,
+        occurred_at=same_event_day,
+    )
+
+    run_same_day_linker(conn)
+
+    # With the fix, these MUST be linked (same occurred_at day).
+    linked = (
+        _edge_exists(conn, nid_a, nid_b, "same-day")
+        or _edge_exists(conn, nid_b, nid_a, "same-day")
+    )
+    assert linked, (
+        "same-day linker did not link two nodes that share occurred_at day "
+        "but have different created_at. After the fix, COALESCE(occurred_at, created_at) "
+        "should group them correctly."
+    )
+
+
+def test_same_day_linker_fallback_to_created_at_when_occurred_at_null():
+    """T3c: When occurred_at is NULL, linker must fall back to created_at.
+
+    Ensures the COALESCE logic doesn't break nodes that have no occurred_at
+    (e.g. conversation nodes, manually created nodes).
+    """
+    import axi.store as store
+    from axi.linkers import run_same_day_linker
+
+    conn = store._connect()
+
+    today_ts = _day_epoch(0) + 3600
+
+    # Two nodes with NULL occurred_at, same created_at day → should still link.
+    nid_a = _insert_node(
+        conn,
+        label="No event date A",
+        created_at=today_ts,
+        occurred_at=None,
+    )
+    nid_b = _insert_node(
+        conn,
+        label="No event date B",
+        created_at=today_ts + 7200,  # 2h later, same day
+        occurred_at=None,
+    )
+
+    run_same_day_linker(conn)
+
+    linked = (
+        _edge_exists(conn, nid_a, nid_b, "same-day")
+        or _edge_exists(conn, nid_b, nid_a, "same-day")
+    )
+    assert linked, (
+        "When occurred_at is NULL, the linker should fall back to created_at "
+        "for grouping. Two NULL-occurred_at nodes on the same created_at day should link."
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# T4 — happened-at linker uses occurred_at, NOT created_at
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_happened_at_linker_uses_occurred_at_not_created_at():
+    """T4a RED: A fact with occurred_at inside the meeting window but
+    created_at OUTSIDE the window must still get a happened-at edge.
+
+    This validates the fix: the linker must check occurred_at, not created_at.
+    """
+    import axi.store as store
+    from axi.linkers import run_happened_at_linker
+
+    conn = store._connect()
+
+    # Meeting happened 5 days ago.
+    meeting_start = _day_epoch(5) + 14 * 3600  # 5 days ago, 14:00 UTC
+
+    mid = _insert_meeting(conn, start_time=meeting_start)
+    meeting_node_id = _insert_node(
+        conn,
+        kind="event",
+        label="Meeting from 5 days ago",
+        domain="meetings",
+        created_at=meeting_start,
+        occurred_at=meeting_start,
+    )
+    conn.execute("UPDATE meetings SET node_id=? WHERE id=?", (meeting_node_id, mid))
+    conn.commit()
+
+    # Fact with created_at = NOW (backfilled today), but occurred_at = 30min after meeting.
+    fact_occurred_at = meeting_start + 30 * 60   # 30 min into the meeting
+    fact_created_at = time.time()                 # inserted today (backfill)
+
+    fact_id = _insert_node(
+        conn,
+        kind="fact",
+        label="Fact from meeting (backfilled today)",
+        created_at=fact_created_at,   # today — OUTSIDE the meeting window
+        occurred_at=fact_occurred_at,  # 5 days ago — INSIDE the meeting window
+    )
+
+    created = run_happened_at_linker(conn)
+
+    assert created >= 1, (
+        "happened-at linker should link the fact to the meeting based on occurred_at, "
+        "not created_at. Fact has occurred_at inside meeting window but created_at outside."
+    )
+    assert _edge_exists(conn, meeting_node_id, fact_id, "happened-at"), (
+        "Expected happened-at edge from meeting_node to fact when fact.occurred_at "
+        "is within ±1h of meeting.start_time"
+    )
+
+
+def test_happened_at_linker_no_edge_when_occurred_at_outside_window():
+    """T4b RED: A fact with occurred_at OUTSIDE the meeting window must NOT link,
+    even if created_at happens to be inside the window.
+    """
+    import axi.store as store
+    from axi.linkers import run_happened_at_linker
+
+    conn = store._connect()
+
+    # Meeting now.
+    meeting_start = time.time()
+
+    mid = _insert_meeting(conn, start_time=meeting_start)
+    meeting_node_id = _insert_node(
+        conn,
+        kind="event",
+        label="Recent meeting",
+        domain="meetings",
+        created_at=meeting_start,
+        occurred_at=meeting_start,
+    )
+    conn.execute("UPDATE meetings SET node_id=? WHERE id=?", (meeting_node_id, mid))
+    conn.commit()
+
+    # Fact: created_at INSIDE window (tricky: could be a new note about a meeting)
+    # but occurred_at is 10 days ago (different real event).
+    fact_created_at = meeting_start + 20 * 60   # 20 min after meeting — inside window
+    fact_occurred_at = _day_epoch(10) + 3600    # 10 days ago — outside window
+
+    fact_id = _insert_node(
+        conn,
+        kind="fact",
+        label="Old event catalogued near meeting",
+        created_at=fact_created_at,
+        occurred_at=fact_occurred_at,
+    )
+
+    run_happened_at_linker(conn)
+
+    assert not _edge_exists(conn, meeting_node_id, fact_id, "happened-at"), (
+        "happened-at linker must NOT link a fact whose occurred_at is outside the "
+        "meeting window, even if created_at falls inside the window."
+    )
+
+
+def test_happened_at_linker_fallback_to_created_at_when_occurred_at_null():
+    """T4c: When occurred_at IS NULL, linker falls back to created_at (no regression).
+
+    Ensures COALESCE doesn't break the existing behaviour for nodes without an
+    event date (e.g. live entries created at the same moment they're recorded).
+    """
+    import axi.store as store
+    from axi.linkers import run_happened_at_linker
+
+    conn = store._connect()
+
+    meeting_start = time.time()
+    mid = _insert_meeting(conn, start_time=meeting_start)
+    meeting_node_id = _insert_node(
+        conn,
+        kind="event",
+        label="Live meeting",
+        domain="meetings",
+        created_at=meeting_start,
+        occurred_at=meeting_start,
+    )
+    conn.execute("UPDATE meetings SET node_id=? WHERE id=?", (meeting_node_id, mid))
+    conn.commit()
+
+    # Fact with NULL occurred_at but created_at inside the meeting window.
+    fact_created_at = meeting_start + 20 * 60  # 20 min after meeting
+    fact_id = _insert_node(
+        conn,
+        kind="fact",
+        label="Live fact (no occurred_at)",
+        created_at=fact_created_at,
+        occurred_at=None,
+    )
+
+    run_happened_at_linker(conn)
+
+    assert _edge_exists(conn, meeting_node_id, fact_id, "happened-at"), (
+        "With occurred_at IS NULL, the linker should fall back to created_at. "
+        "A fact created inside the meeting window should still link."
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# T5 — backfill_node_occurred_at: fills NULL rows from live entries
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_backfill_node_occurred_at_sets_occurred_at_from_entry():
+    """T5a RED: nodes with occurred_at IS NULL + domain_node_map row → occurred_at filled."""
+    import axi.store as store
+    from axi.domain_bridge import backfill_node_occurred_at
+
+    conn = store._connect()
+
+    # Create a node with occurred_at = NULL (simulates a pre-fix backfilled node).
+    now = time.time()
+    cur = conn.execute(
+        "INSERT INTO nodes(kind, label, data, domain, created_at, updated_at) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        ("fact", "health vital check", "{}", "health", now, now),
+    )
+    conn.commit()
+    node_id = cur.lastrowid
+
+    # Register it in domain_node_map.
+    entry_id = "he-backfill-001"
+    conn.execute(
+        "INSERT INTO domain_node_map(domain, entry_id, node_id, created_at) "
+        "VALUES (?, ?, ?, ?)",
+        ("health", entry_id, node_id, now),
+    )
+    conn.commit()
+
+    # Real event date from the domain entry.
+    real_event_dt = datetime(2026, 6, 11, 12, 0, 0, tzinfo=timezone.utc)
+    real_event_epoch = real_event_dt.timestamp()
+
+    # Stub _fetch_domain_entries to return a fake entry with that timestamp.
+    @dataclass
+    class _FakeEntry:
+        id: str = entry_id
+        kind: str = "vital"
+        raw_utterance: str = "health vital"
+        ts: object = real_event_dt
+        created_at: object = None
+
+    with patch("axi.domain_bridge._fetch_domain_entries", return_value=[_FakeEntry()]):
+        count = backfill_node_occurred_at()
+
+    assert count >= 1, (
+        "backfill_node_occurred_at should return >= 1 when at least one node "
+        "had NULL occurred_at and a domain entry with a real timestamp"
+    )
+
+    row = store.get_node(node_id)
+    assert row is not None
+    assert row["occurred_at"] == pytest.approx(real_event_epoch, abs=1), (
+        f"backfill_node_occurred_at should set occurred_at={real_event_epoch} "
+        f"from the entry's ts; got {row['occurred_at']}"
+    )
+
+
+def test_backfill_node_occurred_at_is_idempotent():
+    """T5b RED: Running backfill twice must not change already-set occurred_at values."""
+    import axi.store as store
+    from axi.domain_bridge import backfill_node_occurred_at
+
+    conn = store._connect()
+
+    now = time.time()
+    cur = conn.execute(
+        "INSERT INTO nodes(kind, label, data, domain, created_at, updated_at) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        ("fact", "health to backfill", "{}", "health", now, now),
+    )
+    conn.commit()
+    node_id = cur.lastrowid
+
+    entry_id = "he-backfill-002"
+    conn.execute(
+        "INSERT INTO domain_node_map(domain, entry_id, node_id, created_at) "
+        "VALUES (?, ?, ?, ?)",
+        ("health", entry_id, node_id, now),
+    )
+    conn.commit()
+
+    real_event_dt = datetime(2026, 6, 15, 9, 0, 0, tzinfo=timezone.utc)
+
+    @dataclass
+    class _FakeEntry:
+        id: str = entry_id
+        kind: str = "vital"
+        raw_utterance: str = "health vital"
+        ts: object = real_event_dt
+        created_at: object = None
+
+    with patch("axi.domain_bridge._fetch_domain_entries", return_value=[_FakeEntry()]):
+        count1 = backfill_node_occurred_at()
+        count2 = backfill_node_occurred_at()
+
+    # Second run: node already has occurred_at set → should return 0 updated.
+    assert count2 == 0, (
+        "backfill_node_occurred_at must be idempotent: second run should return 0 "
+        "since occurred_at is already set"
+    )
+
+
+def test_backfill_node_occurred_at_skips_already_set():
+    """T5c: Nodes where occurred_at is already set must not be touched."""
+    import axi.store as store
+    from axi.domain_bridge import backfill_node_occurred_at
+
+    conn = store._connect()
+
+    # Node with occurred_at already set.
+    original_epoch = 1_000_000.0
+    nid = store.add_node("fact", "already has date", occurred_at=original_epoch)
+
+    entry_id = "he-already-set-003"
+    conn.execute(
+        "INSERT INTO domain_node_map(domain, entry_id, node_id, created_at) "
+        "VALUES (?, ?, ?, ?)",
+        ("health", entry_id, nid, time.time()),
+    )
+    conn.commit()
+
+    # Entry with a DIFFERENT timestamp — backfill must not overwrite.
+    other_dt = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+    @dataclass
+    class _FakeEntry:
+        id: str = entry_id
+        kind: str = "vital"
+        raw_utterance: str = "health vital"
+        ts: object = other_dt
+        created_at: object = None
+
+    with patch("axi.domain_bridge._fetch_domain_entries", return_value=[_FakeEntry()]):
+        count = backfill_node_occurred_at()
+
+    assert count == 0, "backfill should skip nodes where occurred_at is already set"
+
+    row = store.get_node(nid)
+    assert row["occurred_at"] == pytest.approx(original_epoch), (
+        "backfill must not overwrite an already-set occurred_at value"
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# T6 — /api/graph/full includes occurred_at; brain3d.html references it
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_graph_full_includes_occurred_at_in_node_json():
+    """T6a RED: /api/graph/full node objects must include occurred_at field."""
+    import axi.store as store
+    from fastapi.testclient import TestClient
+    from axi.dashboard import app
+
+    client = TestClient(app)
+
+    # Create a node with a known occurred_at.
+    known_epoch = _day_epoch(3) + 3600
+    nid = store.add_node("fact", "event with date", occurred_at=known_epoch)
+
+    resp = client.get("/api/graph/full")
+    assert resp.status_code == 200, f"Expected 200, got {resp.status_code}"
+
+    data = resp.json()
+    nodes = {n["id"]: n for n in data["nodes"]}
+
+    assert nid in nodes, f"Node {nid} not found in /api/graph/full response"
+
+    node = nodes[nid]
+    assert "occurred_at" in node, (
+        "/api/graph/full node object is missing 'occurred_at' field; "
+        "dashboard.py must include it in the graph_full response"
+    )
+    assert node["occurred_at"] == pytest.approx(known_epoch, abs=1), (
+        f"Expected occurred_at={known_epoch}, got {node['occurred_at']}"
+    )
+
+
+def test_graph_full_occurred_at_null_when_not_set():
+    """T6b: /api/graph/full node with no event date has occurred_at=null."""
+    import axi.store as store
+    from fastapi.testclient import TestClient
+    from axi.dashboard import app
+
+    client = TestClient(app)
+
+    nid = store.add_node("fact", "event without date")
+
+    resp = client.get("/api/graph/full")
+    assert resp.status_code == 200
+
+    data = resp.json()
+    nodes = {n["id"]: n for n in data["nodes"]}
+    assert nid in nodes
+
+    node = nodes[nid]
+    assert "occurred_at" in node, "/api/graph/full must include occurred_at (even if null)"
+    assert node["occurred_at"] is None, "occurred_at should be null when node has no event date"
+
+
+def test_brain3d_html_references_occurred_at():
+    """T6c RED: brain3d.html template must reference occurred_at and display a date label.
+
+    We check the template source directly — it must contain 'occurred_at' (to read
+    the field from the API response) and a date UI label ('date' key in the LABELS
+    object or a literal 'Fecha' / 'Date' string).
+    """
+    from pathlib import Path
+
+    template_path = Path(__file__).parent.parent / "src" / "axi" / "templates" / "brain3d.html"
+    assert template_path.exists(), f"brain3d.html not found at {template_path}"
+
+    content = template_path.read_text()
+
+    assert "occurred_at" in content, (
+        "brain3d.html must reference 'occurred_at' to display the event date "
+        "in the node-detail panel"
+    )
+
+    # Should have a date label key ('date') in the i18n LABELS or a literal label.
+    has_date_label = (
+        "'date'" in content
+        or '"date"' in content
+        or "Fecha" in content
+        or "Date:" in content
+        or "fecha" in content
+    )
+    assert has_date_label, (
+        "brain3d.html must show a date label (e.g. 'Fecha:' / 'Date:') "
+        "for selected nodes when occurred_at is present"
+    )

--- a/axi/tests/test_graph_event_date.py
+++ b/axi/tests/test_graph_event_date.py
@@ -664,6 +664,158 @@ def test_backfill_node_occurred_at_skips_already_set():
 
 
 # ═══════════════════════════════════════════════════════════════════════════
+# T5d — backfill_node_occurred_at: generous default window (FIX 1)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_backfill_default_window_covers_entries_older_than_one_year():
+    """T5d RED: The DEFAULT call (no days= arg) must populate occurred_at for a
+    node whose real event date is 800 days ago.
+
+    Prior to the fix, days defaulted to 365.  An entry with event_ts = 800 days
+    ago is outside that window and would NOT be returned by _fetch_domain_entries,
+    leaving occurred_at NULL — the dense-mesh bug persists for >1-year-old entries.
+
+    After the fix (days=36500 ≈ 100 years), all existing entries are reachable.
+    The test uses a patched _fetch_domain_entries so the call is local and fast.
+    """
+    import axi.store as store
+    from axi.domain_bridge import backfill_node_occurred_at
+
+    conn = store._connect()
+
+    now = time.time()
+    cur = conn.execute(
+        "INSERT INTO nodes(kind, label, data, domain, created_at, updated_at) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        ("fact", "ancient health event", "{}", "health", now, now),
+    )
+    conn.commit()
+    node_id = cur.lastrowid
+
+    entry_id = "he-ancient-800d"
+    conn.execute(
+        "INSERT INTO domain_node_map(domain, entry_id, node_id, created_at) "
+        "VALUES (?, ?, ?, ?)",
+        ("health", entry_id, node_id, now),
+    )
+    conn.commit()
+
+    # Real event date is 800 days ago — well outside the old 365-day default.
+    ancient_dt = datetime.now(tz=timezone.utc) - timedelta(days=800)
+    ancient_epoch = ancient_dt.timestamp()
+
+    # Track the days= value that _fetch_domain_entries is actually called with.
+    received_days: list[int] = []
+
+    @dataclass
+    class _FakeEntry:
+        id: str = entry_id
+        kind: str = "vital"
+        raw_utterance: str = "ancient vital"
+        ts: object = ancient_dt
+        created_at: object = None
+
+    def _fake_fetch(domain, *, days, limit=None):  # noqa: ANN001
+        received_days.append(days)
+        return [_FakeEntry()]
+
+    with patch("axi.domain_bridge._fetch_domain_entries", side_effect=_fake_fetch):
+        count = backfill_node_occurred_at()  # no days= argument — uses the default
+
+    # The default window must be generous enough to cover 800-day-old entries.
+    assert received_days, "_fetch_domain_entries was never called"
+    assert received_days[0] >= 800, (
+        f"backfill_node_occurred_at default days={received_days[0]} is too small to "
+        f"cover an 800-day-old entry. Default should be >= 36500 (≈100 years)."
+    )
+
+    assert count >= 1, (
+        "backfill_node_occurred_at did not update the ancient node; "
+        "the default look-back window is too narrow."
+    )
+
+    row = store.get_node(node_id)
+    assert row is not None
+    assert row["occurred_at"] == pytest.approx(ancient_epoch, abs=1), (
+        f"occurred_at should be the ancient event epoch ({ancient_epoch}); "
+        f"got {row['occurred_at']}"
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# T5e — backfill_node_occurred_at: rowcount accuracy (FIX 2)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_backfill_rowcount_reflects_actual_rows_updated():
+    """T5e RED: The return value of backfill_node_occurred_at must equal the number
+    of rows actually changed in the DB — NOT the number of iterations.
+
+    Scenario:
+      - Two nodes with NULL occurred_at and matching domain entries.
+      - First call → both updated → count == 2.
+      - Second call → both already set → count == 0 (idempotency + rowcount check).
+
+    If the code does `updated += 1` unconditionally (without checking rowcount),
+    the second call would still return 2 (the loop iterates but SQLite's
+    WHERE occurred_at IS NULL prevents any actual writes).
+    """
+    import axi.store as store
+    from axi.domain_bridge import backfill_node_occurred_at
+
+    conn = store._connect()
+    now = time.time()
+
+    node_ids = []
+    entry_ids = []
+    for i in range(2):
+        cur = conn.execute(
+            "INSERT INTO nodes(kind, label, data, domain, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("fact", f"rowcount test node {i}", "{}", "health", now, now),
+        )
+        conn.commit()
+        nid = cur.lastrowid
+        node_ids.append(nid)
+
+        eid = f"he-rowcount-{i:03d}"
+        entry_ids.append(eid)
+        conn.execute(
+            "INSERT INTO domain_node_map(domain, entry_id, node_id, created_at) "
+            "VALUES (?, ?, ?, ?)",
+            ("health", eid, nid, now),
+        )
+        conn.commit()
+
+    real_dt = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+
+    @dataclass
+    class _FakeEntry:
+        id: str = ""
+        kind: str = "vital"
+        raw_utterance: str = "rowcount test"
+        ts: object = real_dt
+        created_at: object = None
+
+    def _fake_fetch(domain, *, days, limit=None):  # noqa: ANN001
+        return [_FakeEntry(id=eid) for eid in entry_ids]
+
+    with patch("axi.domain_bridge._fetch_domain_entries", side_effect=_fake_fetch):
+        count_first = backfill_node_occurred_at()
+        count_second = backfill_node_occurred_at()
+
+    assert count_first == 2, (
+        f"First backfill run should update exactly 2 nodes; got {count_first}. "
+        "Make sure the count uses cur.rowcount, not unconditional += 1."
+    )
+    assert count_second == 0, (
+        f"Second backfill run should return 0 (all occurred_at already set); "
+        f"got {count_second}. This indicates the count does NOT reflect actual DB writes."
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
 # T6 — /api/graph/full includes occurred_at; brain3d.html references it
 # ═══════════════════════════════════════════════════════════════════════════
 

--- a/axi/tests/test_timezone_grouping.py
+++ b/axi/tests/test_timezone_grouping.py
@@ -1,0 +1,235 @@
+"""Timezone-aware grouping and display tests — Strict TDD RED phase.
+
+Tests cover:
+  TZ-1  config_schema timezone default uses system tz (not hardcoded literal)
+  TZ-2  same-day linker groups by LOCAL tz, not UTC (the headline cross-midnight case)
+  TZ-3  same-day linker falls back to UTC on bad tz string (no crash)
+  TZ-4  brain3d route passes 'tz' to template context
+"""
+from __future__ import annotations
+
+import json
+import time
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TZ-1  config_schema: timezone default reflects system tz via tzlocal
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_config_timezone_default_uses_system_tz():
+    """The 'timezone' ConfigField default must come from tzlocal, not a hardcoded literal.
+
+    We patch tzlocal.get_localzone_name to a known value and re-evaluate the
+    module-level default.  The test discriminates against a hardcoded string
+    like 'America/Mexico_City': if the default is static, changing tzlocal has
+    no effect and the assertion fails.
+    """
+    # Patch tzlocal at the module level that config_schema imports from.
+    with patch("tzlocal.get_localzone_name", return_value="Europe/Berlin"):
+        # Re-import to pick up patched tzlocal.
+        import importlib
+        import axi.config_schema as _cs
+        importlib.reload(_cs)
+        defaults = _cs.defaults()
+
+    # After reload with patched tzlocal the default must reflect the patched value.
+    assert defaults["timezone"] == "Europe/Berlin", (
+        f"timezone default is '{defaults['timezone']}' — expected 'Europe/Berlin'. "
+        "The default is not reading from tzlocal (still hardcoded)."
+    )
+
+
+def test_config_timezone_default_falls_back_to_utc_when_tzlocal_fails():
+    """If tzlocal raises or returns None the default must fall back to 'UTC'."""
+    with patch("tzlocal.get_localzone_name", side_effect=Exception("no tz")):
+        import importlib
+        import axi.config_schema as _cs
+        importlib.reload(_cs)
+        defaults = _cs.defaults()
+
+    assert defaults["timezone"] == "UTC", (
+        f"timezone default is '{defaults['timezone']}' — expected 'UTC' fallback "
+        "when tzlocal raises."
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TZ-2  same-day linker groups by LOCAL tz, not UTC (cross-midnight test)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _insert_node(conn, kind="fact", label="test", domain="health", ts=None) -> int:
+    now = ts or time.time()
+    cur = conn.execute(
+        "INSERT INTO nodes(kind, label, data, domain, created_at, updated_at) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        (kind, label, "{}", domain, now, now),
+    )
+    conn.commit()
+    return cur.lastrowid
+
+
+def _edge_exists(conn, a: int, b: int, kind: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM edges WHERE from_id=? AND to_id=? AND kind=? LIMIT 1",
+        (a, b, kind),
+    ).fetchone()
+    return row is not None
+
+
+def _any_edge(conn, a: int, b: int, kind: str) -> bool:
+    return _edge_exists(conn, a, b, kind) or _edge_exists(conn, b, a, kind)
+
+
+def test_same_day_groups_by_local_tz_not_utc():
+    """Headline test: two timestamps that share a LOCAL calendar day but span UTC midnight
+    must be linked when the linker is configured with the local tz, and must NOT be linked
+    when they span a LOCAL midnight (even if they share the same UTC day).
+
+    Setup (America/Mexico_City = UTC-6):
+      ts_local_eve  = 2026-06-10 23:00 local  → 2026-06-11 05:00 UTC
+      ts_local_morn = 2026-06-10 22:00 local  → 2026-06-11 04:00 UTC
+    Both are LOCAL June 10.  UTC grouping puts them on June 11 together — that part
+    is the same.  The discriminating case is the *negative* case:
+
+      ts_just_past_local_midnight = 2026-06-11 00:30 local → 2026-06-11 06:30 UTC
+    This is LOCAL June 11.  Grouping by UTC both 05:00 and 06:30 are on June 11 —
+    UTC grouping would link them.  Local-tz grouping keeps them on different local days:
+    ts_local_eve is June 10 local; ts_just_past is June 11 local → must NOT be linked.
+
+    So: (ts_local_morn, ts_local_eve) → same local day → linked
+        (ts_local_eve, ts_just_past_local_midnight) → different local day → NOT linked
+    """
+    import axi.store as store
+    from axi.linkers import run_same_day_linker
+
+    conn = store._connect()
+
+    # America/Mexico_City = UTC-6 (standard; no DST at these dates for testing).
+    # We fix the epoch values manually to avoid depending on ZoneInfo in the test itself.
+    # UTC offset: -6h = -21600s
+
+    # 2026-06-10 22:00 local (Mexico City) = 2026-06-11 04:00 UTC
+    ts_local_morn = datetime(2026, 6, 11, 4, 0, 0, tzinfo=timezone.utc).timestamp()
+
+    # 2026-06-10 23:00 local (Mexico City) = 2026-06-11 05:00 UTC
+    ts_local_eve = datetime(2026, 6, 11, 5, 0, 0, tzinfo=timezone.utc).timestamp()
+
+    # 2026-06-11 00:30 local (Mexico City) = 2026-06-11 06:30 UTC
+    ts_just_past_local_midnight = datetime(2026, 6, 11, 6, 30, 0, tzinfo=timezone.utc).timestamp()
+
+    # Nodes A and B share LOCAL June 10; node C is LOCAL June 11.
+    nid_a = _insert_node(conn, label="A: June10 22h local", ts=ts_local_morn)
+    nid_b = _insert_node(conn, label="B: June10 23h local", ts=ts_local_eve)
+    nid_c = _insert_node(conn, label="C: June11 00:30 local", ts=ts_just_past_local_midnight)
+
+    # Run linker with America/Mexico_City tz (window must be huge to capture test dates).
+    window_days = 400  # test dates are ~2 weeks in the past relative to 2026-06-24
+    created = run_same_day_linker(conn, tz_name="America/Mexico_City", window_days=window_days)
+
+    # A and B share local June 10 → MUST be linked.
+    assert _any_edge(conn, nid_a, nid_b, "same-day"), (
+        "A (22h local) and B (23h local) share LOCAL June 10 but are NOT linked. "
+        "Linker is grouping by UTC (where both fall on June 11) instead of by the "
+        "configured local tz."
+    )
+
+    # B and C are local June 10 vs June 11 → must NOT be linked.
+    assert not _any_edge(conn, nid_b, nid_c, "same-day"), (
+        "B (June10 23h local = June11 05:00 UTC) and C (June11 00:30 local = June11 06:30 UTC) "
+        "are on the SAME UTC day (June 11) but on DIFFERENT local days. They must NOT be linked "
+        "when grouping by the configured local tz. UTC grouping would incorrectly link them."
+    )
+
+
+def test_same_day_linker_utc_default_groups_by_utc():
+    """When tz_name is not provided (defaults to UTC), grouping is by UTC day — existing behaviour.
+
+    This is the backward-compatibility guard: callers that don't pass tz_name keep UTC semantics.
+    """
+    import axi.store as store
+    from axi.linkers import run_same_day_linker
+
+    conn = store._connect()
+
+    # Both timestamps are on the same UTC day (2026-06-15).
+    ts1 = datetime(2026, 6, 15, 2, 0, 0, tzinfo=timezone.utc).timestamp()
+    ts2 = datetime(2026, 6, 15, 22, 0, 0, tzinfo=timezone.utc).timestamp()
+
+    nid1 = _insert_node(conn, label="UTC compat 1", ts=ts1)
+    nid2 = _insert_node(conn, label="UTC compat 2", ts=ts2)
+
+    run_same_day_linker(conn, window_days=400)  # no tz_name → UTC
+
+    assert _any_edge(conn, nid1, nid2, "same-day"), (
+        "Without tz_name, UTC default grouping must still link nodes on the same UTC day."
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TZ-3  bad tz string falls back to UTC without crashing
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_same_day_linker_bad_tz_falls_back_to_utc():
+    """A bad/unknown tz string must not raise — linker falls back to UTC and continues."""
+    import axi.store as store
+    from axi.linkers import run_same_day_linker
+
+    conn = store._connect()
+
+    now = time.time()
+    nid1 = _insert_node(conn, label="bad-tz node 1", ts=now)
+    nid2 = _insert_node(conn, label="bad-tz node 2", ts=now + 3600)
+
+    # Must not raise even with an invalid tz name.
+    result = run_same_day_linker(conn, tz_name="Not/AZone")
+
+    # Result must be an integer (not an exception).
+    assert isinstance(result, int)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TZ-4  brain3d route passes 'tz' to template context
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def dashboard_client(monkeypatch):
+    from axi import dashboard
+
+    monkeypatch.setattr(dashboard, "_daemon_cmd", lambda *_a, **_k: "idle")
+    monkeypatch.setattr(dashboard, "_llama_alive", lambda: False)
+    monkeypatch.setattr(dashboard, "_service_state", lambda *_a, **_k: "active")
+    monkeypatch.setattr(dashboard, "_vram_snapshot", lambda: {
+        "name": "test", "used_mb": 100, "total_mb": 1000, "util_pct": 10,
+    })
+    monkeypatch.setattr(dashboard, "_ram_snapshot", lambda: {
+        "used": 100, "total": 1000, "pct": 10.0,
+    })
+    monkeypatch.setattr(dashboard, "_cpu_pct", lambda: 1.5)
+
+    from fastapi.testclient import TestClient
+    return TestClient(dashboard.app)
+
+
+def test_brain3d_route_passes_tz_to_template(dashboard_client):
+    """The /brain3d route must inject the configured 'tz' into the template.
+
+    We verify by checking the rendered HTML contains the tz value.
+    The config used in tests defaults to 'America/Mexico_City'; the template
+    must embed it so client-side JS can format dates in the user's local tz.
+    """
+    r = dashboard_client.get("/brain3d")
+    assert r.status_code == 200
+    # The configured tz string must appear in the rendered HTML.
+    # (The template uses it as a JS variable or data attribute for toLocaleDateString.)
+    assert "America/Mexico_City" in r.text or "UTC" in r.text, (
+        "brain3d route does not embed the configured tz in the template. "
+        "The 'tz' context variable is missing or unused in brain3d.html."
+    )


### PR DESCRIPTION
## Why
The "todo ligado" cross-domain linking was broken: the same-day / happened-at linkers grouped facts by `nodes.created_at` (graph-insertion time). Backfilled facts all share the batch-insert day → every fact appeared "same day" → a meaningless dense mesh (105 edges among 25 nodes). So "¿qué presión cuando dormí mal?" couldn't link the bad-sleep night to that night's BP. Also: nodes didn't carry/show the event date, and grouping was UTC (wrong for a personal day-log).

## What
- **Real event date**: new nullable `nodes.occurred_at` (the entry's real `ts`), set by the bridge; linkers use `COALESCE(occurred_at, created_at)` so they group by when it actually happened, not when it was inserted.
- **User's timezone**: "same day" is the user's LOCAL calendar day in `config.timezone` (not UTC). `config.timezone` now defaults to the **system-detected** tz (tzlocal), user-overridable — the same tz the dashboard/brain already use. Cross-midnight handled (an 11pm-local reading counts as that day).
- **Display**: Cerebro 3D node-detail shows the event date in the configured tz (es/en label), matching the grouping.
- **Migration helper** `backfill_node_occurred_at(days=36500)`: populates occurred_at for existing nodes from their source entries (idempotent; generous window so old entries aren't missed).

## Quality
- Strict TDD. **1671 passed.** Headline tests: same created_at + different real days → NOT linked; different created_at + same real day → linked; cross-midnight local-vs-UTC day; system-tz default; bad-tz fallback; date display in tz.
- **Dual blind adversarial review** of the event-date foundation (both APPROVE — same-day + happened-at COALESCE correct, timezone/epoch correct for every input shape). Review fixes applied (migration window, rowcount, happened-at bound, comments). **Fresh-context verification** of the timezone layer: cross-midnight grouping correct, the production linker call passes the configured tz (live, not a dead UTC path), display matches grouping.

Foundation for the next step (RAG: the brain answering questions using these dated, correctly-linked facts).