### PR TITLE
feat: Layer 3 graph recall + wake-word live-test harness

### DIFF
--- a/axi/scripts/WAKEWORD_LIVETEST.md
+++ b/axi/scripts/WAKEWORD_LIVETEST.md
@@ -1,0 +1,89 @@
+# Wake-word live-test — runbook
+
+Fire-and-forget harness para validar el wake-word manos-libres de Axi ("Axi,
+ayudame…"). Jugás, invocás el wake-word, y al final corrés **un solo comando**
+para obtener la tabla de decisión. No hay que mirar la terminal mientras jugás.
+
+## Qué mide
+
+El daemon ya loguea a journald (`journalctl --user -u axi-voice`). Se agregaron
+anclas machine-parseables con prefijo `wakeword-metric:` SOLO en el wake path:
+
+- `wake_detected t=<epoch> command=<cmd>` — momento del wake (ancla principal)
+- `ask_start t=<epoch>` — el brain ask arranca (estado → thinking)
+- `tts_start t=<epoch>` — empieza la reproducción TTS (estado → speaking)
+- `tts_done t=<epoch>` — termina el TTS (antes de volver a idle)
+
+La latencia del brain sale de la tabla `brain_metrics`. El round-trip honesto es
+`tts_done − wake_detected` (no hay ancla de "empezó a hablar", así que la
+latencia de detección pura no se puede medir con precisión — el reporte lo dice).
+
+## Setup (una vez por sesión)
+
+Habilitar el wake-word y reiniciar el daemon:
+
+```bash
+export AXI_WAKEWORD_ENABLED=1
+systemctl --user restart axi-voice
+# o, equivalente:
+axi-game-on
+```
+
+En una terminal aparte, arrancar el sampler de CPU/RAM (lo ÚNICO que iniciás a
+mano; es set-and-forget):
+
+```bash
+scripts/wakeword_cpu_sample.sh /tmp/axi-wakeword-cpu.csv
+# Ctrl-C al terminar la sesión
+```
+
+## Protocolo de 3 corridas
+
+1. **Silent** (línea base de false-triggers): jugá ~10–15 min SIN invocar el
+   wake-word. Cualquier WAKE DETECTED es un falso positivo. En el reporte, el
+   total de wakes == cantidad de falsos positivos.
+2. **Invocation** (latencia / round-trip): invocá "Axi, ayudame con…" varias
+   veces (8–12) en condiciones reales de juego. Medí round-trip y latencia.
+3. **Real** (uso natural): jugá normal usando el co-piloto cuando lo necesites.
+   Mezcla de invocaciones reales + posibles falsos positivos a confirmar a mano.
+
+## Analizar (EL comando)
+
+Al terminar, corré el analizador con la ventana de tiempo:
+
+```bash
+.venv/bin/python scripts/wakeword_report.py --minutes 60 --cpu-csv /tmp/axi-wakeword-cpu.csv
+# o
+.venv/bin/python scripts/wakeword_report.py --since "1 hour ago" --cpu-csv /tmp/axi-wakeword-cpu.csv
+```
+
+El reporte imprime:
+
+- Conteos: invocaciones, transcripciones, no-wake (near-miss), answers, miss rate.
+- Round-trip p50/p95, latencia de brain p50/p95, duración TTS p50/p95.
+- **Lista de cada WAKE DETECTED** con timestamp + command para que marqués los
+  espurios (en una corrida Silent, TODOS son falsos positivos).
+- Resumen CPU idle/peak y RSS si pasaste `--cpu-csv`.
+- **VEREDICTO** con acción recomendada.
+
+> El veredicto de false-triggers asume conservadoramente que TODOS los wakes son
+> espurios. Restá tus invocaciones intencionales y releé esa línea.
+
+## Tabla de umbrales (constantes en `wakeword_report.py`)
+
+| Métrica              | Verde si…           | Acción si se pasa                                   |
+|----------------------|---------------------|-----------------------------------------------------|
+| Round-trip p95       | ≤ 15 s              | Game-brain más chico (p.ej. gemma-e2b)              |
+| False triggers       | ≤ 0                 | Escalar a openWakeWord (modelo entrenado)           |
+| Miss rate            | ≤ 10 %              | Escalar a openWakeWord (mejor recall)               |
+| CPU idle             | ≤ 15 %              | Profilear el listener en reposo                     |
+| CPU peak             | ≤ 120 % (~1 core)   | Investigar picos de CPU durante el wake             |
+
+**Todo verde → avanzar a slice-2** (co-piloto wake-word con web-search).
+
+## Qué significa cada veredicto
+
+- **GREEN**: el flujo manos-libres está dentro de tolerancia; seguí a slice-2.
+- **ACTION-NEEDED**: el reporte lista la(s) recomendación(es) concreta(s):
+  openWakeWord (detección lenta / falsos positivos / miss alto), game-brain más
+  chico (round-trip > 15 s), o profiling de CPU.

--- a/axi/scripts/wakeword_cpu_sample.sh
+++ b/axi/scripts/wakeword_cpu_sample.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Wake-word live-test CPU/RAM sampler — set-and-forget.
+#
+# Samples the axi-voice process CPU% and RSS every 2s to a CSV until Ctrl-C.
+# This is the ONLY thing Héctor starts manually during a session; it runs in a
+# spare terminal while he plays. The analyzer (wakeword_report.py --cpu-csv)
+# reads the CSV afterward.
+#
+# Output columns: epoch,cpu_pct,rss_mb
+# Robust to transient failures: if axi-voice restarts (new PID), it re-resolves
+# the PID on the next tick instead of dying.
+#
+# Usage:
+#   scripts/wakeword_cpu_sample.sh [OUTPUT_CSV] [INTERVAL_SECONDS]
+# Defaults: OUTPUT_CSV=/tmp/axi-wakeword-cpu.csv  INTERVAL=2
+
+set -u
+
+OUT="${1:-/tmp/axi-wakeword-cpu.csv}"
+INTERVAL="${2:-2}"
+
+resolve_pid() {
+  # Prefer systemd MainPID; fall back to pgrep. Echo empty on failure.
+  local pid
+  pid="$(systemctl --user show -p MainPID --value axi-voice 2>/dev/null || true)"
+  if [ -n "${pid:-}" ] && [ "$pid" != "0" ]; then
+    echo "$pid"
+    return 0
+  fi
+  pgrep -f 'axi-voice' 2>/dev/null | head -n1
+}
+
+# Write header (overwrite previous run).
+echo "epoch,cpu_pct,rss_mb" > "$OUT"
+echo "[wakeword_cpu_sample] writing to $OUT every ${INTERVAL}s — Ctrl-C to stop" >&2
+
+trap 'echo "[wakeword_cpu_sample] stopped" >&2; exit 0' INT TERM
+
+while true; do
+  EPOCH="$(date +%s)"
+  PID="$(resolve_pid)"
+
+  if [ -z "${PID:-}" ]; then
+    # process not running this tick — record a gap row with empty metrics
+    echo "${EPOCH},," >> "$OUT"
+    sleep "$INTERVAL"
+    continue
+  fi
+
+  # ps gives instantaneous-ish CPU% (since process start) and RSS in KB.
+  # %cpu can exceed 100 on multi-core; that's expected and the analyzer handles it.
+  LINE="$(ps -p "$PID" -o %cpu=,rss= 2>/dev/null || true)"
+  if [ -z "${LINE:-}" ]; then
+    echo "${EPOCH},," >> "$OUT"
+    sleep "$INTERVAL"
+    continue
+  fi
+
+  CPU="$(echo "$LINE" | awk '{print $1}')"
+  RSS_KB="$(echo "$LINE" | awk '{print $2}')"
+  # convert KB -> MB (integer-ish)
+  RSS_MB="$(awk "BEGIN{printf \"%.1f\", ${RSS_KB:-0}/1024}")"
+
+  echo "${EPOCH},${CPU},${RSS_MB}" >> "$OUT"
+  sleep "$INTERVAL"
+done

--- a/axi/scripts/wakeword_report.py
+++ b/axi/scripts/wakeword_report.py
@@ -1,0 +1,436 @@
+#!/usr/bin/env python3
+"""Wake-word live-test analyzer — the ONE post-session command.
+
+Fire-and-forget harness for the LifeOS/Axi hands-free wake-word feature.
+Héctor plays a game, invokes the wake-word, then runs this ONCE afterward to
+get a decision table + verdict. No terminal babysitting during play.
+
+Data sources (all read after the fact, no live services required to *parse*):
+  - journald logs of the axi-voice unit (the wake path emits machine-parseable
+    `wakeword-metric:` lines plus existing human log lines).
+  - the `brain_metrics` table in the encrypted store (brain latency per ask).
+  - optionally, a CPU/RAM CSV produced by scripts/wakeword_cpu_sample.sh.
+
+The log PARSER (`parse_log_lines`) is a PURE function over an iterable of log
+lines so it is unit-testable without journalctl or live services.
+
+stdlib only, plus `from axi import store` for brain_metrics access.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import statistics
+import subprocess
+import sys
+from dataclasses import dataclass, field
+
+# ---------------------------------------------------------------------------
+# Verdict thresholds (architect-provided). Edit here to retune.
+# All time thresholds are in SECONDS unless noted.
+# ---------------------------------------------------------------------------
+ROUND_TRIP_GREEN_S = 15.0          # p95 round-trip at/under this is green
+ROUND_TRIP_SMALL_BRAIN_S = 15.0   # p95 over this -> recommend smaller game-brain
+FALSE_TRIGGER_GREEN_MAX = 0       # spurious wakes at/under this is green
+MISS_RATE_GREEN_MAX = 0.10        # fraction (no-wake / total transcripts) green at/under
+CPU_IDLE_GREEN_MAX = 15.0         # idle CPU% at/under this is green
+CPU_PEAK_GREEN_MAX = 120.0        # peak CPU% at/under this is green (one core ~100%)
+
+# Log line markers ----------------------------------------------------------
+_RE_WAKE_DETECTED = re.compile(r"wakeword-metric: wake_detected t=([0-9.]+) command=(.*)$")
+_RE_ASK_START = re.compile(r"wakeword-metric: ask_start t=([0-9.]+)")
+_RE_TTS_START = re.compile(r"wakeword-metric: tts_start t=([0-9.]+)")
+_RE_TTS_DONE = re.compile(r"wakeword-metric: tts_done t=([0-9.]+)")
+_RE_TRANSCRIPT = re.compile(r"wakeword: transcript=(.*)$")
+_RE_NO_WAKE = re.compile(r"wakeword: no wake match for transcript (.*)$")
+_RE_ANSWER = re.compile(r"wakeword answer: (.*)$")
+
+
+@dataclass
+class Invocation:
+    """One wake event and the metrics correlated to it (next-event by ts)."""
+
+    wake_detected: float
+    command: str
+    ask_start: float | None = None
+    tts_start: float | None = None
+    tts_done: float | None = None
+    answer_seen: bool = False
+    brain_latency_ms: int | None = None  # filled by correlate step
+
+    @property
+    def round_trip_s(self) -> float | None:
+        """Full hands-free round-trip: tts_done - wake_detected."""
+        if self.tts_done is None:
+            return None
+        return self.tts_done - self.wake_detected
+
+    @property
+    def tts_duration_s(self) -> float | None:
+        if self.tts_start is None or self.tts_done is None:
+            return None
+        return self.tts_done - self.tts_start
+
+
+@dataclass
+class ParseResult:
+    invocations: list[Invocation] = field(default_factory=list)
+    transcript_count: int = 0
+    no_wake_count: int = 0       # near-misses / false negatives at match step
+    answer_count: int = 0
+
+
+def parse_log_lines(lines) -> ParseResult:
+    """Pure function: parse an iterable of log lines into a ParseResult.
+
+    Lines may be raw journald `-o cat` output (just the message) or include a
+    leading timestamp prefix — we only match on the message substrings, so both
+    work. The `wakeword-metric:` lines carry their own epoch `t=`, so we never
+    depend on journald's clock formatting.
+
+    Correlation strategy: events are assigned to the most recent preceding
+    wake_detected. This mirrors the real sequential flow
+    (wake -> ask_start -> answer -> tts_start -> tts_done) per invocation.
+    """
+    result = ParseResult()
+    current: Invocation | None = None
+
+    for raw in lines:
+        line = raw.rstrip("\n")
+
+        m = _RE_WAKE_DETECTED.search(line)
+        if m:
+            current = Invocation(
+                wake_detected=float(m.group(1)),
+                command=m.group(2).strip(),
+            )
+            result.invocations.append(current)
+            continue
+
+        m = _RE_ASK_START.search(line)
+        if m:
+            if current is not None and current.ask_start is None:
+                current.ask_start = float(m.group(1))
+            continue
+
+        m = _RE_TTS_START.search(line)
+        if m:
+            if current is not None and current.tts_start is None:
+                current.tts_start = float(m.group(1))
+            continue
+
+        m = _RE_TTS_DONE.search(line)
+        if m:
+            if current is not None and current.tts_done is None:
+                current.tts_done = float(m.group(1))
+            continue
+
+        m = _RE_ANSWER.search(line)
+        if m:
+            result.answer_count += 1
+            if current is not None:
+                current.answer_seen = True
+            continue
+
+        m = _RE_NO_WAKE.search(line)
+        if m:
+            result.no_wake_count += 1
+            continue
+
+        # transcript= must be checked AFTER no_wake (no_wake also references a
+        # transcript but with different surrounding text).
+        m = _RE_TRANSCRIPT.search(line)
+        if m:
+            result.transcript_count += 1
+            continue
+
+    return result
+
+
+def correlate_brain_latency(invocations: list[Invocation], brain_rows) -> None:
+    """Attach the nearest following brain_metrics row to each invocation.
+
+    `brain_rows` is an iterable of (ts, latency_ms, model, ok) tuples, ASC by ts.
+    For each wake, pick the first brain row whose ts >= the wake's ask_start
+    (or wake_detected if ask_start missing) and before the next wake's anchor.
+    """
+    rows = sorted(brain_rows, key=lambda r: r[0])
+    for i, inv in enumerate(invocations):
+        anchor = inv.ask_start if inv.ask_start is not None else inv.wake_detected
+        # upper bound: next invocation's anchor (exclusive)
+        if i + 1 < len(invocations):
+            nxt = invocations[i + 1]
+            upper = nxt.ask_start if nxt.ask_start is not None else nxt.wake_detected
+        else:
+            upper = float("inf")
+        for ts, latency_ms, _model, ok in rows:
+            if ts >= anchor and ts < upper and ok:
+                inv.brain_latency_ms = int(latency_ms)
+                break
+
+
+# --- stats helpers ---------------------------------------------------------
+
+def _percentile(values: list[float], pct: float) -> float | None:
+    """Nearest-rank percentile (pct in 0..100). None if no values."""
+    if not values:
+        return None
+    s = sorted(values)
+    if len(s) == 1:
+        return s[0]
+    # nearest-rank
+    k = max(0, min(len(s) - 1, int(round((pct / 100.0) * (len(s) - 1)))))
+    return s[k]
+
+
+def _p50_p95(values: list[float]) -> tuple[float | None, float | None]:
+    return _percentile(values, 50), _percentile(values, 95)
+
+
+# --- CPU CSV ---------------------------------------------------------------
+
+def summarize_cpu_csv(path: str) -> dict | None:
+    """Read epoch,cpu_pct,rss_mb CSV. Return idle/peak summary or None."""
+    cpus: list[float] = []
+    rss: list[float] = []
+    try:
+        with open(path, encoding="utf-8") as fh:
+            for ln in fh:
+                ln = ln.strip()
+                if not ln or ln.lower().startswith("epoch"):
+                    continue
+                parts = ln.split(",")
+                if len(parts) < 3:
+                    continue
+                try:
+                    cpus.append(float(parts[1]))
+                    rss.append(float(parts[2]))
+                except ValueError:
+                    continue
+    except OSError as e:
+        print(f"  (could not read CPU CSV {path}: {e})", file=sys.stderr)
+        return None
+    if not cpus:
+        return None
+    return {
+        "samples": len(cpus),
+        "cpu_idle": min(cpus),        # idle proxy = lowest observed
+        "cpu_peak": max(cpus),
+        "cpu_p50": _percentile(cpus, 50),
+        "rss_p50_mb": _percentile(rss, 50),
+        "rss_peak_mb": max(rss),
+    }
+
+
+# --- verdict ---------------------------------------------------------------
+
+def compute_verdict(
+    *,
+    round_trip_p95: float | None,
+    false_trigger_count: int,
+    miss_rate: float | None,
+    cpu_idle: float | None,
+    cpu_peak: float | None,
+) -> tuple[str, list[str]]:
+    """Return (overall, recommendations[]). overall is GREEN or ACTION-NEEDED."""
+    recs: list[str] = []
+
+    if false_trigger_count > FALSE_TRIGGER_GREEN_MAX:
+        recs.append(
+            f"False triggers={false_trigger_count} (>{FALSE_TRIGGER_GREEN_MAX}): "
+            "escalate to openWakeWord (trained wake model, far fewer spurious wakes)."
+        )
+
+    if miss_rate is not None and miss_rate > MISS_RATE_GREEN_MAX:
+        recs.append(
+            f"Miss rate={miss_rate:.0%} (>{MISS_RATE_GREEN_MAX:.0%}): "
+            "escalate to openWakeWord (improves wake recall)."
+        )
+
+    if round_trip_p95 is not None and round_trip_p95 > ROUND_TRIP_SMALL_BRAIN_S:
+        recs.append(
+            f"Round-trip p95={round_trip_p95:.1f}s (>{ROUND_TRIP_SMALL_BRAIN_S:.0f}s): "
+            "use a smaller game-brain (e.g. gemma-e2b) for the wake co-pilot."
+        )
+
+    if cpu_idle is not None and cpu_idle > CPU_IDLE_GREEN_MAX:
+        recs.append(
+            f"Idle CPU={cpu_idle:.0f}% (>{CPU_IDLE_GREEN_MAX:.0f}%): "
+            "wake listener is heavy at rest — profile before slice-2."
+        )
+    if cpu_peak is not None and cpu_peak > CPU_PEAK_GREEN_MAX:
+        recs.append(
+            f"Peak CPU={cpu_peak:.0f}% (>{CPU_PEAK_GREEN_MAX:.0f}%): "
+            "investigate CPU spikes during wake processing."
+        )
+
+    if not recs:
+        return "GREEN", [
+            "All thresholds green — proceed to slice-2 (web-search wake co-pilot)."
+        ]
+    return "ACTION-NEEDED", recs
+
+
+# --- journald -------------------------------------------------------------
+
+def read_journal(since: str | None, minutes: int | None) -> list[str]:
+    """Fetch axi-voice journal lines. -o cat gives bare messages."""
+    cmd = ["journalctl", "--user", "-u", "axi-voice", "-o", "cat", "--no-pager"]
+    if minutes is not None:
+        cmd += ["--since", f"-{minutes}min"]
+    elif since:
+        cmd += ["--since", since]
+    try:
+        out = subprocess.run(cmd, capture_output=True, text=True, timeout=30, check=False)
+    except (FileNotFoundError, subprocess.TimeoutExpired) as e:
+        print(f"journalctl failed: {e}", file=sys.stderr)
+        return []
+    return out.stdout.splitlines()
+
+
+def read_brain_metrics(since_epoch: float | None):
+    """Read brain_metrics rows since an epoch. Returns list of (ts,latency,model,ok)."""
+    try:
+        from axi import store  # local import: avoids hard dep for pure-parser tests
+    except Exception as e:  # noqa: BLE001
+        print(f"  (store unavailable, skipping brain latency: {e})", file=sys.stderr)
+        return []
+    lower = since_epoch if since_epoch is not None else 0.0
+    try:
+        conn = store._connect()  # noqa: SLF001 (intentional: read-only analyzer)
+        cur = conn.execute(
+            "SELECT ts, latency_ms, model, ok FROM brain_metrics WHERE ts >= ? ORDER BY ts",
+            (lower,),
+        )
+        return [(float(r[0]), int(r[1]), r[2], int(r[3])) for r in cur.fetchall()]
+    except Exception as e:  # noqa: BLE001
+        print(f"  (brain_metrics query failed: {e})", file=sys.stderr)
+        return []
+
+
+# --- report ----------------------------------------------------------------
+
+def _fmt(v, unit="s", nd=1):
+    if v is None:
+        return "n/a"
+    return f"{v:.{nd}f}{unit}"
+
+
+def build_report(parsed: ParseResult, cpu_summary: dict | None) -> str:
+    invs = parsed.invocations
+    lines: list[str] = []
+    lines.append("=" * 70)
+    lines.append("AXI WAKE-WORD LIVE-TEST REPORT")
+    lines.append("=" * 70)
+
+    if not invs:
+        lines.append("")
+        lines.append("no wake events in window.")
+        lines.append("")
+        lines.append(f"transcripts seen : {parsed.transcript_count}")
+        lines.append(f"no-wake (misses) : {parsed.no_wake_count}")
+        return "\n".join(lines)
+
+    round_trips = [i.round_trip_s for i in invs if i.round_trip_s is not None]
+    tts_durs = [i.tts_duration_s for i in invs if i.tts_duration_s is not None]
+    brain_lat = [i.brain_latency_ms for i in invs if i.brain_latency_ms is not None]
+
+    rt_p50, rt_p95 = _p50_p95(round_trips)
+    tts_p50, tts_p95 = _p50_p95(tts_durs)
+    bl_p50, bl_p95 = _p50_p95([float(x) for x in brain_lat])
+
+    # miss rate = no-wake / total transcripts (best-effort recall proxy)
+    total_transcripts = parsed.transcript_count + parsed.no_wake_count
+    miss_rate = (parsed.no_wake_count / total_transcripts) if total_transcripts else None
+
+    lines.append("")
+    lines.append("--- COUNTS ---")
+    lines.append(f"wake invocations    : {len(invs)}")
+    lines.append(f"transcripts (total) : {parsed.transcript_count}")
+    lines.append(f"no-wake / near-miss : {parsed.no_wake_count}")
+    lines.append(f"answers produced    : {parsed.answer_count}")
+    lines.append(f"miss rate           : {('%.0f%%' % (miss_rate*100)) if miss_rate is not None else 'n/a'}")
+
+    lines.append("")
+    lines.append("--- LATENCY (what each measures) ---")
+    lines.append("round-trip = tts_done - wake_detected (full hands-free turn).")
+    lines.append("  NOTE: there is no 'speech started' anchor, so wake-detect")
+    lines.append("  latency itself cannot be measured precisely. Round-trip is")
+    lines.append("  the honest end-to-end number the user actually feels.")
+    lines.append(f"round-trip   p50/p95 : {_fmt(rt_p50)} / {_fmt(rt_p95)}")
+    lines.append(f"brain latency p50/p95: {_fmt(bl_p50, 'ms', 0)} / {_fmt(bl_p95, 'ms', 0)}")
+    lines.append(f"tts duration  p50/p95: {_fmt(tts_p50)} / {_fmt(tts_p95)}")
+
+    lines.append("")
+    lines.append("--- WAKE EVENTS (confirm false triggers) ---")
+    lines.append("Mark any of these you did NOT intend as a false trigger.")
+    lines.append("(In a SILENT run, EVERY wake below is a false positive.)")
+    for i, inv in enumerate(invs, 1):
+        rt = _fmt(inv.round_trip_s)
+        lines.append(f"  [{i}] t={inv.wake_detected:.3f} round-trip={rt} command={inv.command}")
+    lines.append(f"TOTAL WAKES (max possible false triggers) : {len(invs)}")
+
+    # For verdict we assume false_trigger_count == total wakes only in a silent
+    # run; in a real run Héctor subtracts intended ones. We compute the verdict
+    # against the TOTAL as a conservative default and say so.
+    cpu_idle = cpu_summary["cpu_idle"] if cpu_summary else None
+    cpu_peak = cpu_summary["cpu_peak"] if cpu_summary else None
+
+    if cpu_summary:
+        lines.append("")
+        lines.append("--- CPU / RAM ---")
+        lines.append(f"samples       : {cpu_summary['samples']}")
+        lines.append(f"CPU idle/peak : {cpu_idle:.0f}% / {cpu_peak:.0f}%")
+        lines.append(f"CPU p50       : {cpu_summary['cpu_p50']:.0f}%")
+        lines.append(f"RSS p50/peak  : {cpu_summary['rss_p50_mb']:.0f}MB / {cpu_summary['rss_peak_mb']:.0f}MB")
+
+    overall, recs = compute_verdict(
+        round_trip_p95=rt_p95,
+        false_trigger_count=len(invs),  # conservative: treat all as needing confirmation
+        miss_rate=miss_rate,
+        cpu_idle=cpu_idle,
+        cpu_peak=cpu_peak,
+    )
+    lines.append("")
+    lines.append("--- VERDICT ---")
+    lines.append("(false-trigger verdict assumes ALL wakes are spurious; subtract")
+    lines.append(" your intended invocations and re-read the false-trigger line.)")
+    lines.append(f"OVERALL: {overall}")
+    for r in recs:
+        lines.append(f"  - {r}")
+    lines.append("=" * 70)
+    return "\n".join(lines)
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description="Axi wake-word live-test analyzer")
+    g = p.add_mutually_exclusive_group()
+    g.add_argument("--since", help="journalctl --since value, e.g. '1 hour ago'")
+    g.add_argument("--minutes", type=int, help="look back this many minutes")
+    p.add_argument("--cpu-csv", help="path to CSV from wakeword_cpu_sample.sh")
+    p.add_argument("--log-file", help="parse this file instead of journalctl (testing)")
+    args = p.parse_args(argv)
+
+    if args.log_file:
+        with open(args.log_file, encoding="utf-8") as fh:
+            log_lines = fh.read().splitlines()
+    else:
+        log_lines = read_journal(args.since, args.minutes)
+
+    parsed = parse_log_lines(log_lines)
+
+    # brain latency correlation: window lower bound = earliest wake (minus slack)
+    if parsed.invocations:
+        since_epoch = min(i.wake_detected for i in parsed.invocations) - 5.0
+        brain_rows = read_brain_metrics(since_epoch)
+        correlate_brain_latency(parsed.invocations, brain_rows)
+
+    cpu_summary = summarize_cpu_csv(args.cpu_csv) if args.cpu_csv else None
+
+    print(build_report(parsed, cpu_summary))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/axi/src/axi/brain.py
+++ b/axi/src/axi/brain.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 import threading
 import time
@@ -22,6 +23,11 @@ import urllib.request
 from datetime import datetime
 from typing import Any, Callable
 from zoneinfo import ZoneInfo
+
+# Process-level gate: mirrors the same env var in store.py and events.py.
+# When set, the implicit per-call daemon thread spawn in _record_metric_async
+# is suppressed so test isolation is preserved.
+_BG_WORKERS_DISABLED = os.environ.get("AXI_DISABLE_BG_WORKERS", "").lower() in ("1", "true", "yes")
 
 from axi import config
 
@@ -167,17 +173,8 @@ def is_vt_alive(timeout: float = 1.0) -> bool:
         return False
 
 
-_DAYS_ES = ["lunes", "martes", "miércoles", "jueves", "viernes", "sábado", "domingo"]
-_MONTHS_ES = [
-    "enero", "febrero", "marzo", "abril", "mayo", "junio",
-    "julio", "agosto", "septiembre", "octubre", "noviembre", "diciembre",
-]
-
-_DAYS_EN = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
-_MONTHS_EN = [
-    "January", "February", "March", "April", "May", "June",
-    "July", "August", "September", "October", "November", "December",
-]
+from axi.locale_data import DAYS_ES as _DAYS_ES, MONTHS_ES as _MONTHS_ES
+from axi.locale_data import DAYS_EN as _DAYS_EN, MONTHS_EN as _MONTHS_EN
 
 
 def temporal_context() -> str:
@@ -387,6 +384,8 @@ def _record_metric_async(
         except Exception as e:  # noqa: BLE001
             log.warning("brain metric write failed: %s", e)
 
+    if _BG_WORKERS_DISABLED:
+        return
     try:
         threading.Thread(target=_worker, name="axi-brain-metric", daemon=True).start()
     except Exception as e:  # noqa: BLE001
@@ -399,12 +398,17 @@ def _build_messages(
     image_b64: str | None = None,
     history: list[dict] | None = None,
     lang: str | None = None,
+    _skip_recall: bool = False,
 ) -> list[dict[str, Any]]:
     """Build OpenAI-compatible chat messages with Axi's live context.
 
     `lang` is the user's configured language tag (e.g. 'en', 'es-MX').
     When 'en*', English temporal context is injected; otherwise Spanish.
     Callers that do not pass `lang` get Spanish (backward-compatible default).
+
+    `_skip_recall` disables the graph recall injection for callers that manage
+    their own context augmentation (e.g. ask_with_tools). This prevents the
+    embed HTTP call from interfering with tool-calling loops.
     """
     if image_b64:
         user_content: str | list[dict[str, Any]] = [
@@ -419,7 +423,42 @@ def _build_messages(
     # producing wrong-language timestamps).
     _is_en = bool(lang and lang.split("-")[0].lower() == "en")
     _tc = temporal_context_en() if _is_en else temporal_context()
-    full_system = f"{system}\n\n{_tc}"
+
+    # Layer 3 — graph recall injection (gated by config.graph_recall).
+    # Use the text prompt as the recall query (works for both plain text and
+    # multimodal calls where prompt is always the text part).
+    # Skipped when _skip_recall=True (e.g. ask_with_tools manages its own context).
+    _mem = ""
+    if not _skip_recall and config.get("graph_recall", True):
+        try:
+            from axi import recall as _recall  # noqa: PLC0415
+            _max_dist = float(config.get("graph_recall_max_distance", 0.78))
+            _escalate = (
+                float(config.get("graph_recall_tool_max_distance", 0.9))
+                if config.get("recall_escalation_enabled", True)
+                else None
+            )
+            _mem = _recall.build_recall_block(prompt, lang=lang, max_distance=_max_dist, escalate_distance=_escalate)
+        except Exception:  # noqa: BLE001
+            _mem = ""
+
+    if _mem:
+        if _is_en:
+            _restraint = (
+                "The memories above MAY be relevant. Use only those that answer the question "
+                "and cite the date only when it makes the answer correct; "
+                "if they do not apply, ignore them."
+            )
+        else:
+            _restraint = (
+                "Los recuerdos de arriba PUEDEN ser relevantes. "
+                "Usa solo los que respondan la pregunta y cita el día/fecha solo cuando hace "
+                "la respuesta correcta; si no aplican, ignóralos."
+            )
+        full_system = f"{system}\n\n{_tc}\n\n{_mem}\n\n{_restraint}"
+    else:
+        full_system = f"{system}\n\n{_tc}"
+
     messages: list[dict[str, Any]] = [{"role": "system", "content": full_system}]
     if history:
         messages.extend(history)
@@ -488,6 +527,7 @@ def _ask_impl(
     history: list[dict] | None = None,
     lang: str | None = None,
     _retry_budget: int | None = None,
+    _skip_recall: bool = False,
 ) -> tuple[str, dict[str, Any] | None]:
     """Inner implementation: returns (text, raw_response_dict).
 
@@ -546,7 +586,12 @@ def _ask_impl(
     except Exception:  # noqa: BLE001
         pass
 
-    messages = _build_messages(prompt, system=system, image_b64=image_b64, history=history, lang=lang)
+    # _skip_recall=True on retries: recall was already embedded in the first call's
+    # messages; do not fire a second embed on the budget-retry path.
+    messages = _build_messages(
+        prompt, system=system, image_b64=image_b64, history=history, lang=lang,
+        _skip_recall=_skip_recall,
+    )
     effective_max_tokens = _retry_budget if _retry_budget is not None else max_tokens
     try:
         data = _post_chat_completion(
@@ -586,7 +631,7 @@ def _ask_impl(
                     return _ask_impl(
                         prompt, system=system, max_tokens=max_tokens, timeout=timeout,
                         think=think, image_b64=image_b64, history=history,
-                        lang=lang, _retry_budget=retry_budget,
+                        lang=lang, _retry_budget=retry_budget, _skip_recall=True,
                     )
         return content, data
     except urllib.error.URLError as e:
@@ -669,8 +714,46 @@ def _ask_with_tools_impl(
             "- No digas que necesitas /busca si ya recibiste resultados de una herramienta web_search.\n"
             "- Si los resultados son insuficientes, dilo con precisión y cita lo que sí hay."
         )
-    tool_system = system + _tool_instructions
-    messages = _build_messages(prompt, system=tool_system, image_b64=None, history=history, lang=lang)
+    # FIX 1: inject graph recall once into the INITIAL system prompt so the
+    # ask_with_tools path (used for all web-research chat) also benefits from
+    # memory context.  We compute the recall block here — before _build_messages
+    # — so we can prepend it to tool_system.  Subsequent tool-loop rounds still
+    # use _skip_recall=True so the embed fires at most once per ask_with_tools call.
+    _mem = ""
+    if config.get("graph_recall", True):
+        try:
+            from axi import recall as _recall  # noqa: PLC0415
+            _max_dist = float(config.get("graph_recall_max_distance", 0.78))
+            _escalate = (
+                float(config.get("graph_recall_tool_max_distance", 0.9))
+                if config.get("recall_escalation_enabled", True)
+                else None
+            )
+            _mem = _recall.build_recall_block(prompt, lang=lang, max_distance=_max_dist, escalate_distance=_escalate)
+        except Exception:  # noqa: BLE001
+            _mem = ""
+
+    if _mem:
+        _is_en_recall = lang is not None and lang.split("-")[0].lower() == "en"
+        if _is_en_recall:
+            _restraint = (
+                "The memories above MAY be relevant. Use only those that answer the question "
+                "and cite the date only when it makes the answer correct; "
+                "if they do not apply, ignore them."
+            )
+        else:
+            _restraint = (
+                "Los recuerdos de arriba PUEDEN ser relevantes. "
+                "Usa solo los que respondan la pregunta y cita el día/fecha solo cuando hace "
+                "la respuesta correcta; si no aplican, ignóralos."
+            )
+        tool_system = system + _tool_instructions + f"\n\n{_mem}\n\n{_restraint}"
+    else:
+        tool_system = system + _tool_instructions
+
+    # _skip_recall=True: recall already injected above (or skipped); do not
+    # re-embed on every tool-loop round inside _build_messages.
+    messages = _build_messages(prompt, system=tool_system, image_b64=None, history=history, lang=lang, _skip_recall=True)
     last_data: dict[str, Any] | None = None
     try:
         for _round in range(max_tool_rounds + 1):

--- a/axi/src/axi/config_schema.py
+++ b/axi/src/axi/config_schema.py
@@ -404,6 +404,39 @@ FIELDS: tuple[ConfigField, ...] = (
         "If true, facts extracted from chat conversations are added as nodes in the "
         "semantic graph. Default off keeps the graph to structured life-domains only.",
     ),
+    # ─────── graph recall (RAG) ───────
+    ConfigField(
+        "graph_recall", "boolean", True,
+        "If true, semantically relevant graph memories are injected into the brain "
+        "system prompt as a recall block. Default on; set false to disable.",
+    ),
+    ConfigField(
+        "graph_recall_max_distance", "number", 0.78,
+        "Cosine distance upper bound for graph recall. Nodes with distance above "
+        "this threshold are excluded. 0 = identical, 1 = orthogonal. Lower values "
+        "produce tighter relevance. Default 0.78 — empirically tuned against the "
+        "Qwen3-Embedding-4B/512 model on real data: keyword and natural-language "
+        "recall queries land at 0.56-0.74 while casual chat sits at 0.83+, so 0.78 "
+        "separates them. Fully conversational compound questions embed at ~0.87 "
+        "(indistinguishable from casual) and are handled by the big-brain recall tool.",
+        minimum=0.0,
+        maximum=1.0,
+    ),
+    ConfigField(
+        "graph_recall_tool_max_distance", "number", 0.9,
+        "Looser distance gate used when the big brain explicitly calls the "
+        "recall_memory tool (vs the tighter passive-injection default 0.78). "
+        "Tool-based recall is intentional — the model chose to search — so a "
+        "wider net is appropriate.",
+        minimum=0.0,
+        maximum=1.0,
+    ),
+    ConfigField(
+        "recall_escalation_enabled", "boolean", True,
+        "If true, voice/plain-ask compound personal-data questions that miss the tight passive "
+        "recall gate retry at the wider graph_recall_tool_max_distance gate, gated by a "
+        "personal-data heuristic.",
+    ),
 )
 
 

--- a/axi/src/axi/daemon.py
+++ b/axi/src/axi/daemon.py
@@ -898,6 +898,8 @@ class Daemon:
 
         try:
             self._set_state("thinking")
+            # Live-test harness anchor: brain ask is about to start (wake path only).
+            log.info("wakeword-metric: ask_start t=%.3f", time.time())
             question = command
             history = self.memory.messages()
             facts = self.memory.relevant_facts(question, limit=5)
@@ -996,10 +998,14 @@ class Daemon:
             )
 
             self._set_state("speaking")
+            # Live-test harness anchor: TTS playback starting (wake path only).
+            log.info("wakeword-metric: tts_start t=%.3f", time.time())
             def _say():
                 try:
                     speak_text(answer)
                 finally:
+                    # Live-test harness anchor: TTS finished (wake path only).
+                    log.info("wakeword-metric: tts_done t=%.3f", time.time())
                     self._set_state("idle")
             threading.Thread(target=_say, daemon=True).start()
         except Exception as e:  # noqa: BLE001

--- a/axi/src/axi/dashboard.py
+++ b/axi/src/axi/dashboard.py
@@ -694,6 +694,54 @@ def _web_search_tool_handler(args: dict[str, Any]) -> dict[str, Any]:
     return {"ok": bool(packed), "query": query, "results": packed}
 
 
+_RECALL_MEMORY_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "recall_memory",
+        "description": (
+            "Busca en la memoria personal del usuario (su gráfico de vida) para recuperar "
+            "hechos datados que él mismo registró: salud, sueño, presión arterial, glucosa, "
+            "peso, gastos, eventos, actividad física, u otros datos de vida. "
+            "Úsala cuando el usuario pregunta sobre SUS PROPIOS registros pasados y necesitás "
+            "hechos con fechas exactas para responder con precisión. "
+            "Reformulá la pregunta del usuario en términos de búsqueda concisos: por ejemplo, "
+            "si pregunta '¿qué presión tenía cuando dormí mal?' llamá a recall_memory con "
+            "query='presión dormí pocas horas'. "
+            "Devuelve hechos datados de la memoria personal del usuario."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Términos de búsqueda concisos para encontrar los recuerdos relevantes.",
+                },
+            },
+            "required": ["query"],
+        },
+    },
+}
+
+
+def _recall_memory_tool_handler(args: dict[str, Any]) -> dict[str, Any]:
+    """Whitelisted local recall_memory tool for the big brain."""
+    query = str(args.get("query") or "").strip()
+    if not query:
+        return {"ok": False, "error": "query is required", "facts": ""}
+    if not config.get("graph_recall", True):
+        return {"ok": False, "error": "graph recall disabled", "facts": ""}
+    try:
+        from axi import recall
+        lang = str(config.get("language", "es-MX"))
+        max_dist = float(config.get("graph_recall_tool_max_distance", 0.9))
+        block = recall.build_recall_block(query, lang=lang, max_distance=max_dist)
+    except Exception:  # noqa: BLE001
+        return {"ok": False, "error": "recall lookup failed", "facts": ""}
+    if not block:
+        return {"ok": False, "query": query, "facts": "", "note": "no relevant memories found"}
+    return {"ok": True, "query": query, "facts": block}
+
+
 # Map of keywords → suggested format. When the user's message contains
 # one of these keywords AND the brain hallucinated persistence, we
 # include a hint about what format actually works.
@@ -4016,22 +4064,36 @@ async def api_chat_ask(request: Request):
                     log.info("brain: injecting location context (lat=%.5f, lng=%.5f)", _lat, _lng)
                 except (TypeError, ValueError):
                     pass
-            if image_b64 or not web_research.is_enabled():
+            if image_b64:
                 answer = brain.ask(text, system=brain_system, history=history, image_b64=image_b64, lang=_chat_lang)
             else:
+                # Build tool list dynamically: recall_memory always present;
+                # web_search only when web research is enabled.
+                tools: list[dict[str, Any]] = [_RECALL_MEMORY_TOOL]
+                tool_handlers: dict[str, Any] = {"recall_memory": _recall_memory_tool_handler}
                 tool_system = (
                     brain_system
-                    + "\n\nUSO DE INTERNET EN MODO CHARLA:\n"
-                    + "- Tienes disponible la herramienta web_search para consultas actuales, verificables o donde necesites fuentes.\n"
-                    + "- Decide tú cuándo usarla. Úsala para noticias, precios, versiones, documentación reciente, eventos actuales o datos que puedan haber cambiado.\n"
-                    + "- No la uses para charla personal, razonamiento general o información estable que ya sabes."
+                    + "\n\nRECUERDOS PERSONALES:\n"
+                    + "- Tienes disponible la herramienta recall_memory para buscar datos datados que el usuario registró en su memoria personal (salud, sueño, presión, glucosa, etc.).\n"
+                    + "- Úsala cuando el usuario pregunte sobre sus propios registros pasados y necesites hechos con fechas exactas.\n"
+                    + "- No la uses para charla casual, saludos, ni temas que no involucren los registros personales del usuario."
                 )
+                if web_research.is_enabled():
+                    tools.append(_WEB_SEARCH_TOOL)
+                    tool_handlers["web_search"] = _web_search_tool_handler
+                    tool_system = (
+                        tool_system
+                        + "\n\nUSO DE INTERNET EN MODO CHARLA:\n"
+                        + "- Tienes disponible la herramienta web_search para consultas actuales, verificables o donde necesites fuentes.\n"
+                        + "- Decide tú cuándo usarla. Úsala para noticias, precios, versiones, documentación reciente, eventos actuales o datos que puedan haber cambiado.\n"
+                        + "- No la uses para charla personal, razonamiento general o información estable que ya sabes."
+                    )
                 answer = brain.ask_with_tools(
                     text,
                     system=tool_system,
                     history=history,
-                    tools=[_WEB_SEARCH_TOOL],
-                    tool_handlers={"web_search": _web_search_tool_handler},
+                    tools=tools,
+                    tool_handlers=tool_handlers,
                     tool_choice="auto",
                     lang=_chat_lang,
                 )

--- a/axi/src/axi/events.py
+++ b/axi/src/axi/events.py
@@ -23,6 +23,7 @@ Kill switch: `events_enabled` in config (default True). When False every
 from __future__ import annotations
 
 import logging
+import os
 import queue
 import shutil
 import subprocess
@@ -32,6 +33,13 @@ from collections import deque
 from typing import Any
 
 log = logging.getLogger("axi.events")
+
+# Process-level gate: mirrors the same env var in store.py. When set, the
+# implicit auto-start of the events-writer background thread is suppressed so
+# test isolation is preserved (no TOCTOU race on DB_PATH after monkeypatch
+# restores it between tests). Explicit lifecycle calls (stop_events_writer,
+# _ensure_worker) remain unaffected.
+_BG_WORKERS_DISABLED = os.environ.get("AXI_DISABLE_BG_WORKERS", "").lower() in ("1", "true", "yes")
 
 EVENT_LEVELS: tuple[str, ...] = ("info", "warning", "error", "critical")
 _RING_MAX = 200
@@ -48,6 +56,7 @@ _write_queue: queue.Queue = queue.Queue(maxsize=_WRITE_QUEUE_MAX)
 _queue_drop_count = 0       # monotone counter of dropped events (for diagnostics)
 _worker_thread: threading.Thread | None = None
 _worker_lock = threading.Lock()
+_writer_stop = threading.Event()   # set → worker loop exits without touching the DB
 _insert_count = 0
 
 # P2.5 — libnotify rate-limit. Keyed by (source, level), value = last fire ts.
@@ -105,6 +114,7 @@ def _ensure_worker() -> None:
     with _worker_lock:
         if _worker_thread is not None and _worker_thread.is_alive():
             return
+        _writer_stop.clear()
         t = threading.Thread(target=_worker_loop, name="axi-events-writer", daemon=True)
         t.start()
         _worker_thread = t
@@ -114,7 +124,12 @@ def _worker_loop() -> None:
     global _insert_count
     while True:
         item = _write_queue.get()
-        if item is None:  # sentinel for tests
+        # Exit immediately on sentinel or stop signal — do NOT touch the DB.
+        if item is None or _writer_stop.is_set():
+            return
+        # Guard again right before the DB call: teardown may have fired while
+        # this thread was blocked on get().
+        if _writer_stop.is_set():
             return
         try:
             from axi import store  # lazy to avoid import cycles
@@ -133,6 +148,39 @@ def _worker_loop() -> None:
                     log.warning("events trim failed: %s", e)
         except Exception as e:  # noqa: BLE001
             log.warning("event SQLite insert failed: %s", e)
+
+
+def stop_events_writer(timeout: float = 3.0) -> None:
+    """Signal the events writer to stop and wait for it to exit.
+
+    Safe to call even if the worker was never started.  Used in test teardown
+    to prevent the daemon thread from calling store._connect() after the test
+    fixture has restored DB_PATH/STATE_DIR to a prior test's temp path — which
+    would produce an HMAC mismatch on the wrong SQLCipher key (Bus error).
+
+    Mirrors stop_embed_worker() in store.py: sets the stop event, puts a None
+    sentinel to unblock a blocked queue.get(), then joins every alive thread
+    named "axi-events-writer" within the overall timeout budget.
+    """
+    global _worker_thread
+    _writer_stop.set()
+    # Unblock a worker that is blocked on _write_queue.get().
+    try:
+        _write_queue.put_nowait(None)
+    except queue.Full:
+        pass
+    # Collect every live thread named axi-events-writer (handles orphans too).
+    workers = [
+        t for t in threading.enumerate()
+        if t.name == "axi-events-writer" and t.is_alive()
+    ]
+    deadline = time.monotonic() + timeout
+    for t in workers:
+        remaining = max(0.0, deadline - time.monotonic())
+        t.join(timeout=remaining)
+    # Reset state so _ensure_worker() can restart a fresh worker later.
+    _writer_stop.clear()
+    _worker_thread = None
 
 
 # ─────────────────────────────── public API ─────────────────────────────
@@ -197,7 +245,8 @@ def log_event(
                     "events._write_queue full — dropping event (total dropped: %d)",
                     _queue_drop_count,
                 )
-        _ensure_worker()
+        if not _BG_WORKERS_DISABLED:
+            _ensure_worker()
         # P2.5 — fire libnotify for critical/error. Best-effort, rate-limited.
         try:
             _maybe_notify(entry["source"], level, entry["message"])

--- a/axi/src/axi/locale_data.py
+++ b/axi/src/axi/locale_data.py
@@ -1,0 +1,18 @@
+"""Shared locale constants for Axi (month/day names in ES and EN).
+
+Centralised here so both brain.py and recall.py import from a single
+source — avoiding a private cross-module import.
+"""
+from __future__ import annotations
+
+DAYS_ES = ["lunes", "martes", "miércoles", "jueves", "viernes", "sábado", "domingo"]
+MONTHS_ES = [
+    "enero", "febrero", "marzo", "abril", "mayo", "junio",
+    "julio", "agosto", "septiembre", "octubre", "noviembre", "diciembre",
+]
+
+DAYS_EN = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
+MONTHS_EN = [
+    "January", "February", "March", "April", "May", "June",
+    "July", "August", "September", "October", "November", "December",
+]

--- a/axi/src/axi/recall.py
+++ b/axi/src/axi/recall.py
@@ -57,6 +57,30 @@ _PERSONAL_RECALL_PATTERN = re.compile(
     | \bmedicamento\b        # medication
     | \bpastilla\b           # pill / tablet
     | \bfrecuencia\s+card[ií]aca\b  # frecuencia cardíaca (heart rate)
+    # English health / finance vocabulary (mirrors the Spanish set). Bare
+    # ambiguous tokens (gas, sugar, ran, felt) are intentionally omitted; the
+    # 0.9 distance backstop bounds any false positive.
+    | \bblood\s+pressure\b   # blood pressure
+    | \bpressure\b           # pressure (bare; mirrors bare "presión")
+    | \bpulse\b              # pulse
+    | \bheart\s+rate\b       # heart rate
+    | \bslept\b              # slept
+    | \bsleep\b              # sleep
+    | \bsleeping\b           # sleeping
+    | \bweight\b             # weight
+    | \bweighed\b            # weighed
+    | \bglucose\b            # glucose
+    | \bblood\s+sugar\b      # blood sugar
+    | \bexpense\b            # expense
+    | \bspent\b              # spent
+    | \bgasoline\b           # gasoline
+    | \bfuel\b               # fuel
+    | \bexercise\b           # exercise
+    | \bworkout\b            # workout
+    | \bmood\b               # mood
+    | \bsymptoms?\b          # symptom / symptoms
+    | \bmedication\b         # medication
+    | \bpill\b               # pill
     """,
     re.IGNORECASE | re.VERBOSE,
 )

--- a/axi/src/axi/recall.py
+++ b/axi/src/axi/recall.py
@@ -1,0 +1,265 @@
+"""Layer 3 — graph recall (RAG) for Axi.
+
+Provides :func:`build_recall_block` which retrieves semantically relevant
+memories from the knowledge graph and formats them as a concise context block
+for injection into the brain system prompt.
+"""
+from __future__ import annotations
+
+import datetime
+import logging
+import re
+from zoneinfo import ZoneInfo
+
+from axi.locale_data import MONTHS_ES, MONTHS_EN
+
+log = logging.getLogger("axi.recall")
+
+# ---------------------------------------------------------------------------
+# Personal-data recall heuristic
+# ---------------------------------------------------------------------------
+
+# Regex patterns for personal-health/finance domain vocabulary (Spanish).
+# Uses word boundaries so partial matches in unrelated words don't fire.
+# Accent tolerance comes from the explicit character classes (e.g. presi[oó]n,
+# dorm[ií], sue[nñ]o, az[uú]car, [aá]nimo), NOT from re.IGNORECASE — Python's
+# re does not case-fold accents. The character classes accept both the accented
+# and unaccented forms ("presión"/"presion", "dormí"/"dormi", "DORMÍ").
+# NOTE: this heuristic is a cheap PRE-filter, not the safety boundary — the real
+# gate is escalate_distance (0.9): escalation only fires when the tight filter is
+# empty AND a node sits within that distance, so a false-positive match alone
+# cannot leak facts unless the query independently embeds near a stored node.
+_PERSONAL_RECALL_PATTERN = re.compile(
+    r"""
+    \bpresi[oó]n\b           # presión (blood pressure / hypertension)
+    | \bpulso\b              # pulse / heart rate
+    | \bdorm[ií]\b           # dormí / dormiste (slept)
+    | \bdormir\b             # dormir (to sleep)
+    | \bdormido\b            # dormido (slept, past participle)
+    | \bsue[nñ]o\b           # sueño (sleep / dream)
+    | \bdormiste\b           # dormiste (you slept)
+    | \bpeso\b               # peso (weight)
+    | \bpesaba\b             # pesaba (weighed)
+    | \bpes[eé]\b            # pesé (I weighed)
+    | \bglucosa\b            # glucose
+    | \baz[uú]car\b          # azúcar (blood sugar)
+    | \bgasto\b              # gasto (expense / spent)
+    | \bgast[eé]\b           # gasté (I spent)
+    | \bgasolina\b           # gasolina (gas / petrol)
+    | \bejercicio\b          # exercise
+    | \bcorr[ií]\b           # corrí (I ran)
+    | \bentren[eé]\b         # entrené (I trained)
+    | \b[aá]nimo\b           # ánimo (mood)
+    | \bhumor\b              # humor (mood)
+    | \bsent[ií]\b           # sentí (I felt)
+    | \bsent[ií]a\b          # sentía (I was feeling)
+    | \bs[ií]ntoma\b         # síntoma (symptom)
+    | \bmedicamento\b        # medication
+    | \bpastilla\b           # pill / tablet
+    | \bfrecuencia\s+card[ií]aca\b  # frecuencia cardíaca (heart rate)
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+
+def looks_like_personal_recall(text: str) -> bool:
+    """Return True if *text* mentions personal health / finance domain vocabulary.
+
+    Uses a cheap regex heuristic to distinguish personal-data compound queries
+    (e.g. "¿qué presión tenía cuando dormí mal?") from casual chat
+    (e.g. "hola Axi cómo estás").  Word boundaries prevent partial matches in
+    unrelated words.
+
+    Args:
+        text: The user prompt or query string to test.
+
+    Returns:
+        True if the text matches any personal-data keyword, False otherwise.
+    """
+    return bool(_PERSONAL_RECALL_PATTERN.search(text))
+
+# Short timeout for the synchronous recall embed so a slow/hung embed server
+# cannot stall the user's turn.  If the embed exceeds this, build_recall_block
+# returns "" and the turn proceeds normally.
+_RECALL_EMBED_TIMEOUT = 2.0
+
+
+def build_recall_block(
+    query: str,
+    *,
+    lang: str | None = None,
+    k: int = 8,
+    max_distance: float = 0.78,
+    max_days: int = 5,
+    max_labels_per_day: int = 6,
+    max_total_facts: int = 12,
+    timeout: float = _RECALL_EMBED_TIMEOUT,
+    conn=None,
+    escalate_distance: float | None = None,
+) -> str:
+    """Build a compact memory block from semantically similar graph nodes.
+
+    Steps:
+    1. Semantic search for the *k* closest nodes to *query* (with *timeout*).
+    2. Filter to nodes with ``distance <= max_distance``.
+    3. Escalation: if tight filter is empty and *escalate_distance* is set and the
+       query looks personal (health/finance vocabulary), retry with the wider gate
+       using the ALREADY-FETCHED nodes — no second embed call.
+    4. For each surviving node, pull same-day neighbors (both edge directions).
+    5. Group all collected facts by local day (YYYY-MM-DD in config timezone).
+       Deduplicate identical labels within each day.
+    6. Cap per day to *max_labels_per_day* labels (most-recent facts first).
+    7. Cap total facts across all days to *max_total_facts*.
+    8. Cap to *max_days* most-recent days (most recent first).
+    9. Within each day, sort facts by occurred_at desc (most recent first).
+    10. Format a header + one bullet per day.
+
+    Args:
+        query: The user prompt used as the similarity query.
+        lang: Language tag (e.g. 'en', 'es-MX'). Default → Spanish.
+        k: Number of KNN candidates from the vector index.
+        max_distance: Cosine distance upper bound (0 = identical, 1 = orthogonal).
+            Lower values = tighter relevance gate.
+        max_days: Maximum number of distinct days to include.
+        max_labels_per_day: Maximum labels on a single day's bullet.
+        max_total_facts: Hard cap on total fact labels across all days.
+        timeout: Timeout in seconds for the embed HTTP call. If the embed
+            exceeds this, returns "" without blocking the turn.
+        conn: Optional SQLite connection (injected in tests).
+        escalate_distance: If set, and the tight filter yields no results, and the
+            query passes the personal-data heuristic, re-filter the already-fetched
+            nodes at this wider gate. No second embed call is made.
+            Pass ``None`` (default) to disable escalation — behavior is identical
+            to the current implementation.
+
+    Returns ``""`` when there are no relevant memories or on any error.
+    NEVER raises.
+    """
+    try:
+        return _build_recall_block(
+            query,
+            lang=lang,
+            k=k,
+            max_distance=max_distance,
+            max_days=max_days,
+            max_labels_per_day=max_labels_per_day,
+            max_total_facts=max_total_facts,
+            timeout=timeout,
+            conn=conn,
+            escalate_distance=escalate_distance,
+        )
+    except Exception:  # noqa: BLE001
+        log.debug("build_recall_block: unexpected error", exc_info=True)
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# Internal implementation
+# ---------------------------------------------------------------------------
+
+def _build_recall_block(
+    query: str,
+    *,
+    lang: str | None,
+    k: int,
+    max_distance: float,
+    max_days: int,
+    max_labels_per_day: int,
+    max_total_facts: int,
+    timeout: float,
+    conn,
+    escalate_distance: float | None = None,
+) -> str:
+    from axi import config, store
+
+    _is_en = bool(lang and lang.split("-")[0].lower() == "en")
+
+    nodes = store.semantic_search_nodes(query, k=k, conn=conn, timeout=timeout)
+    # Filter by tight distance threshold
+    filtered = [n for n in nodes if n.get("distance", 1.0) <= max_distance]
+    # Escalation: if tight filter is empty and escalate_distance is set and query looks personal,
+    # reuse already-fetched nodes at the wider gate — NO second embed call.
+    if not filtered and escalate_distance is not None and looks_like_personal_recall(query):
+        filtered = [n for n in nodes if n.get("distance", 1.0) <= escalate_distance]
+    if not filtered:
+        return ""
+    nodes = filtered  # continue using filtered set
+
+    tz_name = config.get("timezone", "UTC") or "UTC"
+    try:
+        tz = ZoneInfo(tz_name)
+    except Exception:  # noqa: BLE001
+        tz = ZoneInfo("UTC")
+
+    # Collect all facts: {date_str -> [(occurred_ts_for_sort, label)]}
+    # We track the timestamp alongside the label to enable within-day recency sort.
+    day_facts: dict[str, list[tuple[float, str]]] = {}
+
+    for node in nodes:
+        # Pull same-day neighbors (BOTH directions)
+        neighbors = store.same_day_neighbors(node["id"], conn=conn)
+        all_facts = [node] + neighbors
+
+        for fact in all_facts:
+            # FIX 7 NIT: use explicit None check so occurred_at=0.0 is not dropped.
+            occurred_at = fact.get("occurred_at")
+            created_at = fact.get("created_at")
+            ts = occurred_at if occurred_at is not None else created_at
+            if ts is None:
+                continue
+            dt = datetime.datetime.fromtimestamp(ts, tz=tz)
+            date_str = dt.strftime("%Y-%m-%d")
+            label = fact.get("label", "").strip()
+            if not label:
+                continue
+            if date_str not in day_facts:
+                day_facts[date_str] = []
+            # Dedup by label
+            existing_labels = {lbl for _, lbl in day_facts[date_str]}
+            if label not in existing_labels:
+                day_facts[date_str].append((ts, label))
+
+    if not day_facts:
+        return ""
+
+    # Sort days descending (most recent first), cap to max_days
+    sorted_days = sorted(day_facts.keys(), reverse=True)[:max_days]
+
+    # Format header and lines
+    if _is_en:
+        header = "RELEVANT MEMORY (use only if it answers the question):"
+        months = MONTHS_EN
+        date_format = "en"
+    else:
+        header = "MEMORIA RELEVANTE (usa solo si responde la pregunta):"
+        months = MONTHS_ES
+        date_format = "es"
+
+    lines = [header]
+    total_facts_emitted = 0
+    for date_str in sorted_days:
+        if total_facts_emitted >= max_total_facts:
+            break
+        raw_facts = day_facts[date_str]
+        # FIX 6: sort within-day by occurred_at desc (most recent first)
+        raw_facts_sorted = sorted(raw_facts, key=lambda t: t[0], reverse=True)
+        # FIX 2: cap per-day labels
+        remaining = max_total_facts - total_facts_emitted
+        cap = min(max_labels_per_day, remaining)
+        facts = [lbl for _, lbl in raw_facts_sorted[:cap]]
+
+        year, month_idx, day = int(date_str[:4]), int(date_str[5:7]), int(date_str[8:10])
+        month_name = months[month_idx - 1]
+        if date_format == "en":
+            date_label = f"On {month_name} {day}, {year}"
+        else:
+            date_label = f"El {day} de {month_name} de {year}"
+        lines.append(f"- {date_label}: {'; '.join(facts)}")
+        total_facts_emitted += len(facts)
+
+    if len(lines) <= 1:
+        return ""
+
+    # Note: the usage restraint is NOT included here — it is appended by the
+    # caller (brain._build_messages) so it appears only once in the final prompt.
+    return "\n".join(lines)

--- a/axi/src/axi/store.py
+++ b/axi/src/axi/store.py
@@ -39,6 +39,13 @@ log = logging.getLogger("axi.store")
 
 import sqlcipher3
 
+# Process-level gate: when set to "1", "true", or "yes" (case-insensitive),
+# all implicit background-worker auto-triggers are suppressed. Explicit
+# lifecycle functions (_ensure_embed_worker, stop_embed_worker, etc.) remain
+# callable so worker-lifecycle tests still work. Default is OFF (workers
+# auto-start normally in production).
+_BG_WORKERS_DISABLED = os.environ.get("AXI_DISABLE_BG_WORKERS", "").lower() in ("1", "true", "yes")
+
 
 class RecoveryError(RuntimeError):
     """Raised when healthy backups exist but every restore attempt failed.
@@ -1083,6 +1090,37 @@ def neighbors(node_id: int, edge_kind: str | None = None, depth: int = 1) -> lis
     return list(rows)
 
 
+def same_day_neighbors(node_id: int, conn=None) -> list[dict[str, Any]]:
+    """Return all nodes connected to node_id via a 'same-day' edge in EITHER direction.
+
+    Uses a UNION of two direction-specific queries so SQLite can use the
+    dedicated idx_edges_from and idx_edges_to indexes instead of a full
+    OR-scan.  Self (n.id = node_id) is excluded in both arms.
+
+    Returns a list of node dicts (id, kind, label, domain, created_at,
+    occurred_at).  Returns [] on any error.
+    """
+    c = conn or _connect()
+    try:
+        rows = c.execute(
+            """
+            SELECT n.id, n.kind, n.label, n.domain, n.created_at, n.occurred_at
+            FROM nodes n
+            JOIN edges e ON e.from_id = ? AND e.to_id = n.id AND e.kind = 'same-day'
+            WHERE n.id != ?
+            UNION
+            SELECT n.id, n.kind, n.label, n.domain, n.created_at, n.occurred_at
+            FROM nodes n
+            JOIN edges e ON e.to_id = ? AND e.from_id = n.id AND e.kind = 'same-day'
+            WHERE n.id != ?
+            """,
+            (node_id, node_id, node_id, node_id),
+        ).fetchall()
+    except Exception:  # noqa: BLE001
+        return []
+    return [dict(r) for r in rows]
+
+
 # ─────────────────────────── conversations ─────────────────────────────
 
 def add_conversation(user_text: str, axi_text: str, has_screenshot: bool = False, session_id: str | None = None) -> int:
@@ -1522,35 +1560,43 @@ def upsert_vec_node(conn, *, node_id: int, vector: list[float]) -> None:
     )
 
 
+def knn_nodes_scored(conn, *, vector: list[float], k: int = 10) -> list[tuple[int, float]]:
+    """Return the k nearest node ids with their cosine DISTANCE from vec_nodes.
+
+    Delegates to knn_nodes_with_distance (which already exists further below).
+    Returns a list of (node_id, distance) tuples ordered by ascending distance.
+    Returns an empty list if vec_nodes is empty or sqlite-vec is not loaded.
+    """
+    return knn_nodes_with_distance(conn, vector=vector, k=k)
+
+
 def knn_nodes(conn, *, vector: list[float], k: int = 10) -> list[int]:
     """Return the k nearest node ids from vec_nodes ordered by cosine distance.
 
     Returns an empty list if vec_nodes is empty or sqlite-vec is not loaded.
+    Delegates to knn_nodes_scored to avoid duplicated KNN logic.
     """
-    import struct
-
-    _load_sqlite_vec(conn)
-    vec = vector[:512]
-    blob = struct.pack(f"{len(vec)}f", *vec)
-    try:
-        rows = conn.execute(
-            "SELECT node_id FROM vec_nodes WHERE embedding MATCH ? ORDER BY distance LIMIT ?",
-            (blob, k),
-        ).fetchall()
-    except Exception:  # noqa: BLE001
-        return []
-    return [int(r[0]) for r in rows]
+    return [nid for nid, _dist in knn_nodes_scored(conn, vector=vector, k=k)]
 
 
 # ─────────────────── embed worker (Slice 1) ──────────────────────────────────
 
 # Re-export embed_text from embed_client so store.py callers use a single import,
 # and tests can patch "axi.store.embed_text" cleanly.
-def embed_text(text: str, *, mode: str = "passage") -> list[float]:
-    """Thin wrapper around embed_client.embed — patchable in tests."""
+def embed_text(text: str, *, mode: str = "passage", timeout: float | None = None) -> list[float]:
+    """Thin wrapper around embed_client.embed — patchable in tests.
+
+    Args:
+        text: Text to embed.
+        mode: 'query' or 'passage' (passed to embed_client).
+        timeout: Optional HTTP timeout override. None uses embed_client default (30 s).
+    """
     from axi.embed_client import embed
 
-    return embed(text, mode=mode)  # type: ignore[arg-type]
+    kwargs: dict = {"mode": mode}  # type: ignore[arg-type]
+    if timeout is not None:
+        kwargs["timeout"] = timeout
+    return embed(text, **kwargs)
 
 
 def embed_pending_nodes(*, limit: int = 100) -> int:
@@ -1694,7 +1740,9 @@ def _embed_worker_loop() -> None:
             embed_pending_nodes(limit=_DRAIN_LIMIT)
         except Exception:  # noqa: BLE001
             log.debug("embed_worker: drain error — backing off %ss", _BACKOFF_S)
-            time.sleep(_BACKOFF_S)
+            # Use .wait() instead of time.sleep() so the stop event can interrupt
+            # the backoff immediately, enabling fast shutdown/test teardown.
+            _embed_worker_stop.wait(_BACKOFF_S)
 
 
 def _ensure_embed_worker() -> None:
@@ -1718,6 +1766,10 @@ def stop_embed_worker(timeout: float = 3.0) -> None:
     Safe to call even if the worker was never started.  Used in test teardown
     to prevent the daemon thread from touching sqlcipher during interpreter
     shutdown (which causes SIGSEGV).
+
+    Reaps ALL threads named "axi-embed-worker" (not only the currently tracked
+    one) so orphaned workers — spawned when _embed_worker_started was cleared
+    while a prior worker was still alive — are also joined within `timeout`.
     """
     global _embed_worker_thread
     _embed_worker_stop.set()
@@ -1726,8 +1778,16 @@ def stop_embed_worker(timeout: float = 3.0) -> None:
         _EMBED_QUEUE.put_nowait(-1)
     except queue.Full:
         pass
-    if _embed_worker_thread is not None and _embed_worker_thread.is_alive():
-        _embed_worker_thread.join(timeout=timeout)
+    # Collect every live thread named axi-embed-worker (handles orphans too).
+    workers = [
+        t for t in threading.enumerate()
+        if t.name == "axi-embed-worker" and t.is_alive()
+    ]
+    # Distribute the overall timeout budget across all workers.
+    deadline = time.monotonic() + timeout
+    for t in workers:
+        remaining = max(0.0, deadline - time.monotonic())
+        t.join(timeout=remaining)
     # Reset state so _ensure_embed_worker() can restart a fresh worker later.
     _embed_worker_stop.clear()
     _embed_worker_started.clear()
@@ -1740,8 +1800,12 @@ def trigger_embed_for_node(node_id: int) -> None:
     Returns immediately — never blocks fact creation.  The worker thread
     drains embed_pending_nodes(limit=50) in batches.  If the embed service is
     down, nodes stay embedding IS NULL and are retried on the next signal.
+
+    Gated by AXI_DISABLE_BG_WORKERS: when set, the implicit auto-start is
+    suppressed so test isolation is preserved (no TOCTOU race on DB_PATH).
     """
-    _ensure_embed_worker()
+    if not _BG_WORKERS_DISABLED:
+        _ensure_embed_worker()
     try:
         _EMBED_QUEUE.put_nowait(node_id)
     except queue.Full:
@@ -1817,19 +1881,31 @@ def semantic_search_nodes(
     *,
     k: int = 20,
     conn=None,
+    timeout: float | None = None,
 ) -> list[dict[str, Any]]:
     """Embed *query* and return nodes ranked by cosine similarity via vec_nodes KNN.
 
+    Each returned dict includes: id, kind, label, domain, created_at,
+    occurred_at (float|None), and distance (float, cosine distance from query).
+
     Returns an empty list if:
-      - The embed service is down (EmbedServiceError).
+      - The embed service is down or times out (EmbedServiceError / TimeoutError).
       - vec_nodes is empty or not loaded.
+
+    Args:
+        query: Text to embed for similarity search.
+        k: Number of nearest neighbours to retrieve.
+        conn: Optional connection (injected in tests).
+        timeout: Optional HTTP timeout for the embed call. None uses the embed
+            client default (30 s). Pass a short value (e.g. 2.0) from
+            build_recall_block so a slow embed cannot stall the user's turn.
 
     Never raises — callers receive an empty list on any failure.
     """
     from axi.embed_client import EmbedServiceError
 
     try:
-        vector = embed_text(query, mode="query")
+        vector = embed_text(query, mode="query", timeout=timeout)
     except EmbedServiceError:
         log.debug("semantic_search_nodes: embed service down for query %r", query)
         return []
@@ -1840,23 +1916,32 @@ def semantic_search_nodes(
     c = conn or _connect()
 
     try:
-        node_ids = knn_nodes(c, vector=vector, k=k)
+        scored = knn_nodes_scored(c, vector=vector, k=k)
     except Exception as exc:  # noqa: BLE001
         log.debug("semantic_search_nodes: knn failed: %s", exc)
         return []
 
-    if not node_ids:
+    if not scored:
         return []
+
+    node_ids = [nid for nid, _dist in scored]
+    id_to_distance = {nid: dist for nid, dist in scored}
 
     # Fetch node metadata in one query, preserving KNN order.
     placeholders = ",".join("?" * len(node_ids))
     rows = c.execute(
-        f"SELECT id, kind, label, domain, created_at FROM nodes WHERE id IN ({placeholders})",
+        f"SELECT id, kind, label, domain, created_at, occurred_at FROM nodes WHERE id IN ({placeholders})",
         node_ids,
     ).fetchall()
 
-    # Re-order by the KNN rank.
-    id_to_row = {int(r[0]): dict(r) for r in rows}
+    # Re-order by the KNN rank and attach distance.
+    id_to_row: dict[int, dict[str, Any]] = {}
+    for r in rows:
+        row = dict(r)
+        nid = int(row["id"])
+        row["distance"] = id_to_distance.get(nid, 1.0)
+        id_to_row[nid] = row
+
     return [id_to_row[nid] for nid in node_ids if nid in id_to_row]
 
 

--- a/axi/src/axi/wakeword.py
+++ b/axi/src/axi/wakeword.py
@@ -671,6 +671,8 @@ class WakeWordListener:
             return
 
         log.info("wakeword: WAKE DETECTED — command=%r", command)
+        # Machine-parseable anchor for the live-test harness (wake path only).
+        log.info("wakeword-metric: wake_detected t=%.3f command=%r", time.time(), command)
         try:
             self._on_wake(command)
         except Exception as e:  # noqa: BLE001

--- a/axi/tests/conftest.py
+++ b/axi/tests/conftest.py
@@ -7,10 +7,19 @@ the cached connection.
 from __future__ import annotations
 
 import logging
+import os
 import subprocess as _subprocess
 from unittest.mock import MagicMock
 
 import pytest
+
+# Suppress all background worker auto-triggers for the whole test session.
+# This must be set before any axi module is imported so that the module-level
+# _BG_WORKERS_DISABLED flags in store.py, events.py, and brain.py read the
+# correct value. Without this, the embed-worker / events-writer / brain-metric
+# threads race against monkeypatch DB_PATH swaps (TOCTOU) and produce HMAC
+# mismatches on the wrong SQLCipher key → SIGBUS.
+os.environ.setdefault("AXI_DISABLE_BG_WORKERS", "1")
 
 log = logging.getLogger(__name__)
 
@@ -275,9 +284,7 @@ def fresh_db(tmp_path, monkeypatch):
     # carries the wrong encryption key or an incomplete schema into the next
     # test's fixture setup.
     _events._flush_for_tests(timeout=1.0)
-    _events._write_queue.put(None)  # sentinel: terminates the worker loop
-    if _events._worker_thread is not None:
-        _events._worker_thread.join(timeout=1.0)
+    _events.stop_events_writer()
     # Stop the embed worker so it does not touch sqlcipher during interpreter
     # teardown (preventing SIGSEGV at test-suite shutdown).
     store.stop_embed_worker()

--- a/axi/tests/test_bg_worker_gate.py
+++ b/axi/tests/test_bg_worker_gate.py
@@ -1,0 +1,154 @@
+"""Tests for the AXI_DISABLE_BG_WORKERS process-level gate.
+
+Verifies that:
+  - With the gate ON (default in tests), implicit auto-triggers do NOT start
+    background threads.
+  - With the gate OFF (production default), the implicit triggers DO start the
+    workers, and the threads are properly cleaned up.
+  - The gate is respected by events.py and brain.py as well.
+"""
+from __future__ import annotations
+
+import os
+import threading
+import time
+
+
+def _count_live(name: str) -> int:
+    """Return the number of live threads with the given name."""
+    return sum(1 for t in threading.enumerate() if t.name == name and t.is_alive())
+
+
+# ─────────────────────────── embed worker gate ───────────────────────────────
+
+def test_gate_on_embed_worker_does_not_start(tmp_path, monkeypatch):
+    """With AXI_DISABLE_BG_WORKERS=1, trigger_embed_for_node must NOT start
+    the axi-embed-worker thread."""
+    from axi import store
+
+    # Ensure gate is ON (conftest already sets the env var before import, but
+    # we re-assert the module-level flag here for clarity).
+    assert store._BG_WORKERS_DISABLED, (
+        "Expected _BG_WORKERS_DISABLED=True; conftest must set AXI_DISABLE_BG_WORKERS=1"
+    )
+
+    before = _count_live("axi-embed-worker")
+    store.trigger_embed_for_node(9999)
+    time.sleep(0.05)  # brief pause to let any accidentally spawned thread register
+    after = _count_live("axi-embed-worker")
+    assert after == before, (
+        f"axi-embed-worker thread was started despite AXI_DISABLE_BG_WORKERS=1 "
+        f"(before={before}, after={after})"
+    )
+
+
+def test_gate_off_embed_worker_starts(tmp_path, monkeypatch):
+    """With AXI_DISABLE_BG_WORKERS unset, trigger_embed_for_node MUST start
+    the axi-embed-worker thread. Cleans up after itself."""
+    from axi import store
+
+    # Override the module-level flag to simulate the production (gate-off) path.
+    monkeypatch.setattr(store, "_BG_WORKERS_DISABLED", False)
+
+    store.stop_embed_worker()  # ensure clean state
+    before = _count_live("axi-embed-worker")
+    store.trigger_embed_for_node(1)
+    time.sleep(0.1)  # give the thread a moment to start
+    after = _count_live("axi-embed-worker")
+    store.stop_embed_worker()  # clean up
+    assert after > before, (
+        "Expected axi-embed-worker to start when AXI_DISABLE_BG_WORKERS is off"
+    )
+
+
+# ─────────────────────────── events writer gate ───────────────────────────────
+
+def test_gate_on_events_writer_does_not_start(monkeypatch):
+    """With AXI_DISABLE_BG_WORKERS=1, log_event must NOT start the
+    axi-events-writer thread."""
+    from axi import events
+
+    assert events._BG_WORKERS_DISABLED, (
+        "Expected events._BG_WORKERS_DISABLED=True; conftest must set AXI_DISABLE_BG_WORKERS=1"
+    )
+
+    # Make sure no writer is running from a prior test.
+    events.stop_events_writer()
+    before = _count_live("axi-events-writer")
+    events.log_info("test.gate", "gate-on test event")
+    time.sleep(0.05)
+    after = _count_live("axi-events-writer")
+    assert after == before, (
+        f"axi-events-writer thread was started despite AXI_DISABLE_BG_WORKERS=1 "
+        f"(before={before}, after={after})"
+    )
+
+
+def test_gate_off_events_writer_starts(monkeypatch):
+    """With AXI_DISABLE_BG_WORKERS unset, log_event MUST call _ensure_worker
+    which creates an axi-events-writer thread. Verifies the thread object was
+    created (it may exit quickly if the DB is not accessible in test context).
+    Cleans up after itself."""
+    from axi import events
+
+    monkeypatch.setattr(events, "_BG_WORKERS_DISABLED", False)
+    events.stop_events_writer()  # ensure clean state — resets _worker_thread to None
+    assert events._worker_thread is None, "Expected _worker_thread=None after stop"
+    events.log_info("test.gate", "gate-off test event")
+    # Give the thread a moment to be registered. The thread may exit quickly
+    # (DB not accessible in test context) but it MUST have been created.
+    time.sleep(0.1)
+    thread_created = events._worker_thread is not None
+    events.stop_events_writer()  # clean up
+    assert thread_created, (
+        "Expected _ensure_worker() to create an axi-events-writer thread "
+        "when AXI_DISABLE_BG_WORKERS is off"
+    )
+
+
+# ─────────────────────────── brain metric gate ───────────────────────────────
+
+def test_gate_on_brain_metric_does_not_spawn(monkeypatch):
+    """With AXI_DISABLE_BG_WORKERS=1, _record_metric_async must NOT spawn an
+    axi-brain-metric thread."""
+    from axi import brain
+
+    assert brain._BG_WORKERS_DISABLED, (
+        "Expected brain._BG_WORKERS_DISABLED=True; conftest must set AXI_DISABLE_BG_WORKERS=1"
+    )
+
+    before = _count_live("axi-brain-metric")
+    brain._record_metric_async(latency_ms=100, ok=True, error=None, response_data=None)
+    time.sleep(0.05)
+    after = _count_live("axi-brain-metric")
+    assert after == before, (
+        f"axi-brain-metric thread was spawned despite AXI_DISABLE_BG_WORKERS=1 "
+        f"(before={before}, after={after})"
+    )
+
+
+def test_gate_off_brain_metric_spawns(monkeypatch):
+    """With AXI_DISABLE_BG_WORKERS unset, _record_metric_async MUST spawn an
+    axi-brain-metric thread. Waits for it to finish so the DB is not touched
+    after the fixture tears down."""
+    from axi import brain
+
+    monkeypatch.setattr(brain, "_BG_WORKERS_DISABLED", False)
+    before = _count_live("axi-brain-metric")
+    brain._record_metric_async(latency_ms=50, ok=True, error=None, response_data=None)
+    # Wait up to 1 s for the thread to appear and finish.
+    deadline = time.monotonic() + 1.0
+    spawned = False
+    while time.monotonic() < deadline:
+        if _count_live("axi-brain-metric") > before:
+            spawned = True
+        time.sleep(0.02)
+    # Let any spawned thread finish so it doesn't race with fixture teardown.
+    extra_deadline = time.monotonic() + 1.0
+    while time.monotonic() < extra_deadline:
+        if _count_live("axi-brain-metric") == 0:
+            break
+        time.sleep(0.02)
+    assert spawned, (
+        "Expected axi-brain-metric thread to be spawned when AXI_DISABLE_BG_WORKERS is off"
+    )

--- a/axi/tests/test_brain.py
+++ b/axi/tests/test_brain.py
@@ -96,12 +96,21 @@ def test_ask_disables_thinking_by_default():
 
 
 def test_ask_with_tools_dispatches_tool_and_sends_result():
-    captured = {"bodies": []}
+    # chat_bodies contains only chat-completion requests (not embed requests).
+    # ask_with_tools now fires a recall embed first (FIX 1), which goes through
+    # the same urlopen mock; we filter by URL so the counter stays correct.
+    chat_bodies = []
 
     def fake_urlopen(req, timeout=0):  # noqa: ARG001
         body = json.loads(req.data.decode())
-        captured["bodies"].append(body)
-        if len(captured["bodies"]) == 1:
+        url = getattr(req, "full_url", "") or ""
+        if "embeddings" in url or "input" in body:
+            # Embed pre-call: return a response that causes EmbedServiceError
+            # so build_recall_block returns "" gracefully.
+            return _FakeResp(json.dumps({"data": []}).encode())
+        # Real chat-completion call
+        chat_bodies.append(body)
+        if len(chat_bodies) == 1:
             response = {
                 "choices": [{
                     "finish_reason": "tool_calls",
@@ -135,10 +144,10 @@ def test_ask_with_tools_dispatches_tool_and_sends_result():
 
     assert out == "final answer"
     assert calls == [{"query": "latest news"}]
-    assert len(captured["bodies"]) == 2
-    assert captured["bodies"][0]["tools"] == tools
-    assert captured["bodies"][0]["tool_choice"] == "required"
-    second_messages = captured["bodies"][1]["messages"]
+    assert len(chat_bodies) == 2
+    assert chat_bodies[0]["tools"] == tools
+    assert chat_bodies[0]["tool_choice"] == "required"
+    second_messages = chat_bodies[1]["messages"]
     assert second_messages[-2]["role"] == "assistant"
     assert second_messages[-2]["tool_calls"][0]["id"] == "call_1"
     assert second_messages[-1]["role"] == "tool"
@@ -147,12 +156,16 @@ def test_ask_with_tools_dispatches_tool_and_sends_result():
 
 
 def test_ask_with_tools_unknown_tool_returns_safe_tool_error():
-    captured = {"bodies": []}
+    # Similar to above: filter embed pre-calls from chat-completion calls.
+    chat_bodies = []
 
     def fake_urlopen(req, timeout=0):  # noqa: ARG001
         body = json.loads(req.data.decode())
-        captured["bodies"].append(body)
-        if len(captured["bodies"]) == 1:
+        url = getattr(req, "full_url", "") or ""
+        if "embeddings" in url or "input" in body:
+            return _FakeResp(json.dumps({"data": []}).encode())
+        chat_bodies.append(body)
+        if len(chat_bodies) == 1:
             response = {
                 "choices": [{
                     "finish_reason": "tool_calls",
@@ -180,7 +193,7 @@ def test_ask_with_tools_unknown_tool_returns_safe_tool_error():
         )
 
     assert out == "safe final"
-    tool_msg = captured["bodies"][1]["messages"][-1]
+    tool_msg = chat_bodies[1]["messages"][-1]
     assert tool_msg["role"] == "tool"
     assert "unknown tool 'shell'" in tool_msg["content"]
 

--- a/axi/tests/test_brain_metrics.py
+++ b/axi/tests/test_brain_metrics.py
@@ -85,6 +85,7 @@ def _flush_metric_threads(timeout: float = 2.0) -> None:
 
 def test_ask_records_metric_with_usage_tokens(monkeypatch):
     monkeypatch.setattr(config, "get", lambda k, default=None: True if k == "brain_metrics_enabled" else default)
+    monkeypatch.setattr(brain, "_BG_WORKERS_DISABLED", False)  # test requires metric threads
 
     def fake_impl(prompt, **kw):
         return "hola", {
@@ -112,6 +113,7 @@ def test_ask_records_metric_with_usage_tokens(monkeypatch):
 
 def test_ask_records_null_usage_when_absent(monkeypatch):
     monkeypatch.setattr(config, "get", lambda k, default=None: True if k == "brain_metrics_enabled" else default)
+    monkeypatch.setattr(brain, "_BG_WORKERS_DISABLED", False)  # test requires metric threads
 
     def fake_impl(prompt, **kw):
         return "ok", {"choices": [{"message": {"content": "ok"}}]}
@@ -132,6 +134,7 @@ def test_ask_records_null_usage_when_absent(monkeypatch):
 
 def test_ask_records_metric_on_error_and_reraises(monkeypatch):
     monkeypatch.setattr(config, "get", lambda k, default=None: True if k == "brain_metrics_enabled" else default)
+    monkeypatch.setattr(brain, "_BG_WORKERS_DISABLED", False)  # test requires metric threads
 
     def boom(prompt, **kw):
         raise RuntimeError("brain exploded")

--- a/axi/tests/test_brain_recall.py
+++ b/axi/tests/test_brain_recall.py
@@ -1,0 +1,306 @@
+"""Tests for brain.py graph-recall injection (Layer 3).
+
+Covers:
+  1-4: _build_messages recall injection (existing)
+  5:   ask_with_tools injects recall in FIRST call exactly once (FIX 1)
+  6:   ask_with_tools skips recall when graph_recall=False (FIX 1)
+  7:   4B retry path does NOT trigger a second recall embed (FIX 3)
+  8:   tuteo restraint in Spanish (FIX 7)
+"""
+from __future__ import annotations
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _invoke_build_messages(
+    monkeypatch,
+    prompt: str = "pregunta de prueba",
+    system: str = "eres Axi",
+    lang: str | None = None,
+    *,
+    recall_return: str = "",
+    graph_recall_enabled: bool = True,
+):
+    """Call brain._build_messages with controlled dependencies."""
+    from axi import config, brain
+
+    # Patch config.get to control graph_recall flag
+    _orig_config_get = config.get
+
+    def _mock_config_get(key, default=None):
+        if key == "graph_recall":
+            return graph_recall_enabled
+        return _orig_config_get(key, default)
+
+    monkeypatch.setattr(config, "get", _mock_config_get)
+
+    # Patch recall.build_recall_block
+    import axi.recall as _recall
+    monkeypatch.setattr(_recall, "build_recall_block", lambda *a, **kw: recall_return)
+
+    return brain._build_messages(prompt, system, lang=lang)
+
+
+# ---------------------------------------------------------------------------
+# 1. Non-empty recall block → system contains MEMORIA RELEVANTE + restraint
+# ---------------------------------------------------------------------------
+
+def test_build_messages_includes_recall_block_when_non_empty(monkeypatch):
+    """When recall block is non-empty, system must contain it and the restraint."""
+    msgs = _invoke_build_messages(
+        monkeypatch,
+        recall_return="MEMORIA RELEVANTE (usala solo si responde la pregunta):\n- El 11 de junio: dormí 5h",
+        graph_recall_enabled=True,
+    )
+
+    system_content = msgs[0]["content"]
+    assert "MEMORIA RELEVANTE" in system_content
+    # Restraint must also be present
+    assert "Los recuerdos de arriba" in system_content or "memories above" in system_content.lower()
+
+
+# ---------------------------------------------------------------------------
+# 2. Empty recall block → system unchanged (exact f"{system}\n\n{_tc}" format)
+# ---------------------------------------------------------------------------
+
+def test_build_messages_unchanged_when_recall_empty(monkeypatch):
+    """When recall block is '', _build_messages behaves exactly as before (no extra sections)."""
+    from axi import brain
+
+    system = "eres Axi"
+    msgs = _invoke_build_messages(
+        monkeypatch,
+        system=system,
+        recall_return="",
+        graph_recall_enabled=True,
+    )
+
+    system_content = msgs[0]["content"]
+    # Must NOT contain recall or restraint sections
+    assert "MEMORIA RELEVANTE" not in system_content
+    assert "RELEVANT MEMORY" not in system_content
+    assert "Los recuerdos de arriba" not in system_content
+    assert "memories above" not in system_content.lower()
+
+
+# ---------------------------------------------------------------------------
+# 3. graph_recall=False → recall skipped even if block would be non-empty
+# ---------------------------------------------------------------------------
+
+def test_build_messages_skips_recall_when_graph_recall_false(monkeypatch):
+    """When config graph_recall=False, recall is not injected even if block is non-empty."""
+    msgs = _invoke_build_messages(
+        monkeypatch,
+        recall_return="MEMORIA RELEVANTE:\n- El 11 de junio: dormí 5h",
+        graph_recall_enabled=False,
+    )
+
+    system_content = msgs[0]["content"]
+    assert "MEMORIA RELEVANTE" not in system_content
+    assert "Los recuerdos de arriba" not in system_content
+
+
+# ---------------------------------------------------------------------------
+# 4. lang='en' → English restraint
+# ---------------------------------------------------------------------------
+
+def test_build_messages_en_uses_english_restraint(monkeypatch):
+    """When lang='en', the restraint line uses English, not Spanish."""
+    msgs = _invoke_build_messages(
+        monkeypatch,
+        lang="en",
+        recall_return="RELEVANT MEMORY (use only if it answers the question):\n- On June 11: slept 5h",
+        graph_recall_enabled=True,
+    )
+
+    system_content = msgs[0]["content"]
+    assert "memories above" in system_content.lower() or "The memories above" in system_content
+    assert "Los recuerdos de arriba" not in system_content
+
+
+# ---------------------------------------------------------------------------
+# FIX 7 — tuteo restraint: no voseo in Spanish restraint line
+# ---------------------------------------------------------------------------
+
+def test_build_messages_spanish_restraint_uses_tuteo(monkeypatch):
+    """Spanish restraint must use tuteo (Usa, cita, ignóralos) not voseo."""
+    msgs = _invoke_build_messages(
+        monkeypatch,
+        recall_return="MEMORIA RELEVANTE:\n- El 11 de junio: dormí 5h",
+        graph_recall_enabled=True,
+    )
+    system_content = msgs[0]["content"]
+    assert "Los recuerdos de arriba" in system_content
+    # tuteo forms
+    assert "Usa " in system_content
+    assert "cita " in system_content
+    assert "ignóralos" in system_content
+    # voseo forms must NOT be present
+    assert "Usá " not in system_content
+    assert "citá " not in system_content
+    assert "ignoralos" not in system_content
+
+
+# ---------------------------------------------------------------------------
+# FIX 1 — ask_with_tools injects MEMORIA RELEVANTE exactly once
+# ---------------------------------------------------------------------------
+
+def _make_fake_response(content: str = "respuesta") -> dict:
+    """Build a minimal fake llama-server chat completion response."""
+    import json
+    return {
+        "choices": [
+            {
+                "message": {"role": "assistant", "content": content, "tool_calls": []},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {},
+    }
+
+
+def test_ask_with_tools_injects_recall_in_first_call(monkeypatch):
+    """ask_with_tools must inject MEMORIA RELEVANTE into the system of its FIRST model call."""
+    import json
+    import axi.recall as _recall
+    from axi import config, brain
+
+    # Stub recall to return a non-empty block
+    monkeypatch.setattr(_recall, "build_recall_block", lambda *a, **kw: "MEMORIA RELEVANTE:\n- El 11 de junio: dormí 5h")
+
+    # Control graph_recall=True
+    _orig_get = config.get
+    monkeypatch.setattr(config, "get", lambda key, default=None: (
+        True if key == "graph_recall" else _orig_get(key, default)
+    ))
+
+    captured_payloads: list[dict] = []
+
+    def _fake_post(payload_obj, timeout, endpoint=brain.ENDPOINT):
+        captured_payloads.append(payload_obj)
+        return _make_fake_response()
+
+    monkeypatch.setattr(brain, "_post_chat_completion", _fake_post)
+
+    brain.ask_with_tools(
+        "qué dormí ayer?",
+        tools=[],
+        tool_handlers={},
+    )
+
+    # First (and only) call should have MEMORIA RELEVANTE in system message
+    assert len(captured_payloads) >= 1
+    first_messages = captured_payloads[0]["messages"]
+    system_content = first_messages[0]["content"]
+    assert "MEMORIA RELEVANTE" in system_content
+
+
+def test_ask_with_tools_recall_not_injected_when_disabled(monkeypatch):
+    """ask_with_tools must NOT inject recall when graph_recall=False."""
+    import axi.recall as _recall
+    from axi import config, brain
+
+    monkeypatch.setattr(_recall, "build_recall_block", lambda *a, **kw: "MEMORIA RELEVANTE:\n- hecho")
+
+    _orig_get = config.get
+    monkeypatch.setattr(config, "get", lambda key, default=None: (
+        False if key == "graph_recall" else _orig_get(key, default)
+    ))
+
+    captured_payloads: list[dict] = []
+
+    def _fake_post(payload_obj, timeout, endpoint=brain.ENDPOINT):
+        captured_payloads.append(payload_obj)
+        return _make_fake_response()
+
+    monkeypatch.setattr(brain, "_post_chat_completion", _fake_post)
+
+    brain.ask_with_tools("query", tools=[], tool_handlers={})
+
+    first_messages = captured_payloads[0]["messages"]
+    system_content = first_messages[0]["content"]
+    assert "MEMORIA RELEVANTE" not in system_content
+
+
+def test_ask_with_tools_recall_not_injected_when_block_empty(monkeypatch):
+    """ask_with_tools must leave system unchanged when recall block is ''."""
+    import axi.recall as _recall
+    from axi import config, brain
+
+    monkeypatch.setattr(_recall, "build_recall_block", lambda *a, **kw: "")
+
+    _orig_get = config.get
+    monkeypatch.setattr(config, "get", lambda key, default=None: (
+        True if key == "graph_recall" else _orig_get(key, default)
+    ))
+
+    captured_payloads: list[dict] = []
+
+    def _fake_post(payload_obj, timeout, endpoint=brain.ENDPOINT):
+        captured_payloads.append(payload_obj)
+        return _make_fake_response()
+
+    monkeypatch.setattr(brain, "_post_chat_completion", _fake_post)
+
+    brain.ask_with_tools("query", tools=[], tool_handlers={})
+
+    system_content = captured_payloads[0]["messages"][0]["content"]
+    assert "MEMORIA RELEVANTE" not in system_content
+    assert "RELEVANT MEMORY" not in system_content
+
+
+# ---------------------------------------------------------------------------
+# FIX 3 — 4B retry path does NOT trigger a second recall embed
+# ---------------------------------------------------------------------------
+
+def test_ask_impl_retry_does_not_double_embed(monkeypatch):
+    """The 4B budget-retry path must not fire a second recall embed."""
+    import axi.recall as _recall
+    from axi import config, brain
+
+    embed_calls: list[str] = []
+
+    def _counting_recall(query, **kw):
+        embed_calls.append(query)
+        return "MEMORIA RELEVANTE:\n- El 11 de junio: dormí 5h"
+
+    monkeypatch.setattr(_recall, "build_recall_block", _counting_recall)
+
+    _orig_get = config.get
+    monkeypatch.setattr(config, "get", lambda key, default=None: (
+        True if key == "graph_recall" else _orig_get(key, default)
+    ))
+
+    call_count = [0]
+
+    def _fake_post(payload_obj, timeout, endpoint=brain.ENDPOINT):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            # First call: return reasoning-consumed response to trigger retry
+            return {
+                "choices": [{
+                    "message": {
+                        "role": "assistant",
+                        "content": "",
+                        "reasoning_content": "lots of reasoning",
+                    },
+                    "finish_reason": "length",
+                }],
+                "usage": {},
+            }
+        # Second call (retry): return normal response
+        return _make_fake_response("final answer")
+
+    monkeypatch.setattr(brain, "_post_chat_completion", _fake_post)
+    # Stub routing so we don't need a live VT server
+    monkeypatch.setattr(brain, "_route", lambda *a, **kw: "4b")
+    monkeypatch.setattr(brain, "is_vt_alive", lambda *a, **kw: False)
+
+    brain.ask("test recall retry")
+
+    # Recall embed must fire exactly ONCE even though _post was called twice
+    assert len(embed_calls) == 1

--- a/axi/tests/test_chat_api.py
+++ b/axi/tests/test_chat_api.py
@@ -22,6 +22,7 @@ def client(monkeypatch):
 def test_chat_ask_returns_answer(client, monkeypatch):
     from axi import brain
     monkeypatch.setattr(brain, "ask", lambda prompt, **kw: "respuesta de prueba")
+    monkeypatch.setattr(brain, "ask_with_tools", lambda prompt, **kw: "respuesta de prueba")
 
     r = client.post("/api/chat/ask", json={"text": "hola"})
     assert r.status_code == 200
@@ -47,6 +48,7 @@ def test_chat_ask_passes_history(client, monkeypatch):
         return "ok"
 
     monkeypatch.setattr(brain, "ask", fake_ask)
+    monkeypatch.setattr(brain, "ask_with_tools", fake_ask)
 
     r = client.post("/api/chat/ask", json={"text": "tercera"})
     assert r.status_code == 200
@@ -63,6 +65,7 @@ def test_chat_ask_passes_history(client, monkeypatch):
 def test_chat_ask_then_history_roundtrip(client, monkeypatch):
     from axi import brain
     monkeypatch.setattr(brain, "ask", lambda prompt, **kw: "respuesta")
+    monkeypatch.setattr(brain, "ask_with_tools", lambda prompt, **kw: "respuesta")
 
     r = client.post("/api/chat/ask", json={"text": "pregunta"})
     assert r.status_code == 200
@@ -90,13 +93,17 @@ def test_chat_ask_rejects_empty(client, monkeypatch):
 
 
 def test_chat_ask_records_brain_metric(client, monkeypatch):
-    """The brain.ask call from chat must also feed the brain-metrics table.
+    """The brain call from chat must also feed the brain-metrics table.
 
-    We don't mock _record_metric_async directly — we exercise the real
-    `brain.ask` wrapper with a stub `_ask_impl`, then check the store.
+    Stubs both _ask_impl (for brain.ask) and _ask_with_tools_impl (for
+    brain.ask_with_tools) since the routing now uses ask_with_tools for
+    non-image turns. Either path must record the metric.
     """
     from axi import brain, store
-    monkeypatch.setattr(brain, "_ask_impl", lambda prompt, **kw: ("ok", {"model": "stub", "usage": {"total_tokens": 5, "prompt_tokens": 2, "completion_tokens": 3}}))
+    monkeypatch.setattr(brain, "_BG_WORKERS_DISABLED", False)  # test requires metric threads
+    _stub_meta = {"model": "stub", "usage": {"total_tokens": 5, "prompt_tokens": 2, "completion_tokens": 3}}
+    monkeypatch.setattr(brain, "_ask_impl", lambda prompt, **kw: ("ok", _stub_meta))
+    monkeypatch.setattr(brain, "_ask_with_tools_impl", lambda prompt, **kw: ("ok", _stub_meta))
 
     r = client.post("/api/chat/ask", json={"text": "ping"})
     assert r.status_code == 200

--- a/axi/tests/test_chat_api.py
+++ b/axi/tests/test_chat_api.py
@@ -99,25 +99,35 @@ def test_chat_ask_records_brain_metric(client, monkeypatch):
     brain.ask_with_tools) since the routing now uses ask_with_tools for
     non-image turns. Either path must record the metric.
     """
+    import time
     from axi import brain, store
-    monkeypatch.setattr(brain, "_BG_WORKERS_DISABLED", False)  # test requires metric threads
+    monkeypatch.setattr(brain, "_BG_WORKERS_DISABLED", False)  # test requires the metric thread
     _stub_meta = {"model": "stub", "usage": {"total_tokens": 5, "prompt_tokens": 2, "completion_tokens": 3}}
     monkeypatch.setattr(brain, "_ask_impl", lambda prompt, **kw: ("ok", _stub_meta))
     monkeypatch.setattr(brain, "_ask_with_tools_impl", lambda prompt, **kw: ("ok", _stub_meta))
 
+    # Assert the metric is RECORDED (insert_brain_metric called with the stub
+    # model) rather than reading it back from the per-test encrypted DB. The
+    # metric write happens on an async daemon thread; reading it back couples
+    # this test to the encrypted-DB round-trip, which is order-dependent under
+    # the per-test DB fixture (hmac key races). The DB persistence round-trip is
+    # covered directly by tests/test_brain_metrics.py.
+    recorded_models: list[str | None] = []
+    monkeypatch.setattr(
+        store, "insert_brain_metric",
+        lambda **kw: recorded_models.append(kw.get("model")),
+    )
+
     r = client.post("/api/chat/ask", json={"text": "ping"})
     assert r.status_code == 200
 
-    # The metric write is async — wait briefly for the daemon thread.
-    import threading, time
+    # The metric write is async — wait briefly for the daemon thread to call it.
     deadline = time.time() + 2.0
     while time.time() < deadline:
-        if any(t.name == "axi-brain-metric" and t.is_alive() for t in threading.enumerate()):
-            time.sleep(0.02)
-            continue
-        break
-    metrics = store.recent_brain_metrics(limit=10)
-    assert any(m.get("model") == "stub" for m in metrics)
+        if "stub" in recorded_models:
+            break
+        time.sleep(0.02)
+    assert "stub" in recorded_models, f"brain metric not recorded; got {recorded_models}"
 
 
 def test_chat_history_empty(client):

--- a/axi/tests/test_chat_multimodal.py
+++ b/axi/tests/test_chat_multimodal.py
@@ -134,6 +134,7 @@ def test_chat_ask_speak_synthesizes_wav_in_response(client, monkeypatch):
     """
     from axi import brain, speak as speak_mod
     monkeypatch.setattr(brain, "ask", lambda prompt, **kw: "hola Héctor")
+    monkeypatch.setattr(brain, "ask_with_tools", lambda prompt, **kw: "hola Héctor")
     synthesized: list[str] = []
 
     def fake_synth(text: str) -> bytes:

--- a/axi/tests/test_events_worker_stop.py
+++ b/axi/tests/test_events_worker_stop.py
@@ -1,0 +1,134 @@
+"""Tests for the axi-events-writer worker stop/teardown behaviour.
+
+TDD red phase: these tests define the contract for stop_events_writer().
+They are written BEFORE the implementation and must FAIL until events.py
+is updated with the stop machinery.
+
+Tests:
+  1. stop_events_writer reaps the worker thread.
+  2. Worker refuses to touch the DB after stop is signalled.
+  3. stop_events_writer is safe to call when the worker was never started.
+"""
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _writer_threads() -> list[threading.Thread]:
+    """Return all currently alive axi-events-writer threads."""
+    return [t for t in threading.enumerate()
+            if t.name == "axi-events-writer" and t.is_alive()]
+
+
+# ---------------------------------------------------------------------------
+# Test 1: stop_events_writer reaps the worker thread
+# ---------------------------------------------------------------------------
+
+def test_stop_events_writer_reaps_worker():
+    """After stop_events_writer(), no axi-events-writer thread remains alive."""
+    from axi import events as _events
+
+    try:
+        # Enqueue an event so the worker spins up.
+        _events.log_event("test.source", "info", "reap-test message")
+        # Give the worker a moment to start.
+        deadline = time.monotonic() + 1.0
+        while time.monotonic() < deadline:
+            if _writer_threads():
+                break
+            time.sleep(0.01)
+
+        # Now stop it.
+        _events.stop_events_writer()
+
+        # No alive worker should remain.
+        alive = _writer_threads()
+        assert alive == [], (
+            f"Expected no axi-events-writer threads after stop, "
+            f"found: {[t.ident for t in alive]}"
+        )
+    finally:
+        _events.stop_events_writer()
+        _events._reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Worker refuses to call store.insert_event after stop is signalled
+# ---------------------------------------------------------------------------
+
+def test_worker_refuses_insert_after_stop(monkeypatch):
+    """Worker must NOT call store.insert_event after _writer_stop is set."""
+    from axi import events as _events
+    from axi import store
+
+    calls: list[tuple] = []
+
+    def _fake_insert(ts, source, level, message, data_json):
+        calls.append((ts, source, level, message, data_json))
+
+    monkeypatch.setattr(store, "insert_event", _fake_insert)
+
+    try:
+        # Reset to a clean state (no live worker).
+        _events.stop_events_writer()
+        _events._reset_for_tests()
+
+        # Signal stop BEFORE the worker processes anything.
+        _events._writer_stop.set()
+
+        # Enqueue an item (bypassing log_event to avoid _ensure_worker starting a thread
+        # that clears the stop flag).
+        _events._write_queue.put_nowait({
+            "ts": time.time(),
+            "source": "test.source",
+            "level": "info",
+            "message": "should not be inserted",
+            "data_json": None,
+        })
+
+        # Start a worker manually. It should see the stop flag and exit without
+        # calling store.insert_event.
+        t = threading.Thread(target=_events._worker_loop, name="axi-events-writer", daemon=True)
+        t.start()
+        # Put a sentinel to unblock the get() in case the worker didn't see the flag first.
+        _events._write_queue.put(None)
+        t.join(timeout=2.0)
+
+        assert not t.is_alive(), "Worker thread did not exit within timeout"
+        assert calls == [], (
+            f"store.insert_event was called {len(calls)} time(s) after stop was set"
+        )
+    finally:
+        _events._writer_stop.clear()
+        _events.stop_events_writer()
+        _events._reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# Test 3: stop_events_writer is safe to call when never started
+# ---------------------------------------------------------------------------
+
+def test_stop_events_writer_safe_when_never_started():
+    """stop_events_writer() must not raise even if the worker was never started."""
+    from axi import events as _events
+
+    # Ensure clean state: stop any running worker first.
+    _events.stop_events_writer()
+    _events._reset_for_tests()
+
+    # Now call stop again on an idle module — must be fast and exception-free.
+    start = time.monotonic()
+    try:
+        _events.stop_events_writer()
+    except Exception as exc:  # noqa: BLE001
+        pytest.fail(f"stop_events_writer() raised unexpectedly: {exc!r}")
+
+    elapsed = time.monotonic() - start
+    assert elapsed < 1.0, f"stop_events_writer() took too long on idle module: {elapsed:.2f}s"

--- a/axi/tests/test_logging_mode_toggle.py
+++ b/axi/tests/test_logging_mode_toggle.py
@@ -47,6 +47,7 @@ def conv_client(client_base, monkeypatch):
     monkeypatch.setattr(web_research, "_enabled_fn", None)
 
     monkeypatch.setattr(brain, "ask", lambda prompt, **kw: "respuesta libre del brain")
+    monkeypatch.setattr(brain, "ask_with_tools", lambda prompt, **kw: "respuesta libre del brain")
     return TestClient(dashboard.app)
 
 
@@ -69,6 +70,7 @@ def test_conversation_mode_brain_returns_persistence_word_unchanged(conv_client,
         "Ya lo tenés anotado como referencia."
     )
     monkeypatch.setattr(brain, "ask", lambda prompt, **kw: gym_answer)
+    monkeypatch.setattr(brain, "ask_with_tools", lambda prompt, **kw: gym_answer)
 
     r = conv_client.post("/api/chat/ask", json={
         "text": "dame una rutina de gym",
@@ -92,6 +94,7 @@ def test_conversation_mode_default_no_logging_mode_field(conv_client, monkeypatc
 
     answer_with_persistence = "Guardé esto en mi memoria para futuras consultas."
     monkeypatch.setattr(brain, "ask", lambda prompt, **kw: answer_with_persistence)
+    monkeypatch.setattr(brain, "ask_with_tools", lambda prompt, **kw: answer_with_persistence)
 
     r = conv_client.post("/api/chat/ask", json={
         "text": "recuerda que prefiero el gym los lunes",
@@ -114,13 +117,14 @@ def test_conversation_mode_brain_is_called(conv_client, monkeypatch):
         return "ok"
 
     monkeypatch.setattr(brain, "ask", tracking_brain)
+    monkeypatch.setattr(brain, "ask_with_tools", tracking_brain)
 
     r = conv_client.post("/api/chat/ask", json={
         "text": "cuéntame sobre machine learning",
         "logging_mode": False,
     })
     assert r.status_code == 200
-    assert brain_called, "brain.ask was NOT called in conversation mode"
+    assert brain_called, "brain.ask or ask_with_tools was NOT called in conversation mode"
 
 
 # ---------------------------------------------------------------------------
@@ -349,6 +353,7 @@ def test_ordinary_today_conversation_does_not_trigger_deterministic_web_research
         enabled_fn=lambda: False,
     )
     monkeypatch.setattr(brain, "ask", lambda p, **kw: (brain_called.append(p), "brain")[1])
+    monkeypatch.setattr(brain, "ask_with_tools", lambda p, **kw: (brain_called.append(p), "brain")[1])
 
     tc = TestClient(dashboard.app)
     r = tc.post("/api/chat/ask", json={
@@ -394,7 +399,9 @@ def test_conversation_mode_uses_brain_tools_when_web_enabled(monkeypatch):
     assert r.status_code == 200
     assert r.json()["answer"] == "tool answer"
     assert ask_called
-    assert ask_called[0]["kw"]["tools"][0]["function"]["name"] == "web_search"
+    tool_names = [t["function"]["name"] for t in ask_called[0]["kw"]["tools"]]
+    assert "web_search" in tool_names
+    assert "recall_memory" in tool_names
     assert tool_called[0]["results"][0]["url"] == "https://example.test"
 
 
@@ -538,6 +545,7 @@ def test_logging_mode_absent_defaults_to_conversation(monkeypatch):
 
     answer_with_persistence_verb = "Anotado y registré la información en tu perfil."
     monkeypatch.setattr(brain, "ask", lambda p, **kw: answer_with_persistence_verb)
+    monkeypatch.setattr(brain, "ask_with_tools", lambda p, **kw: answer_with_persistence_verb)
 
     tc = TestClient(dashboard.app)
     # No logging_mode field at all
@@ -717,6 +725,7 @@ def test_logging_mode_string_true_treated_as_false(monkeypatch):
 
     brain_called = []
     monkeypatch.setattr(brain, "ask", lambda p, **kw: (brain_called.append(p), "from brain")[1])
+    monkeypatch.setattr(brain, "ask_with_tools", lambda p, **kw: (brain_called.append(p), "from brain")[1])
 
     tc = TestClient(dashboard.app)
     # logging_mode is a STRING "true" — must be treated as False (conversation)
@@ -728,7 +737,7 @@ def test_logging_mode_string_true_treated_as_false(monkeypatch):
     # Brain must be called because string "true" → False (conversation mode)
     assert brain_called, (
         "String 'true' for logging_mode must be coerced to False (conversation). "
-        "brain.ask should have been called."
+        "brain.ask or ask_with_tools should have been called."
     )
 
 

--- a/axi/tests/test_obs_review_fixes.py
+++ b/axi/tests/test_obs_review_fixes.py
@@ -543,18 +543,121 @@ def test_stop_embed_worker_stops_thread():
     if not alive_before:
         pytest.skip("axi-embed-worker did not start — cannot test stop")
 
-    store.stop_embed_worker()
+    try:
+        store.stop_embed_worker()
 
-    deadline = time.time() + 2.0
-    while time.time() < deadline:
+        deadline = time.time() + 2.0
+        while time.time() < deadline:
+            alive = [t for t in threading.enumerate()
+                     if t.name == "axi-embed-worker" and t.is_alive()]
+            if not alive:
+                break
+            time.sleep(0.05)
+
         alive = [t for t in threading.enumerate()
                  if t.name == "axi-embed-worker" and t.is_alive()]
-        if not alive:
-            break
+        assert not alive, (
+            f"axi-embed-worker is still alive after stop_embed_worker() (FIX 9)"
+        )
+    finally:
+        store.stop_embed_worker()
+
+
+def test_embed_worker_backoff_is_interruptible():
+    """stop_embed_worker() completes within 2 s even when worker is in backoff sleep.
+
+    With OLD code (time.sleep(_BACKOFF_S)) this would take ~10 s to complete.
+    With the fix (_embed_worker_stop.wait(_BACKOFF_S)) the stop event wakes the
+    worker immediately and stop_embed_worker() returns in well under 2 s.
+    """
+    from axi import store
+
+    # Ensure clean state
+    store.stop_embed_worker()
+
+    def _always_raise(*, limit: int = 100) -> int:  # noqa: ARG001
+        raise RuntimeError("simulated embed service error")
+
+    with patch.object(store, "embed_pending_nodes", side_effect=_always_raise):
+        store._embed_worker_started.clear()
+        store._ensure_embed_worker()
+
+        # Give the worker a moment to start
         time.sleep(0.05)
 
-    alive = [t for t in threading.enumerate()
-             if t.name == "axi-embed-worker" and t.is_alive()]
-    assert not alive, (
-        f"axi-embed-worker is still alive after stop_embed_worker() (FIX 9)"
-    )
+        # Trigger the error→backoff path
+        try:
+            store._EMBED_QUEUE.put_nowait(1)
+        except queue.Full:
+            pass
+
+        # Let the worker enter the error handler and begin backoff (~0.1 s headroom)
+        time.sleep(0.15)
+
+        # Now stop — must complete well within 2 s (the fix makes this ~instant)
+        t_start = time.monotonic()
+        try:
+            store.stop_embed_worker(timeout=2.0)
+        finally:
+            pass
+        elapsed = time.monotonic() - t_start
+
+        assert elapsed < 2.0, (
+            f"stop_embed_worker took {elapsed:.2f}s — backoff is not interruptible "
+            f"(expected < 2s with interruptible wait)"
+        )
+
+        # Confirm the thread is actually gone
+        alive = [t for t in threading.enumerate()
+                 if t.name == "axi-embed-worker" and t.is_alive()]
+        assert not alive, (
+            f"axi-embed-worker still alive {elapsed:.2f}s after stop_embed_worker()"
+        )
+
+
+def test_stop_embed_worker_reaps_orphaned_workers():
+    """stop_embed_worker() kills ALL axi-embed-worker threads, not just the tracked one.
+
+    Simulates the orphan scenario: start a worker, force-orphan it by clearing
+    _embed_worker_started and starting a second worker.  Two threads are alive.
+    stop_embed_worker() must reap both.
+    """
+    from axi import store
+
+    # Ensure clean state
+    store.stop_embed_worker()
+
+    try:
+        # Start first worker
+        store._embed_worker_started.clear()
+        store._ensure_embed_worker()
+        time.sleep(0.05)
+
+        first_alive = [t for t in threading.enumerate()
+                       if t.name == "axi-embed-worker" and t.is_alive()]
+        if not first_alive:
+            pytest.skip("first axi-embed-worker did not start")
+
+        # Orphan the first worker: clear the started flag so _ensure_embed_worker
+        # spawns a SECOND worker thread (the tracked _embed_worker_thread is replaced,
+        # but the first thread is still alive and untracked).
+        store._embed_worker_started.clear()
+        store._ensure_embed_worker()
+        time.sleep(0.05)
+
+        both_alive = [t for t in threading.enumerate()
+                      if t.name == "axi-embed-worker" and t.is_alive()]
+        # We expect 2, but the test is meaningful as long as at least 1 is alive.
+        assert len(both_alive) >= 1, "No axi-embed-worker threads alive before stop"
+
+        # stop_embed_worker must reap every thread named axi-embed-worker
+        store.stop_embed_worker(timeout=3.0)
+
+        alive_after = [t for t in threading.enumerate()
+                       if t.name == "axi-embed-worker" and t.is_alive()]
+        assert not alive_after, (
+            f"{len(alive_after)} axi-embed-worker thread(s) still alive after "
+            f"stop_embed_worker() — orphaned threads not reaped"
+        )
+    finally:
+        store.stop_embed_worker()

--- a/axi/tests/test_recall.py
+++ b/axi/tests/test_recall.py
@@ -1,0 +1,443 @@
+"""Tests for axi.recall.build_recall_block (Layer 3 — graph recall)."""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _node_dict(
+    node_id: int,
+    label: str,
+    *,
+    distance: float = 0.3,
+    occurred_at: float | None = None,
+    created_at: float | None = None,
+) -> dict:
+    return {
+        "id": node_id,
+        "kind": "fact",
+        "label": label,
+        "domain": "health",
+        "distance": distance,
+        "occurred_at": occurred_at,
+        "created_at": created_at or time.time(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. Empty when no nodes returned by semantic_search_nodes
+# ---------------------------------------------------------------------------
+
+def test_build_recall_block_empty_when_no_nodes(monkeypatch):
+    """Returns '' when semantic_search_nodes returns no results."""
+    import axi.store as _store
+    monkeypatch.setattr(_store, "semantic_search_nodes", lambda *a, **kw: [])
+
+    from axi.recall import build_recall_block
+    result = build_recall_block("cualquier cosa")
+    assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# 2. Empty when all nodes are above the distance threshold
+# ---------------------------------------------------------------------------
+
+def test_build_recall_block_empty_when_all_above_threshold(monkeypatch):
+    """Returns '' when every node's distance exceeds max_distance."""
+    import axi.store as _store
+
+    far_node = _node_dict(1, "distant fact", distance=0.99)
+    monkeypatch.setattr(_store, "semantic_search_nodes", lambda *a, **kw: [far_node])
+
+    from axi.recall import build_recall_block
+    result = build_recall_block("query", max_distance=0.6)
+    assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# 3. Empty when embed service is down (semantic_search_nodes returns [])
+# ---------------------------------------------------------------------------
+
+def test_build_recall_block_empty_when_embed_down(monkeypatch):
+    """Returns '' (never raises) when semantic_search_nodes returns [] due to embed down."""
+    import axi.store as _store
+    monkeypatch.setattr(_store, "semantic_search_nodes", lambda *a, **kw: [])
+
+    from axi.recall import build_recall_block
+    result = build_recall_block("query")
+    assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# 4. Pulls same-day neighbor into same day line
+# ---------------------------------------------------------------------------
+
+def test_build_recall_block_pulls_same_day_neighbor(monkeypatch):
+    """A matched node's same-day neighbor should appear in the SAME day's output line."""
+    import axi.store as _store
+
+    # Use a fixed timestamp: 2026-06-11 noon UTC (will be the same day in any tz close to UTC)
+    day_ts = 1749643200.0  # 2026-06-11 00:00:00 UTC
+
+    main_node = _node_dict(10, "dormí 4.9h", distance=0.2, occurred_at=day_ts + 3600)
+    neighbor_node = _node_dict(20, "presión 115/81", distance=None, occurred_at=day_ts + 7200)
+
+    monkeypatch.setattr(_store, "semantic_search_nodes", lambda *a, **kw: [main_node])
+    monkeypatch.setattr(_store, "same_day_neighbors", lambda nid, conn=None: [neighbor_node])
+
+    from axi.recall import build_recall_block
+    result = build_recall_block("cómo dormí?", max_distance=0.6)
+
+    # Both labels should appear in the block
+    assert "dormí 4.9h" in result
+    assert "presión 115/81" in result
+    # They should be on the SAME day line (only one bullet/line for that date)
+    lines_with_content = [ln for ln in result.splitlines() if "dormí 4.9h" in ln or "presión 115/81" in ln]
+    # Both labels should be on the same line
+    assert any("dormí 4.9h" in ln and "presión 115/81" in ln for ln in lines_with_content)
+
+
+# ---------------------------------------------------------------------------
+# 5. Date rendered in config timezone
+# ---------------------------------------------------------------------------
+
+def test_build_recall_block_date_in_config_tz(monkeypatch):
+    """The day grouping uses the config timezone, not UTC."""
+    import axi.store as _store
+    from axi import config
+
+    # Force timezone to America/Mexico_City (UTC-6) via monkeypatch
+    monkeypatch.setattr(config, "get", lambda key, default=None: (
+        "America/Mexico_City" if key == "timezone" else default
+    ))
+
+    # 2026-06-11 02:00 UTC == 2026-06-10 20:00 in Mexico_City
+    # So this should be grouped under 2026-06-10 in Mexico_City tz
+    ts = 1749600000.0 + 7200  # approx 2026-06-11 02:00 UTC
+
+    node = _node_dict(5, "hecho nocturno", distance=0.2, occurred_at=ts)
+    monkeypatch.setattr(_store, "semantic_search_nodes", lambda *a, **kw: [node])
+    monkeypatch.setattr(_store, "same_day_neighbors", lambda nid, conn=None: [])
+
+    from axi.recall import build_recall_block
+    result = build_recall_block("query", max_distance=0.6)
+
+    assert result != ""
+    # The date line should exist and include the node's label
+    assert "hecho nocturno" in result
+
+
+# ---------------------------------------------------------------------------
+# 6. Spanish header and month names
+# ---------------------------------------------------------------------------
+
+def test_build_recall_block_spanish_header_and_months(monkeypatch):
+    """Default (no lang / es lang) uses Spanish header and month names."""
+    import axi.store as _store
+    from axi import config
+
+    monkeypatch.setattr(config, "get", lambda key, default=None: (
+        "UTC" if key == "timezone" else default
+    ))
+
+    # 2026-06-11 noon UTC
+    ts = 1749643200.0 + 43200
+
+    node = _node_dict(1, "hecho salud", distance=0.2, occurred_at=ts)
+    monkeypatch.setattr(_store, "semantic_search_nodes", lambda *a, **kw: [node])
+    monkeypatch.setattr(_store, "same_day_neighbors", lambda nid, conn=None: [])
+
+    from axi.recall import build_recall_block
+    result = build_recall_block("query", lang=None, max_distance=0.6)
+
+    assert "MEMORIA RELEVANTE" in result
+    assert "junio" in result  # Spanish month name for June
+
+
+# ---------------------------------------------------------------------------
+# 7. English header and month names
+# ---------------------------------------------------------------------------
+
+def test_build_recall_block_english_header_and_months(monkeypatch):
+    """lang='en' uses English header and English month names."""
+    import axi.store as _store
+    from axi import config
+
+    monkeypatch.setattr(config, "get", lambda key, default=None: (
+        "UTC" if key == "timezone" else default
+    ))
+
+    # 2026-06-11 noon UTC
+    ts = 1749643200.0 + 43200
+
+    node = _node_dict(1, "slept 7h", distance=0.2, occurred_at=ts)
+    monkeypatch.setattr(_store, "semantic_search_nodes", lambda *a, **kw: [node])
+    monkeypatch.setattr(_store, "same_day_neighbors", lambda nid, conn=None: [])
+
+    from axi.recall import build_recall_block
+    result = build_recall_block("query", lang="en", max_distance=0.6)
+
+    assert "RELEVANT MEMORY" in result
+    assert "June" in result
+
+
+# ---------------------------------------------------------------------------
+# 8. max_facts cap respected
+# ---------------------------------------------------------------------------
+
+def test_build_recall_block_max_facts_cap(monkeypatch):
+    """Only max_facts most-recent days are included in the output."""
+    import axi.store as _store
+    from axi import config
+
+    monkeypatch.setattr(config, "get", lambda key, default=None: (
+        "UTC" if key == "timezone" else default
+    ))
+
+    # Create 10 nodes each one day apart
+    base_ts = 1749643200.0  # 2026-06-11
+    nodes = [
+        _node_dict(i + 1, f"fact-day-{i}", distance=0.2, occurred_at=base_ts - i * 86400)
+        for i in range(10)
+    ]
+    monkeypatch.setattr(_store, "semantic_search_nodes", lambda *a, **kw: nodes)
+    monkeypatch.setattr(_store, "same_day_neighbors", lambda nid, conn=None: [])
+
+    from axi.recall import build_recall_block
+    result = build_recall_block("query", max_days=3, max_distance=0.6)
+
+    # Count bullet lines (lines starting with "- ")
+    bullet_lines = [ln for ln in result.splitlines() if ln.strip().startswith("- ")]
+    # Header line is not a bullet, date lines are bullets: at most max_facts=3
+    assert len(bullet_lines) <= 3
+
+
+# ---------------------------------------------------------------------------
+# 9. Never raises when store raises
+# ---------------------------------------------------------------------------
+
+def test_build_recall_block_never_raises_when_store_raises(monkeypatch):
+    """Returns '' without raising when semantic_search_nodes raises."""
+    import axi.store as _store
+
+    def _raise(*a, **kw):
+        raise RuntimeError("unexpected store error")
+
+    monkeypatch.setattr(_store, "semantic_search_nodes", _raise)
+
+    from axi.recall import build_recall_block
+    result = build_recall_block("query")
+    assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# FIX 2 — per-day label cap and total-fact cap
+# ---------------------------------------------------------------------------
+
+def test_build_recall_block_per_day_label_cap(monkeypatch):
+    """max_labels_per_day caps labels even when a single day has many facts."""
+    import axi.store as _store
+    from axi import config
+
+    monkeypatch.setattr(config, "get", lambda key, default=None: "UTC" if key == "timezone" else default)
+
+    # Single day, many neighbors (30 total)
+    day_ts = 1749643200.0  # 2026-06-11 00:00:00 UTC
+    main_node = _node_dict(1, "fact-main", distance=0.2, occurred_at=day_ts + 3600)
+    neighbors = [
+        _node_dict(i + 2, f"neighbor-{i}", distance=None, occurred_at=day_ts + i * 60)
+        for i in range(29)
+    ]
+
+    monkeypatch.setattr(_store, "semantic_search_nodes", lambda *a, **kw: [main_node])
+    monkeypatch.setattr(_store, "same_day_neighbors", lambda nid, conn=None: neighbors)
+
+    from axi.recall import build_recall_block
+    result = build_recall_block("query", max_distance=0.6, max_labels_per_day=4)
+
+    # Count labels on the single bullet line (semicolon-separated)
+    bullet_lines = [ln for ln in result.splitlines() if ln.strip().startswith("- ")]
+    assert len(bullet_lines) == 1
+    # Labels on that line should be at most max_labels_per_day=4
+    label_count = len(bullet_lines[0].split(";"))
+    assert label_count <= 4
+
+
+def test_build_recall_block_total_fact_cap(monkeypatch):
+    """max_total_facts caps the total labels across all days."""
+    import axi.store as _store
+    from axi import config
+
+    monkeypatch.setattr(config, "get", lambda key, default=None: "UTC" if key == "timezone" else default)
+
+    # 5 days, 6 nodes each day → 30 potential labels total
+    base_ts = 1749643200.0  # 2026-06-11
+    all_nodes = []
+    for day_i in range(5):
+        day_ts = base_ts - day_i * 86400
+        for fact_i in range(6):
+            nid = day_i * 6 + fact_i + 1
+            all_nodes.append(_node_dict(nid, f"d{day_i}-f{fact_i}", distance=0.2, occurred_at=day_ts + fact_i))
+
+    monkeypatch.setattr(_store, "semantic_search_nodes", lambda *a, **kw: all_nodes)
+    monkeypatch.setattr(_store, "same_day_neighbors", lambda nid, conn=None: [])
+
+    from axi.recall import build_recall_block
+    result = build_recall_block("query", max_distance=0.6, max_total_facts=8, max_labels_per_day=6)
+
+    # Count total labels: each bullet line is "; "-joined
+    bullet_lines = [ln for ln in result.splitlines() if ln.strip().startswith("- ")]
+    total = sum(len(ln.split(";")) for ln in bullet_lines)
+    assert total <= 8
+
+
+# ---------------------------------------------------------------------------
+# FIX 4 — default max_distance is 0.78 (empirically tuned for Qwen3-Embedding-4B);
+# config override respected
+# ---------------------------------------------------------------------------
+
+def test_build_recall_block_default_max_distance_excludes_casual(monkeypatch):
+    """A casual-chat node (distance 0.85) is excluded with the default 0.78.
+
+    Measured against real data: casual greetings sit at 0.83+, so the default
+    threshold must keep them out of the recall block.
+    """
+    import axi.store as _store
+
+    node = _node_dict(1, "tangential fact", distance=0.85)
+    monkeypatch.setattr(_store, "semantic_search_nodes", lambda *a, **kw: [node])
+    monkeypatch.setattr(_store, "same_day_neighbors", lambda nid, conn=None: [])
+
+    from axi.recall import build_recall_block
+    result = build_recall_block("hola Axi")  # uses default max_distance=0.78
+    assert result == ""
+
+
+def test_build_recall_block_default_max_distance_includes_natural_query(monkeypatch):
+    """A natural recall match (distance 0.70) IS included with the default 0.78.
+
+    Measured: 'cómo dormí esta semana' → 0.699; the default must let it through.
+    """
+    import axi.store as _store
+    from axi import config
+
+    monkeypatch.setattr(config, "get", lambda key, default=None: "UTC" if key == "timezone" else default)
+
+    node = _node_dict(1, "dormí 4.9h", distance=0.70, occurred_at=time.time())
+    monkeypatch.setattr(_store, "semantic_search_nodes", lambda *a, **kw: [node])
+    monkeypatch.setattr(_store, "same_day_neighbors", lambda nid, conn=None: [])
+
+    from axi.recall import build_recall_block
+    result = build_recall_block("cómo dormí esta semana")  # default max_distance=0.78
+    assert "dormí 4.9h" in result
+
+
+def test_build_recall_block_config_max_distance_override(monkeypatch):
+    """Passing max_distance=0.6 explicitly includes a node at distance 0.5."""
+    import axi.store as _store
+    from axi import config
+
+    monkeypatch.setattr(config, "get", lambda key, default=None: "UTC" if key == "timezone" else default)
+
+    node = _node_dict(1, "included fact", distance=0.5, occurred_at=time.time())
+    monkeypatch.setattr(_store, "semantic_search_nodes", lambda *a, **kw: [node])
+    monkeypatch.setattr(_store, "same_day_neighbors", lambda nid, conn=None: [])
+
+    from axi.recall import build_recall_block
+    result = build_recall_block("query", max_distance=0.6)
+    assert "included fact" in result
+
+
+# ---------------------------------------------------------------------------
+# FIX 6 — within-day ordering by occurred_at desc
+# ---------------------------------------------------------------------------
+
+def test_build_recall_block_within_day_recency_order(monkeypatch):
+    """Two same-day facts must appear most-recent-first in the bullet line."""
+    import axi.store as _store
+    from axi import config
+
+    monkeypatch.setattr(config, "get", lambda key, default=None: "UTC" if key == "timezone" else default)
+
+    day_ts = 1749643200.0  # 2026-06-11 00:00:00 UTC
+    # older fact: at +1h, newer fact: at +3h
+    older_node = _node_dict(1, "older fact", distance=0.2, occurred_at=day_ts + 3600)
+    newer_node = _node_dict(2, "newer fact", distance=0.2, occurred_at=day_ts + 10800)
+
+    # Both returned as KNN hits (not neighbors) so they're both in the same day
+    monkeypatch.setattr(_store, "semantic_search_nodes", lambda *a, **kw: [older_node, newer_node])
+    monkeypatch.setattr(_store, "same_day_neighbors", lambda nid, conn=None: [])
+
+    from axi.recall import build_recall_block
+    result = build_recall_block("query", max_distance=0.6)
+
+    bullet_lines = [ln for ln in result.splitlines() if ln.strip().startswith("- ")]
+    assert len(bullet_lines) == 1
+    line = bullet_lines[0]
+    assert "newer fact" in line and "older fact" in line
+    # newer fact must appear BEFORE older fact in the semicolon-joined string
+    assert line.index("newer fact") < line.index("older fact")
+
+
+# ---------------------------------------------------------------------------
+# FIX 7 — occurred_at=0.0 is not dropped (None check fix)
+# ---------------------------------------------------------------------------
+
+def test_build_recall_block_zero_occurred_at_not_dropped(monkeypatch):
+    """A fact with occurred_at=0.0 (Unix epoch) should NOT be silently dropped."""
+    import axi.store as _store
+    from axi import config
+
+    monkeypatch.setattr(config, "get", lambda key, default=None: "UTC" if key == "timezone" else default)
+
+    # occurred_at = 0.0 is falsy but not None — the old `or` would drop it
+    node = {
+        "id": 1,
+        "kind": "fact",
+        "label": "epoch fact",
+        "domain": None,
+        "distance": 0.2,
+        "occurred_at": 0.0,   # Unix epoch — must NOT be treated as missing
+        "created_at": None,
+    }
+    monkeypatch.setattr(_store, "semantic_search_nodes", lambda *a, **kw: [node])
+    monkeypatch.setattr(_store, "same_day_neighbors", lambda nid, conn=None: [])
+
+    from axi.recall import build_recall_block
+    result = build_recall_block("query", max_distance=0.6)
+    assert "epoch fact" in result
+
+
+# ---------------------------------------------------------------------------
+# FIX 7 — locale_data constants are importable and match expected values
+# ---------------------------------------------------------------------------
+
+def test_locale_data_constants():
+    """MONTHS_ES and MONTHS_EN are importable from locale_data with correct length."""
+    from axi.locale_data import MONTHS_ES, MONTHS_EN
+    assert len(MONTHS_ES) == 12
+    assert len(MONTHS_EN) == 12
+    assert MONTHS_ES[5] == "junio"
+    assert MONTHS_EN[5] == "June"
+
+
+# ---------------------------------------------------------------------------
+# FIX 3a — embed timeout: build_recall_block returns "" when embed hangs
+# ---------------------------------------------------------------------------
+
+def test_build_recall_block_returns_empty_on_embed_timeout(monkeypatch):
+    """When semantic_search_nodes raises (simulating timeout/hang), '' is returned."""
+    import axi.store as _store
+    from axi.embed_client import EmbedServiceError
+
+    # Simulate the embed timing out (store returns [] when embed raises)
+    monkeypatch.setattr(_store, "semantic_search_nodes", lambda *a, **kw: [])
+
+    from axi.recall import build_recall_block
+    result = build_recall_block("query", timeout=0.001)
+    assert result == ""

--- a/axi/tests/test_recall_escalation.py
+++ b/axi/tests/test_recall_escalation.py
@@ -1,0 +1,339 @@
+"""Tests for recall escalation feature.
+
+Covers:
+  1-5:   looks_like_personal_recall — True cases
+  6-10:  looks_like_personal_recall — False cases
+  11:    build_recall_block escalation fires for personal query
+  12:    build_recall_block escalation blocked for casual query
+  13:    build_recall_block no escalation when escalate_distance=None
+  14:    NO double embed: semantic_search_nodes called exactly once even when escalation fires
+  15:    brain._build_messages no escalation when flag off
+  16:    brain._build_messages escalation injects recall for personal query
+"""
+from __future__ import annotations
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# 1–5. looks_like_personal_recall — True cases
+# ---------------------------------------------------------------------------
+
+def test_looks_like_personal_recall_true_presion_dormi():
+    from axi.recall import looks_like_personal_recall
+    assert looks_like_personal_recall("¿qué presión tenía cuando dormí mal?") is True
+
+
+def test_looks_like_personal_recall_true_pulso_dormi():
+    from axi.recall import looks_like_personal_recall
+    assert looks_like_personal_recall("¿cómo estaba mi pulso los días que dormí poco?") is True
+
+
+def test_looks_like_personal_recall_true_cuanto_dormi():
+    from axi.recall import looks_like_personal_recall
+    assert looks_like_personal_recall("¿cuánto dormí la noche de la presión más alta?") is True
+
+
+def test_looks_like_personal_recall_true_pesaba():
+    from axi.recall import looks_like_personal_recall
+    assert looks_like_personal_recall("cuánto pesaba el mes pasado") is True
+
+
+def test_looks_like_personal_recall_true_gasolina():
+    from axi.recall import looks_like_personal_recall
+    assert looks_like_personal_recall("qué gasté en gasolina") is True
+
+
+# ---------------------------------------------------------------------------
+# 6–10. looks_like_personal_recall — False cases
+# ---------------------------------------------------------------------------
+
+def test_looks_like_personal_recall_false_greeting():
+    from axi.recall import looks_like_personal_recall
+    assert looks_like_personal_recall("hola Axi cómo estás") is False
+
+
+def test_looks_like_personal_recall_false_joke():
+    from axi.recall import looks_like_personal_recall
+    assert looks_like_personal_recall("contame un chiste") is False
+
+
+def test_looks_like_personal_recall_false_thanks():
+    from axi.recall import looks_like_personal_recall
+    assert looks_like_personal_recall("gracias sos un genio") is False
+
+
+def test_looks_like_personal_recall_false_time():
+    from axi.recall import looks_like_personal_recall
+    assert looks_like_personal_recall("qué hora es") is False
+
+
+def test_looks_like_personal_recall_false_react():
+    from axi.recall import looks_like_personal_recall
+    assert looks_like_personal_recall("cómo funciona React") is False
+
+
+# ---------------------------------------------------------------------------
+# Helpers for build_recall_block tests
+# ---------------------------------------------------------------------------
+
+def _make_node(distance: float, label: str = "test fact", occurred_at: float = 1_700_000_000.0):
+    return {
+        "id": 1,
+        "label": label,
+        "distance": distance,
+        "occurred_at": occurred_at,
+        "created_at": occurred_at,
+    }
+
+
+def _make_neighbor(label: str, occurred_at: float = 1_700_000_000.0):
+    return {
+        "id": 2,
+        "label": label,
+        "occurred_at": occurred_at,
+        "created_at": occurred_at,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 11. build_recall_block escalation fires for personal query
+# ---------------------------------------------------------------------------
+
+def test_build_recall_block_escalation_fires_for_personal_query(monkeypatch):
+    """Nodes at distance 0.85 (above 0.78, below 0.9) + personal query + escalate_distance=0.9
+    → result is non-empty (escalation fires)."""
+    from axi import store, config
+    import axi.recall as recall_mod
+
+    node = _make_node(distance=0.85, label="presión 120/80")
+    monkeypatch.setattr(store, "semantic_search_nodes", lambda *a, **kw: [node])
+    monkeypatch.setattr(store, "same_day_neighbors", lambda *a, **kw: [])
+    monkeypatch.setattr(config, "get", lambda key, default=None: {
+        "timezone": "UTC",
+    }.get(key, default))
+
+    result = recall_mod.build_recall_block(
+        "¿qué presión tenía cuando dormí mal?",
+        max_distance=0.78,
+        escalate_distance=0.9,
+    )
+    assert result != "", "Expected non-empty recall block when escalation fires for personal query"
+
+
+# ---------------------------------------------------------------------------
+# 12. build_recall_block escalation blocked for casual query
+# ---------------------------------------------------------------------------
+
+def test_build_recall_block_escalation_blocked_for_casual_query(monkeypatch):
+    """Nodes at distance 0.85, casual query, escalate_distance=0.9 → result is '' (blocked)."""
+    from axi import store, config
+    import axi.recall as recall_mod
+
+    node = _make_node(distance=0.85, label="presión 120/80")
+    monkeypatch.setattr(store, "semantic_search_nodes", lambda *a, **kw: [node])
+    monkeypatch.setattr(store, "same_day_neighbors", lambda *a, **kw: [])
+    monkeypatch.setattr(config, "get", lambda key, default=None: {
+        "timezone": "UTC",
+    }.get(key, default))
+
+    result = recall_mod.build_recall_block(
+        "hola",
+        max_distance=0.78,
+        escalate_distance=0.9,
+    )
+    assert result == "", "Expected empty recall block when casual query and escalation should be blocked"
+
+
+# ---------------------------------------------------------------------------
+# 13. escalate_distance=None → no escalation (behavior identical to current)
+# ---------------------------------------------------------------------------
+
+def test_build_recall_block_no_escalation_when_escalate_distance_none(monkeypatch):
+    """Nodes at distance 0.85, personal query, escalate_distance=None → result is ''."""
+    from axi import store, config
+    import axi.recall as recall_mod
+
+    node = _make_node(distance=0.85, label="presión 120/80")
+    monkeypatch.setattr(store, "semantic_search_nodes", lambda *a, **kw: [node])
+    monkeypatch.setattr(store, "same_day_neighbors", lambda *a, **kw: [])
+    monkeypatch.setattr(config, "get", lambda key, default=None: {
+        "timezone": "UTC",
+    }.get(key, default))
+
+    result = recall_mod.build_recall_block(
+        "¿qué presión tenía cuando dormí mal?",
+        max_distance=0.78,
+        escalate_distance=None,
+    )
+    assert result == "", "Expected empty recall block when escalate_distance=None (no escalation)"
+
+
+# ---------------------------------------------------------------------------
+# 14. NO double embed: semantic_search_nodes called exactly once
+# ---------------------------------------------------------------------------
+
+def test_build_recall_block_escalation_no_double_embed(monkeypatch):
+    """semantic_search_nodes is called exactly once even when escalation path fires."""
+    from axi import store, config
+    import axi.recall as recall_mod
+
+    call_count = 0
+    node = _make_node(distance=0.85, label="presión 120/80")
+
+    def counting_search(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return [node]
+
+    monkeypatch.setattr(store, "semantic_search_nodes", counting_search)
+    monkeypatch.setattr(store, "same_day_neighbors", lambda *a, **kw: [])
+    monkeypatch.setattr(config, "get", lambda key, default=None: {
+        "timezone": "UTC",
+    }.get(key, default))
+
+    recall_mod.build_recall_block(
+        "¿qué presión tenía cuando dormí mal?",
+        max_distance=0.78,
+        escalate_distance=0.9,
+    )
+    assert call_count == 1, f"Expected exactly 1 embed call, got {call_count}"
+
+
+# ---------------------------------------------------------------------------
+# 15. Config flag off → brain passes escalate_distance=None → no escalation
+# ---------------------------------------------------------------------------
+
+def test_brain_build_messages_no_escalation_when_flag_off(monkeypatch):
+    """When recall_escalation_enabled=False, brain passes escalate_distance=None."""
+    from axi import config, brain
+    import axi.recall as recall_mod
+
+    captured_kwargs: dict = {}
+
+    def spy_build_recall_block(query, **kwargs):
+        captured_kwargs.update(kwargs)
+        return ""
+
+    _orig_config_get = config.get
+
+    def _mock_config_get(key, default=None):
+        if key == "graph_recall":
+            return True
+        if key == "recall_escalation_enabled":
+            return False
+        if key == "graph_recall_max_distance":
+            return 0.78
+        if key == "graph_recall_tool_max_distance":
+            return 0.9
+        return _orig_config_get(key, default)
+
+    monkeypatch.setattr(config, "get", _mock_config_get)
+    monkeypatch.setattr(recall_mod, "build_recall_block", spy_build_recall_block)
+
+    brain._build_messages("¿qué presión tenía cuando dormí mal?", "eres Axi")
+
+    assert captured_kwargs.get("escalate_distance") is None, (
+        f"Expected escalate_distance=None when flag is off, got {captured_kwargs.get('escalate_distance')}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 16. Flag on + personal query + nodes at 0.85 → recall injected in _build_messages
+# ---------------------------------------------------------------------------
+
+def test_brain_build_messages_escalation_injects_recall_for_personal_query(monkeypatch):
+    """Flag on + personal compound query + nodes at 0.85 → recall block IS injected."""
+    from axi import config, brain, store
+    import axi.recall as recall_mod
+
+    node = _make_node(distance=0.85, label="presión 120/80")
+
+    _orig_config_get = config.get
+
+    def _mock_config_get(key, default=None):
+        if key == "graph_recall":
+            return True
+        if key == "recall_escalation_enabled":
+            return True
+        if key == "graph_recall_max_distance":
+            return 0.78
+        if key == "graph_recall_tool_max_distance":
+            return 0.9
+        if key == "timezone":
+            return "UTC"
+        return _orig_config_get(key, default)
+
+    monkeypatch.setattr(config, "get", _mock_config_get)
+    monkeypatch.setattr(store, "semantic_search_nodes", lambda *a, **kw: [node])
+    monkeypatch.setattr(store, "same_day_neighbors", lambda *a, **kw: [])
+
+    msgs = brain._build_messages(
+        "¿qué presión tenía cuando dormí mal?",
+        "eres Axi",
+    )
+
+    system_content = msgs[0]["content"]
+    assert "presión 120/80" in system_content or "MEMORIA RELEVANTE" in system_content, (
+        "Expected recall block injected in system content when flag is on and escalation fires"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 17. Heuristic false positive WITHOUT a near node → still no escalation.
+#     Proves the 0.9 distance backstop — not the heuristic — is the real gate.
+# ---------------------------------------------------------------------------
+
+def test_build_recall_block_false_positive_heuristic_does_not_leak(monkeypatch):
+    """A heuristic false positive ('peso' in a non-health question) must NOT leak
+    facts when no node sits within escalate_distance. The 0.9 backstop is the gate."""
+    from axi import store, config
+    import axi.recall as recall_mod
+
+    # "peso" trips the heuristic, but this is not a health question.
+    assert recall_mod.looks_like_personal_recall("cuánto cuesta un peso mexicano") is True
+
+    # Only far nodes exist — nothing within 0.9.
+    far_node = _make_node(distance=0.95, label="presión 120/80")
+    monkeypatch.setattr(store, "semantic_search_nodes", lambda *a, **kw: [far_node])
+    monkeypatch.setattr(store, "same_day_neighbors", lambda *a, **kw: [])
+    monkeypatch.setattr(config, "get", lambda key, default=None: {
+        "timezone": "UTC",
+    }.get(key, default))
+
+    result = recall_mod.build_recall_block(
+        "cuánto cuesta un peso mexicano",
+        max_distance=0.78,
+        escalate_distance=0.9,
+    )
+    assert result == "", "False-positive heuristic must not leak when no node is within 0.9"
+
+
+# ---------------------------------------------------------------------------
+# 18. Escalation is SKIPPED when the tight filter already has matches —
+#     junk within the wide gate must not be dragged in.
+# ---------------------------------------------------------------------------
+
+def test_build_recall_block_no_escalation_when_tight_filter_nonempty(monkeypatch):
+    """When a node passes the tight 0.78 gate, escalation never runs, so a second
+    node at 0.88 (inside 0.9 but outside 0.78) must NOT be included."""
+    from axi import store, config
+    import axi.recall as recall_mod
+
+    tight = {"id": 1, "label": "dormí 4.9h", "distance": 0.70,
+             "occurred_at": 1_700_000_000.0, "created_at": 1_700_000_000.0}
+    wide_junk = {"id": 2, "label": "JUNK-0-88", "distance": 0.88,
+                 "occurred_at": 1_700_000_000.0, "created_at": 1_700_000_000.0}
+    monkeypatch.setattr(store, "semantic_search_nodes", lambda *a, **kw: [tight, wide_junk])
+    monkeypatch.setattr(store, "same_day_neighbors", lambda *a, **kw: [])
+    monkeypatch.setattr(config, "get", lambda key, default=None: {
+        "timezone": "UTC",
+    }.get(key, default))
+
+    result = recall_mod.build_recall_block(
+        "¿qué presión tenía cuando dormí mal?",
+        max_distance=0.78,
+        escalate_distance=0.9,
+    )
+    assert "dormí 4.9h" in result, "Tight match must be present"
+    assert "JUNK-0-88" not in result, "Escalation must be skipped when tight filter is non-empty"

--- a/axi/tests/test_recall_escalation.py
+++ b/axi/tests/test_recall_escalation.py
@@ -74,6 +74,54 @@ def test_looks_like_personal_recall_false_react():
 
 
 # ---------------------------------------------------------------------------
+# English coverage — True cases (mirror the Spanish health/finance vocab)
+# ---------------------------------------------------------------------------
+
+def test_looks_like_personal_recall_en_blood_pressure_sleep():
+    from axi.recall import looks_like_personal_recall
+    assert looks_like_personal_recall("what was my blood pressure when I slept badly?") is True
+
+
+def test_looks_like_personal_recall_en_sleep():
+    from axi.recall import looks_like_personal_recall
+    assert looks_like_personal_recall("how did I sleep last week") is True
+
+
+def test_looks_like_personal_recall_en_weight():
+    from axi.recall import looks_like_personal_recall
+    assert looks_like_personal_recall("my weight last month") is True
+
+
+def test_looks_like_personal_recall_en_glucose():
+    from axi.recall import looks_like_personal_recall
+    assert looks_like_personal_recall("what were my glucose readings") is True
+
+
+def test_looks_like_personal_recall_en_mood():
+    from axi.recall import looks_like_personal_recall
+    assert looks_like_personal_recall("how was my mood the days I didn't sleep") is True
+
+
+# ---------------------------------------------------------------------------
+# English coverage — False cases (casual / unrelated)
+# ---------------------------------------------------------------------------
+
+def test_looks_like_personal_recall_en_false_time():
+    from axi.recall import looks_like_personal_recall
+    assert looks_like_personal_recall("what time is it") is False
+
+
+def test_looks_like_personal_recall_en_false_joke():
+    from axi.recall import looks_like_personal_recall
+    assert looks_like_personal_recall("tell me a joke") is False
+
+
+def test_looks_like_personal_recall_en_false_weather():
+    from axi.recall import looks_like_personal_recall
+    assert looks_like_personal_recall("what's the weather today") is False
+
+
+# ---------------------------------------------------------------------------
 # Helpers for build_recall_block tests
 # ---------------------------------------------------------------------------
 

--- a/axi/tests/test_recall_memory_tool.py
+++ b/axi/tests/test_recall_memory_tool.py
@@ -1,0 +1,342 @@
+"""Tests for the recall_memory tool (Layer 3 — Phase 2).
+
+Covers:
+- _RECALL_MEMORY_TOOL schema structure
+- _recall_memory_tool_handler: empty query, disabled, success, no-match, never raises
+- routing: non-image chat always uses ask_with_tools with recall_memory in tools
+- web_search included/excluded based on web_research.is_enabled()
+- handler uses graph_recall_tool_max_distance config value
+
+Strict TDD (RED→GREEN). All external services are mocked.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _reset_web_research(monkeypatch):
+    """Reset web_research globals before every test."""
+    import lifeos.web as web_research
+    monkeypatch.setattr(web_research, "_search_fn", None)
+    monkeypatch.setattr(web_research, "_read_fn", None)
+    monkeypatch.setattr(web_research, "_enabled_fn", None)
+
+
+@pytest.fixture
+def chat_client(monkeypatch):
+    """Minimal chat client with memory reset and nano disabled."""
+    from axi import dashboard
+    monkeypatch.setattr(dashboard, "_chat_memory", None)
+    monkeypatch.setattr(dashboard, "_chat_memory_lock", None)
+    monkeypatch.setattr(dashboard, "_try_nano_extract", lambda *a, **kw: None)
+    return TestClient(dashboard.app)
+
+
+# ---------------------------------------------------------------------------
+# Part A — tool schema
+# ---------------------------------------------------------------------------
+
+def test_recall_memory_tool_schema_name():
+    """_RECALL_MEMORY_TOOL must have function name 'recall_memory'."""
+    from axi.dashboard import _RECALL_MEMORY_TOOL
+    assert _RECALL_MEMORY_TOOL["type"] == "function"
+    assert _RECALL_MEMORY_TOOL["function"]["name"] == "recall_memory"
+
+
+def test_recall_memory_tool_schema_required_query():
+    """_RECALL_MEMORY_TOOL must require the 'query' parameter."""
+    from axi.dashboard import _RECALL_MEMORY_TOOL
+    params = _RECALL_MEMORY_TOOL["function"]["parameters"]
+    assert "query" in params["properties"]
+    assert "query" in params["required"]
+
+
+# ---------------------------------------------------------------------------
+# Part A — handler: basic cases
+# ---------------------------------------------------------------------------
+
+def test_recall_memory_handler_empty_query():
+    """Empty query string returns ok=False with an error key."""
+    from axi.dashboard import _recall_memory_tool_handler
+    result = _recall_memory_tool_handler({"query": ""})
+    assert result["ok"] is False
+    assert "error" in result
+
+
+def test_recall_memory_handler_whitespace_query():
+    """Whitespace-only query is treated as empty → ok=False."""
+    from axi.dashboard import _recall_memory_tool_handler
+    result = _recall_memory_tool_handler({"query": "   "})
+    assert result["ok"] is False
+    assert "error" in result
+
+
+def test_recall_memory_handler_missing_query_key():
+    """Missing query key (args={}) → ok=False, no exception."""
+    from axi.dashboard import _recall_memory_tool_handler
+    result = _recall_memory_tool_handler({})
+    assert result["ok"] is False
+
+
+def test_recall_memory_handler_graph_recall_disabled(monkeypatch):
+    """When config graph_recall=False, handler returns ok=False immediately."""
+    from axi import config
+    from axi.dashboard import _recall_memory_tool_handler
+
+    orig_get = config.get
+    monkeypatch.setattr(config, "get", lambda key, default=None: (
+        False if key == "graph_recall" else orig_get(key, default)
+    ))
+
+    result = _recall_memory_tool_handler({"query": "presión arterial"})
+    assert result["ok"] is False
+    assert "error" in result
+
+
+def test_recall_memory_handler_success(monkeypatch):
+    """Non-empty recall block → ok=True, facts contains the block."""
+    import axi.recall as _recall
+    from axi import config
+    from axi.dashboard import _recall_memory_tool_handler
+
+    block = "MEMORIA RELEVANTE:\n- El 10 de junio: presión 120/80"
+    monkeypatch.setattr(_recall, "build_recall_block", lambda *a, **kw: block)
+
+    orig_get = config.get
+    monkeypatch.setattr(config, "get", lambda key, default=None: (
+        True if key == "graph_recall" else orig_get(key, default)
+    ))
+
+    result = _recall_memory_tool_handler({"query": "presión arterial"})
+    assert result["ok"] is True
+    assert result["facts"] == block
+    assert result["query"] == "presión arterial"
+
+
+def test_recall_memory_handler_no_match(monkeypatch):
+    """Empty recall block (no match) → ok=False with 'note' key."""
+    import axi.recall as _recall
+    from axi import config
+    from axi.dashboard import _recall_memory_tool_handler
+
+    monkeypatch.setattr(_recall, "build_recall_block", lambda *a, **kw: "")
+
+    orig_get = config.get
+    monkeypatch.setattr(config, "get", lambda key, default=None: (
+        True if key == "graph_recall" else orig_get(key, default)
+    ))
+
+    result = _recall_memory_tool_handler({"query": "glucosa"})
+    assert result["ok"] is False
+    assert "note" in result
+    assert result["facts"] == ""
+
+
+def test_recall_memory_handler_never_raises(monkeypatch):
+    """Handler must not propagate exceptions from build_recall_block."""
+    import axi.recall as _recall
+    from axi import config
+    from axi.dashboard import _recall_memory_tool_handler
+
+    monkeypatch.setattr(_recall, "build_recall_block", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("db gone")))
+
+    orig_get = config.get
+    monkeypatch.setattr(config, "get", lambda key, default=None: (
+        True if key == "graph_recall" else orig_get(key, default)
+    ))
+
+    result = _recall_memory_tool_handler({"query": "presión"})
+    assert isinstance(result, dict)
+    assert result["ok"] is False
+
+
+# ---------------------------------------------------------------------------
+# Part A — handler uses the looser tool threshold
+# ---------------------------------------------------------------------------
+
+def test_recall_memory_handler_uses_tool_max_distance(monkeypatch):
+    """Handler must call build_recall_block with graph_recall_tool_max_distance."""
+    import axi.recall as _recall
+    from axi import config
+    from axi.dashboard import _recall_memory_tool_handler
+
+    captured_kw: list[dict] = []
+
+    def _capturing_recall(*a, **kw):
+        captured_kw.append(kw)
+        return "MEMORIA RELEVANTE:\n- hecho"
+
+    monkeypatch.setattr(_recall, "build_recall_block", _capturing_recall)
+
+    orig_get = config.get
+    monkeypatch.setattr(config, "get", lambda key, default=None: (
+        True if key == "graph_recall"
+        else 0.92 if key == "graph_recall_tool_max_distance"
+        else orig_get(key, default)
+    ))
+
+    _recall_memory_tool_handler({"query": "test"})
+
+    assert len(captured_kw) == 1
+    assert captured_kw[0]["max_distance"] == 0.92
+
+
+# ---------------------------------------------------------------------------
+# Part C — routing: recall_memory ALWAYS present on non-image turns
+# ---------------------------------------------------------------------------
+
+def test_routing_non_image_uses_ask_with_tools(monkeypatch):
+    """Non-image chat turn must call brain.ask_with_tools, not brain.ask."""
+    import lifeos.web as web_research
+    from axi import brain, dashboard
+
+    web_research.configure(
+        search_fn=lambda q, **kw: [],
+        read_fn=lambda url: None,
+        enabled_fn=lambda: False,  # web disabled
+    )
+
+    monkeypatch.setattr(dashboard, "_chat_memory", None)
+    monkeypatch.setattr(dashboard, "_chat_memory_lock", None)
+    monkeypatch.setattr(dashboard, "_try_nano_extract", lambda *a, **kw: None)
+
+    ask_called = []
+    ask_with_tools_called = []
+
+    monkeypatch.setattr(brain, "ask", lambda *a, **kw: ask_called.append(1) or "answer")
+    monkeypatch.setattr(brain, "ask_with_tools", lambda *a, **kw: ask_with_tools_called.append(kw) or "answer")
+
+    tc = TestClient(dashboard.app)
+    r = tc.post("/api/chat/ask", json={"text": "hola"})
+    assert r.status_code == 200
+    assert ask_called == [], "brain.ask must NOT be called on non-image turns"
+    assert len(ask_with_tools_called) == 1
+
+
+def test_routing_recall_tool_always_in_tools_web_disabled(monkeypatch):
+    """When web is disabled, recall_memory is still in tools."""
+    import lifeos.web as web_research
+    from axi import brain, dashboard
+
+    web_research.configure(
+        search_fn=lambda q, **kw: [],
+        read_fn=lambda url: None,
+        enabled_fn=lambda: False,
+    )
+
+    monkeypatch.setattr(dashboard, "_chat_memory", None)
+    monkeypatch.setattr(dashboard, "_chat_memory_lock", None)
+    monkeypatch.setattr(dashboard, "_try_nano_extract", lambda *a, **kw: None)
+
+    captured: dict = {}
+
+    def fake_ask_with_tools(prompt, **kw):
+        captured.update(kw)
+        return "answer"
+
+    monkeypatch.setattr(brain, "ask_with_tools", fake_ask_with_tools)
+
+    tc = TestClient(dashboard.app)
+    r = tc.post("/api/chat/ask", json={"text": "qué presión tuve?"})
+    assert r.status_code == 200
+
+    tools = captured.get("tools", [])
+    tool_names = [t["function"]["name"] for t in tools]
+    assert "recall_memory" in tool_names
+    assert "web_search" not in tool_names
+    # tool_choice must stay "auto" — "required" would force the tool on every
+    # casual turn, which is the spurious-call failure mode we want to avoid.
+    assert captured.get("tool_choice") == "auto"
+    # lang must be forwarded so recall/temporal context render in the user's language.
+    assert "lang" in captured
+
+
+def test_routing_recall_tool_present_web_enabled(monkeypatch):
+    """When web is enabled, both recall_memory AND web_search are in tools."""
+    import lifeos.web as web_research
+    from axi import brain, dashboard
+
+    web_research.configure(
+        search_fn=lambda q, **kw: [],
+        read_fn=lambda url: None,
+        enabled_fn=lambda: True,
+    )
+
+    monkeypatch.setattr(dashboard, "_chat_memory", None)
+    monkeypatch.setattr(dashboard, "_chat_memory_lock", None)
+    monkeypatch.setattr(dashboard, "_try_nano_extract", lambda *a, **kw: None)
+
+    captured: dict = {}
+
+    def fake_ask_with_tools(prompt, **kw):
+        captured.update(kw)
+        return "answer"
+
+    monkeypatch.setattr(brain, "ask_with_tools", fake_ask_with_tools)
+
+    tc = TestClient(dashboard.app)
+    r = tc.post("/api/chat/ask", json={"text": "hola cómo estás"})
+    assert r.status_code == 200
+
+    tools = captured.get("tools", [])
+    tool_names = [t["function"]["name"] for t in tools]
+    assert "recall_memory" in tool_names
+    assert "web_search" in tool_names
+
+
+def test_routing_image_turn_uses_brain_ask(monkeypatch):
+    """Image turn must still use brain.ask (not ask_with_tools)."""
+    from axi import brain, dashboard
+
+    monkeypatch.setattr(dashboard, "_chat_memory", None)
+    monkeypatch.setattr(dashboard, "_chat_memory_lock", None)
+    monkeypatch.setattr(dashboard, "_try_nano_extract", lambda *a, **kw: None)
+
+    ask_called = []
+    ask_with_tools_called = []
+
+    monkeypatch.setattr(brain, "ask", lambda *a, **kw: ask_called.append(1) or "vision answer")
+    monkeypatch.setattr(brain, "ask_with_tools", lambda *a, **kw: ask_with_tools_called.append(1) or "tools answer")
+
+    tc = TestClient(dashboard.app)
+    r = tc.post("/api/chat/ask", json={"text": "qué ves?", "image_b64": "AAABBB"})
+    assert r.status_code == 200
+    assert len(ask_called) == 1, "brain.ask must be called for image turns"
+    assert ask_with_tools_called == []
+
+
+def test_routing_tool_handlers_include_recall_handler(monkeypatch):
+    """tool_handlers dict passed to ask_with_tools must include 'recall_memory'."""
+    import lifeos.web as web_research
+    from axi import brain, dashboard
+
+    web_research.configure(
+        search_fn=lambda q, **kw: [],
+        read_fn=lambda url: None,
+        enabled_fn=lambda: False,
+    )
+
+    monkeypatch.setattr(dashboard, "_chat_memory", None)
+    monkeypatch.setattr(dashboard, "_chat_memory_lock", None)
+    monkeypatch.setattr(dashboard, "_try_nano_extract", lambda *a, **kw: None)
+
+    captured: dict = {}
+
+    def fake_ask_with_tools(prompt, **kw):
+        captured.update(kw)
+        return "answer"
+
+    monkeypatch.setattr(brain, "ask_with_tools", fake_ask_with_tools)
+
+    tc = TestClient(dashboard.app)
+    tc.post("/api/chat/ask", json={"text": "prueba"})
+
+    handlers = captured.get("tool_handlers", {})
+    assert "recall_memory" in handlers
+    assert callable(handlers["recall_memory"])

--- a/axi/tests/test_recall_store.py
+++ b/axi/tests/test_recall_store.py
@@ -1,0 +1,271 @@
+"""Tests for store.py Layer-3 graph-recall additions.
+
+Tests cover:
+  - knn_nodes_scored: alias for knn_nodes_with_distance
+  - semantic_search_nodes: includes occurred_at, distance, and timeout param
+  - same_day_neighbors: bidirectional, self-exclusion, empty, error cases
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _insert_node(conn, label: str, *, occurred_at: float | None = None) -> int:
+    """Insert a minimal node and return its id."""
+    now = time.time()
+    cur = conn.execute(
+        "INSERT INTO nodes(kind, label, domain, created_at, updated_at) VALUES (?,?,?,?,?)",
+        ("fact", label, "health", now, now),
+    )
+    node_id = cur.lastrowid
+    if occurred_at is not None:
+        conn.execute("UPDATE nodes SET occurred_at=? WHERE id=?", (occurred_at, node_id))
+    conn.commit()
+    return node_id
+
+
+def _insert_vec(conn, node_id: int, vector: list[float]) -> None:
+    """Insert an embedding into vec_nodes for testing KNN."""
+    import struct
+    from axi.store import _load_sqlite_vec
+    _load_sqlite_vec(conn)
+    vec = vector[:512]
+    blob = struct.pack(f"{len(vec)}f", *vec)
+    conn.execute(
+        "INSERT OR REPLACE INTO vec_nodes(node_id, embedding) VALUES (?, ?)",
+        (node_id, blob),
+    )
+    conn.commit()
+
+
+def _make_vec(dim: int = 512, value: float = 0.1) -> list[float]:
+    """Return a simple unit-ish vector for testing (512 dims required by vec_nodes)."""
+    return [value] * dim
+
+
+# ---------------------------------------------------------------------------
+# 1. knn_nodes_scored returns sorted (id, distance) tuples
+# ---------------------------------------------------------------------------
+
+def test_knn_nodes_scored_returns_sorted_id_distance_tuples():
+    """knn_nodes_scored must return a list of (node_id, float) sorted by distance."""
+    from axi import store
+    from axi.store import knn_nodes_scored
+
+    conn = store._connect()
+
+    # Insert two nodes with different vectors so we get two distinct distances.
+    node1 = _insert_node(conn, "node-close")
+    node2 = _insert_node(conn, "node-far")
+
+    query_vec = _make_vec(512, 1.0)
+    close_vec = _make_vec(512, 0.99)   # nearly identical to query → smallest distance
+    far_vec = _make_vec(512, 0.1)      # different direction → larger distance
+
+    _insert_vec(conn, node1, close_vec)
+    _insert_vec(conn, node2, far_vec)
+
+    results = knn_nodes_scored(conn, vector=query_vec, k=2)
+
+    assert len(results) == 2
+    # Each item is a (int, float) tuple
+    for item in results:
+        assert isinstance(item, tuple) and len(item) == 2
+        assert isinstance(item[0], int)
+        assert isinstance(item[1], float)
+
+    # Results are sorted by ascending distance (closest first)
+    assert results[0][1] <= results[1][1]
+    # The closest node is node1
+    assert results[0][0] == node1
+
+
+# ---------------------------------------------------------------------------
+# 2. semantic_search_nodes includes occurred_at and distance
+# ---------------------------------------------------------------------------
+
+def test_semantic_search_nodes_includes_occurred_at_and_distance(monkeypatch):
+    """Each dict returned by semantic_search_nodes must include occurred_at and distance."""
+    from axi import store
+
+    conn = store._connect()
+    occurred = time.time() - 3600.0  # 1 hour ago
+
+    node_id = _insert_node(conn, "health-fact", occurred_at=occurred)
+    vec = _make_vec(512, 0.8)
+    _insert_vec(conn, node_id, vec)
+
+    # Patch embed_text so we don't need a real embed service.
+    monkeypatch.setattr(store, "embed_text", lambda *a, **kw: _make_vec(512, 0.8))
+
+    results = store.semantic_search_nodes("health", k=5, conn=conn)
+
+    assert len(results) >= 1
+    row = results[0]
+    # Must have occurred_at (may be float or None) and distance (float)
+    assert "occurred_at" in row
+    assert "distance" in row
+    assert isinstance(row["distance"], float)
+    # The occurred_at we set should come back
+    assert abs(row["occurred_at"] - occurred) < 1.0
+
+
+# ---------------------------------------------------------------------------
+# 3. semantic_search_nodes preserves KNN ordering
+# ---------------------------------------------------------------------------
+
+def test_semantic_search_nodes_preserves_knn_ordering(monkeypatch):
+    """semantic_search_nodes must return rows in KNN distance order (closest first)."""
+    from axi import store
+
+    conn = store._connect()
+
+    node_close = _insert_node(conn, "close-node")
+    node_far = _insert_node(conn, "far-node")
+
+    query_vec = _make_vec(512, 1.0)
+    _insert_vec(conn, node_close, _make_vec(512, 0.99))
+    _insert_vec(conn, node_far, _make_vec(512, 0.1))
+
+    monkeypatch.setattr(store, "embed_text", lambda *a, **kw: query_vec)
+
+    results = store.semantic_search_nodes("anything", k=5, conn=conn)
+
+    ids = [r["id"] for r in results]
+    assert ids.index(node_close) < ids.index(node_far)
+
+    # Distances are non-decreasing
+    distances = [r["distance"] for r in results]
+    assert all(distances[i] <= distances[i + 1] for i in range(len(distances) - 1))
+
+
+# ---------------------------------------------------------------------------
+# 4. semantic_search_nodes returns [] when embed is down
+# ---------------------------------------------------------------------------
+
+def test_semantic_search_nodes_returns_empty_when_embed_down(monkeypatch):
+    """semantic_search_nodes must return [] and not raise when embed service is down."""
+    from axi import store
+    from axi.embed_client import EmbedServiceError
+
+    def _raise(*a, **kw):
+        raise EmbedServiceError("service down")
+
+    monkeypatch.setattr(store, "embed_text", _raise)
+
+    result = store.semantic_search_nodes("anything")
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# 5. semantic_search_nodes passes timeout to embed_text
+# ---------------------------------------------------------------------------
+
+def test_semantic_search_nodes_passes_timeout_to_embed_text(monkeypatch):
+    """semantic_search_nodes must forward the timeout kwarg to embed_text."""
+    from axi import store
+
+    captured: list = []
+
+    def _stub_embed(text, *, mode="passage", timeout=None):
+        captured.append(timeout)
+        raise store.embed_text.__class__  # just return [] path via exception
+
+    # Patch embed_text to capture the timeout and then raise so we get []
+    from axi.embed_client import EmbedServiceError
+
+    def _capture_embed(text, *, mode="passage", timeout=None):
+        captured.append(timeout)
+        raise EmbedServiceError("stub")
+
+    monkeypatch.setattr(store, "embed_text", _capture_embed)
+
+    result = store.semantic_search_nodes("test", timeout=1.5)
+    assert result == []
+    assert len(captured) == 1
+    assert captured[0] == 1.5
+
+
+# ---------------------------------------------------------------------------
+# FIX 5 — same_day_neighbors: bidirectional, self-exclusion, empty, error
+# ---------------------------------------------------------------------------
+
+def _insert_same_day_edge(conn, from_id: int, to_id: int) -> None:
+    """Insert a same-day edge between two nodes for test setup."""
+    import time as _time
+    conn.execute(
+        "INSERT INTO edges(from_id, to_id, kind, data, created_at) VALUES (?,?,?,?,?)",
+        (from_id, to_id, "same-day", "{}", _time.time()),
+    )
+    conn.commit()
+
+
+def test_same_day_neighbors_forward_direction():
+    """Edge A→B returns B from A's perspective."""
+    from axi import store
+
+    conn = store._connect()
+    node_a = _insert_node(conn, "node-A")
+    node_b = _insert_node(conn, "node-B")
+    _insert_same_day_edge(conn, node_a, node_b)
+
+    result = store.same_day_neighbors(node_a, conn=conn)
+    ids = [r["id"] for r in result]
+    assert node_b in ids
+
+
+def test_same_day_neighbors_reverse_direction():
+    """Edge A→B returns A from B's perspective (reverse lookup)."""
+    from axi import store
+
+    conn = store._connect()
+    node_a = _insert_node(conn, "rev-A")
+    node_b = _insert_node(conn, "rev-B")
+    _insert_same_day_edge(conn, node_a, node_b)
+
+    result = store.same_day_neighbors(node_b, conn=conn)
+    ids = [r["id"] for r in result]
+    assert node_a in ids
+
+
+def test_same_day_neighbors_self_exclusion():
+    """Self (node_id == n.id) must never appear in results."""
+    from axi import store
+
+    conn = store._connect()
+    node_x = _insert_node(conn, "self-exclude-X")
+    node_y = _insert_node(conn, "self-exclude-Y")
+    _insert_same_day_edge(conn, node_x, node_y)
+
+    result = store.same_day_neighbors(node_x, conn=conn)
+    ids = [r["id"] for r in result]
+    assert node_x not in ids
+
+
+def test_same_day_neighbors_empty_graph():
+    """Returns [] when there are no same-day edges for the node."""
+    from axi import store
+
+    conn = store._connect()
+    isolated_node = _insert_node(conn, "isolated")
+
+    result = store.same_day_neighbors(isolated_node, conn=conn)
+    assert result == []
+
+
+def test_same_day_neighbors_store_error_swallowed():
+    """Returns [] and does not raise when the DB connection errors."""
+    from axi import store
+
+    class _BadConn:
+        def execute(self, *a, **kw):
+            raise RuntimeError("simulated DB failure")
+
+    result = store.same_day_neighbors(999, conn=_BadConn())
+    assert result == []

--- a/axi/tests/test_wakeword.py
+++ b/axi/tests/test_wakeword.py
@@ -1017,6 +1017,39 @@ class TestDaemonWakewordAskEmptyCommand:
 
 
 # ===========================================================================
+# Live-test harness — wake path must emit machine-parseable metric logs
+# ===========================================================================
+
+class TestWakewordMetricLogs(TestDaemonWakewordAskEmptyCommand):
+    """The wake/ask path must emit `wakeword-metric:` INFO lines for the
+    live-test harness (scripts/wakeword_report.py): ask_start, tts_start,
+    tts_done. These let Héctor get a decision table from journald afterward
+    without babysitting a terminal during play.
+    """
+
+    def test_wake_path_emits_metric_logs(self, monkeypatch, caplog):
+        import logging
+        import time as _t
+        import axi.daemon as _d
+
+        _d.notify = lambda *a, **kw: None
+        _d.speak_text = lambda text: None
+        _d._game_mode_active = lambda: False
+
+        daemon, _ = self._build_daemon(monkeypatch=None)
+        daemon.brain_ask = lambda *a, **kw: "respuesta de prueba"
+
+        with caplog.at_level(logging.INFO, logger="axi.daemon"):
+            daemon._wakeword_ask("ayudame con esto", screenshot=None)
+            _t.sleep(0.2)  # let the _say thread emit tts_done
+
+        msgs = [r.getMessage() for r in caplog.records]
+        assert any("wakeword-metric: ask_start t=" in m for m in msgs), msgs
+        assert any("wakeword-metric: tts_start t=" in m for m in msgs), msgs
+        assert any("wakeword-metric: tts_done t=" in m for m in msgs), msgs
+
+
+# ===========================================================================
 # openWakeWord state machine — TDD RED → GREEN
 # ===========================================================================
 

--- a/axi/tests/test_wakeword_report.py
+++ b/axi/tests/test_wakeword_report.py
@@ -1,0 +1,262 @@
+"""Tests for the wake-word live-test analyzer (scripts/wakeword_report.py).
+
+The analyzer's parser is a PURE function over an iterable of log lines, so these
+tests need no journald, no live services, and no real DB — they feed synthetic
+`wakeword-metric:` lines and a synthetic brain_metrics fixture and assert the
+computed metrics, percentiles, false-trigger count, and verdict at boundaries.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_MODULE_PATH = Path(__file__).parent.parent / "scripts" / "wakeword_report.py"
+
+
+def _load_module():
+    import sys
+
+    spec = importlib.util.spec_from_file_location("wakeword_report", _MODULE_PATH)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    # Register before exec so @dataclass can resolve cls.__module__ in __dict__.
+    sys.modules["wakeword_report"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+wr = _load_module()
+
+
+# --- synthetic log builder -------------------------------------------------
+
+def _invocation_lines(*, wake_t, command, ask_t=None, tts_start_t=None, tts_done_t=None,
+                      transcript="hola axi", answer="respuesta"):
+    """Emit the journal lines for one full wake invocation, in order."""
+    lines = [f"wakeword: transcript={transcript!r}"]
+    lines.append(f"wakeword: WAKE DETECTED — command={command!r}")
+    lines.append(f"wakeword-metric: wake_detected t={wake_t:.3f} command={command!r}")
+    if ask_t is not None:
+        lines.append(f"wakeword-metric: ask_start t={ask_t:.3f}")
+    if answer is not None:
+        lines.append(f"wakeword answer: {answer}")
+    if tts_start_t is not None:
+        lines.append(f"wakeword-metric: tts_start t={tts_start_t:.3f}")
+    if tts_done_t is not None:
+        lines.append(f"wakeword-metric: tts_done t={tts_done_t:.3f}")
+    return lines
+
+
+# ===========================================================================
+# Parser
+# ===========================================================================
+
+class TestParser:
+    def test_single_invocation_round_trip(self):
+        lines = _invocation_lines(
+            wake_t=1000.0, command="que hago aca",
+            ask_t=1000.5, tts_start_t=1003.0, tts_done_t=1005.0,
+        )
+        r = wr.parse_log_lines(lines)
+        assert len(r.invocations) == 1
+        inv = r.invocations[0]
+        assert inv.command == "'que hago aca'"
+        assert inv.round_trip_s == pytest.approx(5.0)
+        assert inv.tts_duration_s == pytest.approx(2.0)
+        assert r.answer_count == 1
+
+    def test_multiple_invocations_isolated(self):
+        lines = []
+        lines += _invocation_lines(wake_t=10, command="a", ask_t=10.2,
+                                   tts_start_t=12, tts_done_t=14)
+        lines += _invocation_lines(wake_t=100, command="b", ask_t=100.5,
+                                   tts_start_t=103, tts_done_t=110)
+        r = wr.parse_log_lines(lines)
+        assert len(r.invocations) == 2
+        assert r.invocations[0].round_trip_s == pytest.approx(4.0)
+        assert r.invocations[1].round_trip_s == pytest.approx(10.0)
+
+    def test_no_wake_and_transcript_counts(self):
+        lines = [
+            "wakeword: transcript='hola'",
+            "wakeword: no wake match for transcript 'hola'",
+            "wakeword: transcript='axi ayudame'",
+            "wakeword: WAKE DETECTED — command='ayudame'",
+            "wakeword-metric: wake_detected t=5.000 command='ayudame'",
+        ]
+        r = wr.parse_log_lines(lines)
+        assert r.no_wake_count == 1
+        # both transcript= lines counted
+        assert r.transcript_count == 2
+        assert len(r.invocations) == 1
+
+    def test_incomplete_invocation_round_trip_none(self):
+        # wake but TTS never completed (e.g. crash) -> round_trip None
+        lines = _invocation_lines(wake_t=1.0, command="x", ask_t=1.1,
+                                  tts_start_t=None, tts_done_t=None)
+        r = wr.parse_log_lines(lines)
+        assert r.invocations[0].round_trip_s is None
+
+    def test_journald_prefix_tolerated(self):
+        # lines with a leading timestamp prefix must still match on substrings
+        lines = [
+            "Jun 22 10:00:00 host axi[1]: wakeword: WAKE DETECTED — command='hi'",
+            "Jun 22 10:00:00 host axi[1]: wakeword-metric: wake_detected t=1.000 command='hi'",
+            "Jun 22 10:00:05 host axi[1]: wakeword-metric: tts_done t=6.000",
+        ]
+        r = wr.parse_log_lines(lines)
+        assert len(r.invocations) == 1
+        assert r.invocations[0].round_trip_s == pytest.approx(5.0)
+
+
+# ===========================================================================
+# Percentiles / stats
+# ===========================================================================
+
+class TestPercentiles:
+    def test_percentile_single_value(self):
+        assert wr._percentile([42.0], 50) == 42.0
+        assert wr._percentile([42.0], 95) == 42.0
+
+    def test_percentile_empty_none(self):
+        assert wr._percentile([], 50) is None
+
+    def test_p50_p95(self):
+        vals = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+        p50, p95 = wr._p50_p95(vals)
+        # nearest-rank: idx round(0.50*9)=4 -> 5.0 ; idx round(0.95*9)=9 -> 10.0
+        assert p50 == pytest.approx(5.0)
+        assert p95 == pytest.approx(10.0)
+
+
+# ===========================================================================
+# Brain latency correlation
+# ===========================================================================
+
+class TestCorrelate:
+    def test_nearest_following_brain_row(self):
+        invs = wr.parse_log_lines(
+            _invocation_lines(wake_t=1000, command="a", ask_t=1000.5,
+                              tts_start_t=1003, tts_done_t=1005)
+            + _invocation_lines(wake_t=2000, command="b", ask_t=2000.5,
+                                tts_start_t=2003, tts_done_t=2005)
+        ).invocations
+        # brain rows: one in window of inv0, one in window of inv1
+        rows = [
+            (1001.0, 480, "qwen", 1),
+            (2001.0, 920, "qwen", 1),
+        ]
+        wr.correlate_brain_latency(invs, rows)
+        assert invs[0].brain_latency_ms == 480
+        assert invs[1].brain_latency_ms == 920
+
+    def test_failed_brain_row_skipped(self):
+        invs = wr.parse_log_lines(
+            _invocation_lines(wake_t=1000, command="a", ask_t=1000.5,
+                              tts_done_t=1005)
+        ).invocations
+        rows = [(1001.0, 9999, "qwen", 0)]  # ok=0 -> skip
+        wr.correlate_brain_latency(invs, rows)
+        assert invs[0].brain_latency_ms is None
+
+
+# ===========================================================================
+# Verdict thresholds (boundary values)
+# ===========================================================================
+
+class TestVerdict:
+    def test_all_green(self):
+        overall, recs = wr.compute_verdict(
+            round_trip_p95=10.0, false_trigger_count=0,
+            miss_rate=0.05, cpu_idle=10.0, cpu_peak=90.0,
+        )
+        assert overall == "GREEN"
+        assert any("slice-2" in r for r in recs)
+
+    def test_false_trigger_boundary_green(self):
+        # exactly at the max is still green
+        overall, _ = wr.compute_verdict(
+            round_trip_p95=5.0, false_trigger_count=wr.FALSE_TRIGGER_GREEN_MAX,
+            miss_rate=0.0, cpu_idle=5.0, cpu_peak=50.0,
+        )
+        assert overall == "GREEN"
+
+    def test_false_trigger_over_recommends_openwakeword(self):
+        overall, recs = wr.compute_verdict(
+            round_trip_p95=5.0, false_trigger_count=wr.FALSE_TRIGGER_GREEN_MAX + 1,
+            miss_rate=0.0, cpu_idle=5.0, cpu_peak=50.0,
+        )
+        assert overall == "ACTION-NEEDED"
+        assert any("openWakeWord" in r for r in recs)
+
+    def test_slow_round_trip_recommends_small_brain(self):
+        overall, recs = wr.compute_verdict(
+            round_trip_p95=wr.ROUND_TRIP_SMALL_BRAIN_S + 0.1, false_trigger_count=0,
+            miss_rate=0.0, cpu_idle=5.0, cpu_peak=50.0,
+        )
+        assert overall == "ACTION-NEEDED"
+        assert any("game-brain" in r for r in recs)
+
+    def test_high_miss_rate_recommends_openwakeword(self):
+        overall, recs = wr.compute_verdict(
+            round_trip_p95=5.0, false_trigger_count=0,
+            miss_rate=wr.MISS_RATE_GREEN_MAX + 0.01, cpu_idle=5.0, cpu_peak=50.0,
+        )
+        assert overall == "ACTION-NEEDED"
+        assert any("openWakeWord" in r for r in recs)
+
+    def test_high_cpu_flagged(self):
+        overall, recs = wr.compute_verdict(
+            round_trip_p95=5.0, false_trigger_count=0,
+            miss_rate=0.0, cpu_idle=wr.CPU_IDLE_GREEN_MAX + 1, cpu_peak=999.0,
+        )
+        assert overall == "ACTION-NEEDED"
+        assert any("CPU" in r or "cpu" in r for r in recs)
+
+
+# ===========================================================================
+# CPU CSV summary
+# ===========================================================================
+
+class TestCpuCsv:
+    def test_summarize(self, tmp_path):
+        csv = tmp_path / "cpu.csv"
+        csv.write_text(
+            "epoch,cpu_pct,rss_mb\n"
+            "1000,5.0,400\n"
+            "1002,50.0,420\n"
+            "1004,12.0,410\n"
+        )
+        s = wr.summarize_cpu_csv(str(csv))
+        assert s["samples"] == 3
+        assert s["cpu_idle"] == 5.0
+        assert s["cpu_peak"] == 50.0
+        assert s["rss_peak_mb"] == 420.0
+
+    def test_missing_file_returns_none(self, tmp_path):
+        assert wr.summarize_cpu_csv(str(tmp_path / "nope.csv")) is None
+
+
+# ===========================================================================
+# Report rendering (smoke / empty handling)
+# ===========================================================================
+
+class TestReport:
+    def test_empty_window_message(self):
+        r = wr.parse_log_lines([])
+        out = wr.build_report(r, None)
+        assert "no wake events in window" in out
+
+    def test_report_lists_each_wake_for_false_trigger_confirmation(self):
+        lines = (
+            _invocation_lines(wake_t=10, command="a", ask_t=10.2, tts_done_t=14)
+            + _invocation_lines(wake_t=20, command="b", ask_t=20.2, tts_done_t=25)
+        )
+        r = wr.parse_log_lines(lines)
+        out = wr.build_report(r, None)
+        assert "TOTAL WAKES (max possible false triggers) : 2" in out
+        assert "[1]" in out and "[2]" in out
+        assert "VERDICT" in out


### PR DESCRIPTION
## Summary

Two themes from one session, verified green (**1777 passed, 6 skipped**, suite stabilized).

### 1. `feat(recall)` — Layer 3 graph recall (RAG) + background-worker test stabilization
- **Passive injection**: dated, same-day-linked memories injected into the brain system prompt (gate `graph_recall`, distance `graph_recall_max_distance=0.78`, empirically tuned for the embed model). Works on chat, voice, and nano.
- **`recall_memory` tool** on the big-brain whitelist (`graph_recall_tool_max_distance=0.9`) so the model reformulates compound conversational questions ("¿qué presión tenía cuando dormí mal?").
- **Heuristic escalation** (`recall_escalation_enabled`): voice/plain-ask compound questions that miss the tight gate retry at the wider gate, gated by a personal-data heuristic — no extra embed, casual chat stays clean.
- New `recall.py`, `locale_data.py`; `semantic_search_nodes` now returns `occurred_at`+`distance` via `knn_nodes_scored`, with `same_day_neighbors` for cross-domain same-day links.
- **Test stabilization**: fixes a ~60%-of-runs mid-suite SIGBUS where background DB workers (embed/events/brain-metric) reopened a monkeypatch-swapped encrypted DB with the wrong sqlcipher key. Adds `AXI_DISABLE_BG_WORKERS` (conftest-set, no-ops worker auto-start in tests) + deterministic embed/events worker shutdown. **Production behaviour unchanged (gate defaults off).**

### 2. `feat(wakeword)` — live-test harness for the hands-free voice loop
- `wakeword-metric:` INFO logs on the wake path only (`_wakeword_ask`) to reconstruct wake→spoken round-trip.
- `scripts/wakeword_cpu_sample.sh`, `scripts/wakeword_report.py` (the one analyzer command → decision table with verdicts), `scripts/WAKEWORD_LIVETEST.md` runbook.

## Verification
- Independent re-runs (not agent self-reports): **4/4 + 3/3 full-suite runs clean**, zero crash signatures, after a ~60% SIGBUS rate before the fix.
- Instrumentation confirmed wake-path-only (`_stop_and_ask` hotkey path untouched).
- Components reviewed with fresh context during development (dual blind judges on the recall injection; opus review on the tool + escalation).

## Notes
- Decision thresholds in `wakeword_report.py` are top-of-file constants (e.g. `FALSE_TRIGGER_GREEN_MAX`) — easy to tune.
- Follow-ups (deferred): English coverage for the recall heuristic; the live wake-word test itself (latency / false-triggers / CPU).
