### PR TITLE
feat(game-mode): keep VibeThinker-3B available on CPU instead of stopping it

### DIFF
--- a/axi/scripts/axi-game-off
+++ b/axi/scripts/axi-game-off
@@ -22,6 +22,7 @@ echo "[axi-game-off] removing CPU drop-ins…"
 # Current drop-ins written by axi-game-on.
 rm -f "$UNIT_DIR/axi-whisper.service.d/game-cpu.conf"
 rm -f "$UNIT_DIR/llama-server.service.d/game-cpu.conf"
+rm -f "$UNIT_DIR/llama-vt.service.d/game-cpu.conf"
 rm -f "$UNIT_DIR/axi-translate.service.d/game-cpu.conf"
 rm -f "$UNIT_DIR/axi-voice.service.d/game-cpu.conf"
 # Legacy drop-in names from earlier versions of these scripts.
@@ -32,6 +33,7 @@ rm -f "$UNIT_DIR/axi-voice.service.d/cpu-env.conf"
 # hold unrelated user drop-ins).
 rmdir "$UNIT_DIR/axi-whisper.service.d" 2>/dev/null || true
 rmdir "$UNIT_DIR/llama-server.service.d" 2>/dev/null || true
+rmdir "$UNIT_DIR/llama-vt.service.d" 2>/dev/null || true
 rmdir "$UNIT_DIR/axi-translate.service.d" 2>/dev/null || true
 rmdir "$UNIT_DIR/axi-voice.service.d" 2>/dev/null || true
 
@@ -82,11 +84,13 @@ done
 # ~/.config/systemd/user/ (the unit file exists in axi/systemd/ but may not be
 # symlinked). All operations are skipped silently if the unit is not found.
 if systemctl --user list-unit-files llama-vt.service 2>/dev/null | grep -q "llama-vt.service"; then
-    echo "[axi-game-off] unmasking llama-vt.service…"
+    # Unmask in case an older game-on masked it (previous VRAM-eviction behavior).
     systemctl --user unmask llama-vt.service 2>/dev/null || true
     if [ "${PREV_MODEL:-}" = "qwen35-4b" ]; then
-        echo "[axi-game-off] restoring VibeThinker-3B sibling (primary is qwen35-4b)…"
-        systemctl --user start llama-vt.service 2>/dev/null || true
+        echo "[axi-game-off] restoring VibeThinker-3B sibling to GPU (primary is qwen35-4b)…"
+        # restart (not start): VT may still be RUNNING on CPU from game-on's
+        # relocate; the game-cpu drop-in is now removed, so it re-execs on GPU.
+        systemctl --user restart llama-vt.service 2>/dev/null || true
         echo "[axi-game-off] waiting for llama-vt /health (8082)…"
         for i in $(seq 1 30); do
             if curl -sf http://127.0.0.1:8082/health >/dev/null 2>&1; then
@@ -95,7 +99,10 @@ if systemctl --user list-unit-files llama-vt.service 2>/dev/null | grep -q "llam
             sleep 1
         done
     else
-        echo "[axi-game-off] primary is '${PREV_MODEL:-<none>}' (not qwen35-4b) — leaving llama-vt stopped (VRAM guard)."
+        # Primary is the big 35B (or other) — VT cannot share VRAM, so STOP it
+        # (it may be running on CPU from game-on's relocate). VRAM guard.
+        echo "[axi-game-off] primary is '${PREV_MODEL:-<none>}' (not qwen35-4b) — stopping llama-vt (VRAM guard)."
+        systemctl --user stop llama-vt.service 2>/dev/null || true
     fi
 else
     echo "[axi-game-off] llama-vt.service not installed — skipping VT restore (safe, no-op)."

--- a/axi/scripts/axi-game-on
+++ b/axi/scripts/axi-game-on
@@ -25,8 +25,10 @@
 # VRAM holders on the RTX 5070 Ti (12 GB) and where they go in game mode:
 #   axi-whisper  (Whisper large-v3-turbo): ~2.3 GB VRAM  -> RAM (int8, CPU)
 #   llama-server (co-pilot qwen35-2b):     ~0 VRAM        -> RAM (--cpu, ngl=0)
+#   llama-vt     (VibeThinker-3B):         ~3.3 GB VRAM  -> RAM (--cpu, ngl=0)
 #   axi-translate (Opus/NLLB):             already CPU by default
 #   Result: ~0 MiB VRAM used by axi (effectively all 12 GB free for the game).
+# All of Axi stays available in game mode (slower, on CPU/RAM) — nothing is lost.
 
 set -u
 
@@ -124,20 +126,27 @@ else
     systemctl --user try-restart llama-server.service 2>/dev/null || true
 fi
 
-# VibeThinker-3B (GPU-resident reasoning sibling) has no game-mode role.
-# Mask it (reboot-safe) and stop it immediately to free its VRAM.
-# game-off will unmask and restart it ONLY if the restored primary == qwen35-4b.
+# VibeThinker-3B (reasoning sibling): RELOCATE to CPU instead of stopping it,
+# so all of Axi stays available (slower) during game mode without losing VT's
+# reasoning. The drop-in hides the GPU (CUDA_VISIBLE_DEVICES=) and re-points
+# ExecStart at the --cpu launcher (ngl=0) → true 0 VRAM. game-off removes it.
 #
 # MEETING-SAFE DEFENSIVE GUARD: llama-vt.service may not yet be installed into
 # ~/.config/systemd/user/ (the unit file exists in axi/systemd/ but may not be
 # symlinked). All operations are skipped silently if the unit is not found.
 if systemctl --user list-unit-files llama-vt.service 2>/dev/null | grep -q "llama-vt.service"; then
-    echo "[axi-game-on] masking llama-vt.service (VibeThinker-3B — reboot-safe VRAM eviction)…"
-    systemctl --user mask llama-vt.service 2>/dev/null || true
-    echo "[axi-game-on] stopping llama-vt.service…"
-    systemctl --user stop llama-vt.service 2>/dev/null || true
+    # Unmask first in case an older game-on masked it (previous behavior).
+    systemctl --user unmask llama-vt.service 2>/dev/null || true
+    echo "[axi-game-on] relocating llama-vt (VibeThinker-3B) to CPU (ngl=0, ~0 VRAM, stays available)…"
+    write_dropin llama-vt "[Service]
+Environment=CUDA_VISIBLE_DEVICES=
+ExecStart=
+ExecStart=%h/LifeOS/lifeos/axi/scripts/axi-vt-launch --cpu"
+    systemctl --user daemon-reload
+    # try-restart: relocate to CPU only if VT was running; don't force it on.
+    systemctl --user try-restart llama-vt.service 2>/dev/null || true
 else
-    echo "[axi-game-on] llama-vt.service not installed — skipping VT eviction (safe, no-op)."
+    echo "[axi-game-on] llama-vt.service not installed — skipping VT relocation (safe, no-op)."
 fi
 
 # axi-voice: enable the always-listening wake-word co-pilot by writing a drop-in

--- a/axi/scripts/axi-vt-launch
+++ b/axi/scripts/axi-vt-launch
@@ -5,9 +5,14 @@
 # (creates it with VibeThinker-3B defaults if missing — so a fresh install
 # works without manual config), then execs /usr/bin/llama-server on port 8082.
 #
-# VT is GPU-resident (ngl=999). Unlike axi-nano-launch, this script does NOT
-# set CUDA_VISIBLE_DEVICES — the unit file intentionally omits it so the GPU
-# is fully visible to the process.
+# VT is GPU-resident (ngl=999) by default. Unlike axi-nano-launch, this script
+# does NOT set CUDA_VISIBLE_DEVICES — the unit file intentionally omits it so
+# the GPU is fully visible to the process.
+#
+# axi-vt-launch --cpu  forces ngl=0 (game-mode CPU relocation — mirrors
+# axi-llama-launch --cpu). Game mode pairs this with a CUDA_VISIBLE_DEVICES=
+# drop-in so VibeThinker-3B stays available in RAM (slower) instead of being
+# stopped, keeping all of Axi usable while the game owns the VRAM.
 #
 # Mandatory flags per VRAM measurement #565 (RTX 5070 Ti 12 GB):
 #   -c 61440  -np 1  --cache-type-k q8_0  --cache-type-v q8_0  -fa on
@@ -17,6 +22,12 @@
 # (used by tests and smoke checks).
 
 set -u
+
+# --cpu forces ngl=0 (game-mode CPU relocation; mirrors axi-llama-launch).
+CPU_MODE=0
+[ "${1:-}" = "--cpu" ] && CPU_MODE=1
+export AXI_VT_CPU="$CPU_MODE"
+
 exec python3 - <<'PY'
 import json, os, sys
 from pathlib import Path
@@ -79,7 +90,10 @@ if "gguf" not in cfg:
     print(f"WARNING: active_vt_model.json has no 'gguf' key; using DEFAULT config", file=sys.stderr)
     cfg = DEFAULT
 
-ngl = int(cfg.get("ngl", 999))
+# AXI_VT_CPU=1 (set by `axi-vt-launch --cpu`) forces ngl=0 so VibeThinker-3B
+# runs on CPU/RAM during game mode instead of being stopped.
+cpu_mode = os.environ.get("AXI_VT_CPU") == "1"
+ngl = 0 if cpu_mode else int(cfg.get("ngl", 999))
 port = str(cfg.get("port", 8082))
 ctx = int(cfg.get("ctx", 61440))
 


### PR DESCRIPTION
## Summary
Game mode previously **masked + stopped** `llama-vt` to free its ~3.3 GB VRAM, which meant **losing VT-3B's reasoning** during play. This relocates VT-3B to **CPU** (ngl=0, CUDA hidden) — the same pattern the brain co-pilot already uses — so **all of Axi stays available (slower) without losing reasoning**, while the game still owns the full 12 GB VRAM.

## Changes
- `axi-vt-launch`: new `--cpu` flag (mirrors `axi-llama-launch --cpu`) → forces `-ngl 0`.
- `axi-game-on`: writes a `llama-vt` CPU drop-in (CUDA_VISIBLE_DEVICES= + ExecStart→`axi-vt-launch --cpu`) instead of mask/stop.
- `axi-game-off`: removes the drop-in and restarts VT on GPU when the restored primary is `qwen35-4b`; stops it for the big 35B (VRAM mutual-exclusion guard preserved). Also unmasks (recovers a VT masked by an older game-on).

## Verification
- All 3 scripts pass `bash -n`.
- `AXI_DRY_RUN=1 axi-vt-launch --cpu` → `-ngl 0`; default → `-ngl 999`.
- Live toggle (`axi-game-on` / `axi-game-off`) is the user's to run — it restarts services and swaps the active brain.

## Tradeoff (accepted)
VT-3B on CPU is noticeably slower (~5-15 tok/s vs GPU) and competes for CPU with the game, but only when invoked. Chosen deliberately: keep all of Axi usable during play over max FPS.